### PR TITLE
Fix Observer#OnSubscribe contracts

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserver.java
@@ -5,6 +5,7 @@ import com.uber.autodispose.internal.AutoDisposeUtil;
 import io.reactivex.CompletableObserver;
 import io.reactivex.Maybe;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Action;
@@ -33,15 +34,16 @@ public final class AutoDisposingCompletableObserver implements CompletableObserv
 
   @Override
   public final void onSubscribe(Disposable d) {
-    if (AutoDisposableHelper.setOnce(mainDisposable, d)) {
-      AutoDisposableHelper.setOnce(lifecycleDisposable,
-          lifecycle.subscribe(e -> dispose(), this::onError));
-      try {
-        onSubscribe.accept(this);
-      } catch (Throwable t) {
-        Exceptions.throwIfFatal(t);
-        d.dispose();
-        onError(t);
+    if (AutoDisposableHelper.setOnce(lifecycleDisposable,
+        lifecycle.subscribe(e -> dispose(), this::onError))) {
+      if (AutoDisposableHelper.setOnce(mainDisposable, d)) {
+        try {
+          onSubscribe.accept(this);
+        } catch (Throwable t) {
+          Exceptions.throwIfFatal(t);
+          d.dispose();
+          onError(t);
+        }
       }
     }
   }
@@ -55,6 +57,18 @@ public final class AutoDisposingCompletableObserver implements CompletableObserv
   public final void dispose() {
     synchronized (this) {
       AutoDisposableHelper.dispose(lifecycleDisposable);
+
+      // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
+      // onSubscribe and had a terminal event), we need to still send an empty disposable instance
+      // to abide by the Observer contract.
+      if (mainDisposable.get() == null) {
+        try {
+          onSubscribe.accept(Disposables.disposed());
+        } catch (Exception e) {
+          Exceptions.throwIfFatal(e);
+          RxJavaPlugins.onError(e);
+        }
+      }
       AutoDisposableHelper.dispose(mainDisposable);
     }
   }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserver.java
@@ -5,6 +5,7 @@ import com.uber.autodispose.internal.AutoDisposeUtil;
 import io.reactivex.Maybe;
 import io.reactivex.MaybeObserver;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Action;
@@ -36,15 +37,16 @@ public final class AutoDisposingMaybeObserver<T> implements MaybeObserver<T>, Di
 
   @Override
   public final void onSubscribe(Disposable d) {
-    if (AutoDisposableHelper.setOnce(this.mainDisposable, d)) {
-      AutoDisposableHelper.setOnce(this.lifecycleDisposable,
-          lifecycle.subscribe(e -> dispose(), this::onError));
-      try {
-        onSubscribe.accept(this);
-      } catch (Throwable t) {
-        Exceptions.throwIfFatal(t);
-        d.dispose();
-        onError(t);
+    if (AutoDisposableHelper.setOnce(lifecycleDisposable,
+        lifecycle.subscribe(e -> dispose(), this::onError))) {
+      if (AutoDisposableHelper.setOnce(mainDisposable, d)) {
+        try {
+          onSubscribe.accept(this);
+        } catch (Throwable t) {
+          Exceptions.throwIfFatal(t);
+          d.dispose();
+          onError(t);
+        }
       }
     }
   }
@@ -58,6 +60,18 @@ public final class AutoDisposingMaybeObserver<T> implements MaybeObserver<T>, Di
   public final void dispose() {
     synchronized (this) {
       AutoDisposableHelper.dispose(lifecycleDisposable);
+
+      // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
+      // onSubscribe and had a terminal event), we need to still send an empty disposable instance
+      // to abide by the Observer contract.
+      if (mainDisposable.get() == null) {
+        try {
+          onSubscribe.accept(Disposables.disposed());
+        } catch (Exception e) {
+          Exceptions.throwIfFatal(e);
+          RxJavaPlugins.onError(e);
+        }
+      }
       AutoDisposableHelper.dispose(mainDisposable);
     }
   }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserver.java
@@ -5,6 +5,7 @@ import com.uber.autodispose.internal.AutoDisposeUtil;
 import io.reactivex.Maybe;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Action;
@@ -36,15 +37,16 @@ public final class AutoDisposingObserver<T> implements Observer<T>, Disposable {
 
   @Override
   public final void onSubscribe(Disposable d) {
-    if (AutoDisposableHelper.setOnce(this.mainDisposable, d)) {
-      AutoDisposableHelper.setOnce(this.lifecycleDisposable,
-          lifecycle.subscribe(e -> dispose(), this::onError));
-      try {
-        onSubscribe.accept(this);
-      } catch (Throwable t) {
-        Exceptions.throwIfFatal(t);
-        d.dispose();
-        onError(t);
+    if (AutoDisposableHelper.setOnce(lifecycleDisposable,
+        lifecycle.subscribe(e -> dispose(), this::onError))) {
+      if (AutoDisposableHelper.setOnce(mainDisposable, d)) {
+        try {
+          onSubscribe.accept(this);
+        } catch (Throwable t) {
+          Exceptions.throwIfFatal(t);
+          d.dispose();
+          onError(t);
+        }
       }
     }
   }
@@ -58,6 +60,18 @@ public final class AutoDisposingObserver<T> implements Observer<T>, Disposable {
   public final void dispose() {
     synchronized (this) {
       AutoDisposableHelper.dispose(lifecycleDisposable);
+
+      // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
+      // onSubscribe and had a terminal event), we need to still send an empty disposable instance
+      // to abide by the Observer contract.
+      if (mainDisposable.get() == null) {
+        try {
+          onSubscribe.accept(Disposables.disposed());
+        } catch (Exception e) {
+          Exceptions.throwIfFatal(e);
+          RxJavaPlugins.onError(e);
+        }
+      }
       AutoDisposableHelper.dispose(mainDisposable);
     }
   }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -120,6 +120,7 @@ public class AutoDisposeCompletableObserverTest {
         .subscribe(AutoDispose.completable(provider)
             .around(o));
 
+    o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleNotStartedException.class);
   }
 
@@ -135,6 +136,7 @@ public class AutoDisposeCompletableObserverTest {
         .subscribe(AutoDispose.completable(provider)
             .around(o));
 
+    o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
   }
 

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -145,6 +145,7 @@ public class AutoDisposeMaybeObserverTest {
         .subscribe(AutoDispose.maybe(provider)
             .around(o));
 
+    o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleNotStartedException.class);
   }
 
@@ -160,6 +161,7 @@ public class AutoDisposeMaybeObserverTest {
         .subscribe(AutoDispose.maybe(provider)
             .around(o));
 
+    o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
   }
 

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -100,6 +100,7 @@ public class AutoDisposeObserverTest {
         .subscribe(AutoDispose.observable(provider)
             .around(o));
 
+    o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleNotStartedException.class);
   }
 
@@ -115,6 +116,7 @@ public class AutoDisposeObserverTest {
         .subscribe(AutoDispose.observable(provider)
             .around(o));
 
+    o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
   }
 

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -120,6 +120,7 @@ public class AutoDisposeSingleObserverTest {
         .subscribe(AutoDispose.single(provider)
             .around(o));
 
+    o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleNotStartedException.class);
   }
 
@@ -135,6 +136,7 @@ public class AutoDisposeSingleObserverTest {
         .subscribe(AutoDispose.single(provider)
             .around(o));
 
+    o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
   }
 

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -111,10 +111,8 @@ public class AutoDisposeSubscriberTest {
             .around(o));
 
     List<Throwable> errors = o.errors();
-    assertThat(errors).hasSize(2);
-    // On subscribe not called in proper order. Super weird exception to throw...
-    assertThat(errors.get(0)).isInstanceOf(NullPointerException.class);
-    assertThat(errors.get(1)).isInstanceOf(LifecycleNotStartedException.class);
+    assertThat(errors).hasSize(1);
+    assertThat(errors.get(0)).isInstanceOf(LifecycleNotStartedException.class);
   }
 
   @Test
@@ -130,10 +128,8 @@ public class AutoDisposeSubscriberTest {
             .around(o));
 
     List<Throwable> errors = o.errors();
-    assertThat(errors).hasSize(2);
-    // On subscribe not called in proper order. Super weird exception to throw...
-    assertThat(errors.get(0)).isInstanceOf(NullPointerException.class);
-    assertThat(errors.get(1)).isInstanceOf(LifecycleEndedException.class);
+    assertThat(errors).hasSize(1);
+    assertThat(errors.get(0)).isInstanceOf(LifecycleEndedException.class);
   }
 
   @Test


### PR DESCRIPTION
Prior, we weren't guaranteed to send an `onSubscribe()` callback to the wrapped observer if there was a lifecycle issue (pre-post lifecycle). This ensures that by doing the check in `dispose()`/`cancel()` and triggering it to be safe, while still preventing a full completion upstream (especially problematic for scalar flowables, which could otherwise completely complete in onSubscribe())