### PR TITLE
Tweak RecordingObserver toString()

### DIFF
--- a/autodispose/src/test/java/com/uber/autodispose/RecordingObserver.java
+++ b/autodispose/src/test/java/com/uber/autodispose/RecordingObserver.java
@@ -146,7 +146,7 @@ public final class RecordingObserver<T>
 
     @Override
     public String toString() {
-      return "OnSubscribe[" + disposable + "]";
+      return "OnSubscribe";
     }
   }
 


### PR DESCRIPTION
Disposables don't have a `toString()` implementation, so this is just noise