### PR TITLE
Migrate back to Java 7

### DIFF
--- a/autodispose-android/build.gradle
+++ b/autodispose-android/build.gradle
@@ -1,16 +1,10 @@
 buildscript {
   dependencies {
     classpath deps.build.gradlePlugins.android
-    classpath deps.build.gradlePlugins.retrolambda
   }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'me.tatarka.retrolambda'
-
-retrolambda {
-  oldJdk System.getenv("JAVA7_HOME")
-}
 
 android {
   compileSdkVersion deps.build.compileSdkVersion
@@ -21,8 +15,8 @@ android {
     targetSdkVersion deps.build.targetSdkVersion
   }
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_1_7
+    targetCompatibility JavaVersion.VERSION_1_7
   }
 }
 

--- a/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeAndroid.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeAndroid.java
@@ -15,22 +15,27 @@ public final class AutoDisposeAndroid {
   }
 
   public static ObservableSubscribeClause observable(View view) {
-    return AutoDispose.observable().withScope(new ViewLifecycleScopeProvider(view));
+    return AutoDispose.observable()
+        .withScope(new ViewLifecycleScopeProvider(view));
   }
 
   public static SingleSubscribeClause single(View view) {
-    return AutoDispose.single().withScope(new ViewLifecycleScopeProvider(view));
+    return AutoDispose.single()
+        .withScope(new ViewLifecycleScopeProvider(view));
   }
 
   public static MaybeSubscribeClause maybe(View view) {
-    return AutoDispose.maybe().withScope(new ViewLifecycleScopeProvider(view));
+    return AutoDispose.maybe()
+        .withScope(new ViewLifecycleScopeProvider(view));
   }
 
   public static CompletableSubscribeClause completable(View view) {
-    return AutoDispose.completable().withScope(new ViewLifecycleScopeProvider(view));
+    return AutoDispose.completable()
+        .withScope(new ViewLifecycleScopeProvider(view));
   }
 
   public static FlowableSubscribeClause flowable(View view) {
-    return AutoDispose.flowable().withScope(new ViewLifecycleScopeProvider(view));
+    return AutoDispose.flowable()
+        .withScope(new ViewLifecycleScopeProvider(view));
   }
 }

--- a/autodispose-android/src/main/java/com/uber/autodispose/android/ViewLifecycleScopeProvider.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/ViewLifecycleScopeProvider.java
@@ -5,6 +5,8 @@ import android.view.View;
 import com.uber.autodispose.LifecycleEndedException;
 import com.uber.autodispose.LifecycleScopeProvider;
 import io.reactivex.Observable;
+import io.reactivex.ObservableEmitter;
+import io.reactivex.ObservableOnSubscribe;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Function;
@@ -13,12 +15,14 @@ import static com.uber.autodispose.android.Util.isMainThread;
 
 class ViewLifecycleScopeProvider implements LifecycleScopeProvider<ViewLifecycleEvent> {
   private static final Function<ViewLifecycleEvent, ViewLifecycleEvent> CORRESPONDING_EVENTS =
-      lastEvent -> {
-        switch (lastEvent) {
-          case ATTACH:
-            return ViewLifecycleEvent.DETACH;
-          default:
-            throw new LifecycleEndedException();
+      new Function<ViewLifecycleEvent, ViewLifecycleEvent>() {
+        @Override public ViewLifecycleEvent apply(ViewLifecycleEvent lastEvent) throws Exception {
+          switch (lastEvent) {
+            case ATTACH:
+              return ViewLifecycleEvent.DETACH;
+            default:
+              throw new LifecycleEndedException();
+          }
         }
       };
 
@@ -27,65 +31,63 @@ class ViewLifecycleScopeProvider implements LifecycleScopeProvider<ViewLifecycle
 
   ViewLifecycleScopeProvider(final View view) {
     this.view = view;
-    lifecycle = Observable.create(e -> {
-      if (!isMainThread()) {
-        throw new IllegalStateException("Views can only be bound to on the main thread!");
-      }
+    lifecycle = Observable.create(new ObservableOnSubscribe<ViewLifecycleEvent>() {
+      @Override public void subscribe(final ObservableEmitter<ViewLifecycleEvent> e)
+          throws Exception {
+        if (!isMainThread()) {
+          throw new IllegalStateException("Views can only be bound to on the main thread!");
+        }
 
-      if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && view.isAttachedToWindow())
-          || view.getWindowToken() != null) {
-        // Emit the last event, like a behavior subject
-        e.onNext(ViewLifecycleEvent.ATTACH);
-      }
-
-      final View.OnAttachStateChangeListener listener = new View.OnAttachStateChangeListener() {
-        @Override
-        public void onViewAttachedToWindow(View view1) {
+        if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && view.isAttachedToWindow())
+            || view.getWindowToken() != null) {
+          // Emit the last event, like a behavior subject
           e.onNext(ViewLifecycleEvent.ATTACH);
         }
 
-        @Override
-        public void onViewDetachedFromWindow(View view1) {
-          e.onNext(ViewLifecycleEvent.DETACH);
-        }
-      };
-
-      e.setCancellable(new Cancellable() {
-        @Override
-        public void cancel() throws Exception {
-          // A "main thread cancellable"
-          if (isMainThread()) {
-            onCancel();
-          } else {
-            AndroidSchedulers.mainThread()
-                .createWorker()
-                .schedule(this::onCancel);
+        final View.OnAttachStateChangeListener listener = new View.OnAttachStateChangeListener() {
+          @Override public void onViewAttachedToWindow(View view1) {
+            e.onNext(ViewLifecycleEvent.ATTACH);
           }
-        }
 
-        private void onCancel() {
-          view.removeOnAttachStateChangeListener(listener);
-        }
-      });
+          @Override public void onViewDetachedFromWindow(View view1) {
+            e.onNext(ViewLifecycleEvent.DETACH);
+          }
+        };
+
+        e.setCancellable(new Cancellable() {
+          @Override public void cancel() throws Exception {
+            // A "main thread cancellable"
+            if (isMainThread()) {
+              onCancel();
+            } else {
+              AndroidSchedulers.mainThread()
+                  .createWorker()
+                  .schedule(new Runnable() {
+                    @Override public void run() {
+                      onCancel();
+                    }
+                  });
+            }
+          }
+
+          private void onCancel() {
+            view.removeOnAttachStateChangeListener(listener);
+          }
+        });
+      }
     });
   }
 
-  @Override
-  public Observable<ViewLifecycleEvent> lifecycle() {
+  @Override public Observable<ViewLifecycleEvent> lifecycle() {
     return lifecycle;
   }
 
-  @Override
-  public Function<ViewLifecycleEvent, ViewLifecycleEvent> correspondingEvents() {
+  @Override public Function<ViewLifecycleEvent, ViewLifecycleEvent> correspondingEvents() {
     return CORRESPONDING_EVENTS;
   }
 
-  @Override
-  public ViewLifecycleEvent peekLifecycle() {
-    return
-        (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && view.isAttachedToWindow())
-            || view.getWindowToken() != null
-        ? ViewLifecycleEvent.ATTACH
-        : ViewLifecycleEvent.DETACH;
+  @Override public ViewLifecycleEvent peekLifecycle() {
+    return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && view.isAttachedToWindow())
+        || view.getWindowToken() != null ? ViewLifecycleEvent.ATTACH : ViewLifecycleEvent.DETACH;
   }
 }

--- a/autodispose/build.gradle
+++ b/autodispose/build.gradle
@@ -1,25 +1,10 @@
-buildscript {
-  repositories {
-    jcenter()
-  }
-
-  dependencies {
-    classpath deps.build.gradlePlugins.retrolambda
-  }
-}
-
 apply plugin: 'java'
-apply plugin: 'me.tatarka.retrolambda'
 
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
+sourceCompatibility = "1.7"
+targetCompatibility = "1.7"
 
 test {
   testLogging.showStandardStreams = true
-}
-
-retrolambda {
-  oldJdk System.getenv("JAVA7_HOME")
 }
 
 dependencies {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -30,12 +30,12 @@ import static com.uber.autodispose.internal.AutoDisposeUtil.checkNotNull;
 public final class AutoDispose {
 
   private static final FlowableScopeClause FLOWABLE_SCOPE_CLAUSE = new FlowableClauseImpl();
-  private static final ObservableScopeClause OBSERVABLE_SCOPE_CLAUSE
-      = new ObservableScopeClauseImpl();
+  private static final ObservableScopeClause OBSERVABLE_SCOPE_CLAUSE =
+      new ObservableScopeClauseImpl();
   private static final MaybeScopeClause MAYBE_SCOPE_CLAUSE = new MaybeScopeClauseImpl();
   private static final SingleScopeClause SINGLE_SCOPE_CLAUSE = new SingleScopeClauseImpl();
-  private static final CompletableScopeClause COMPLETABLE_SCOPE_CLAUSE
-      = new CompletableScopeClauseImpl();
+  private static final CompletableScopeClause COMPLETABLE_SCOPE_CLAUSE =
+      new CompletableScopeClauseImpl();
 
   private AutoDispose() {
     throw new InstantiationError();
@@ -62,86 +62,71 @@ public final class AutoDispose {
   }
 
   private static class FlowableClauseImpl implements FlowableScopeClause {
-    @Override
-    public AutoDisposingSubscriberCreator withScope(ScopeProvider provider) {
+    @Override public AutoDisposingSubscriberCreator withScope(ScopeProvider provider) {
       return new AutoDisposingSubscriberCreator(provider);
     }
 
-    @Override
-    public AutoDisposingSubscriberCreator withScope(LifecycleScopeProvider<?> provider) {
+    @Override public AutoDisposingSubscriberCreator withScope(LifecycleScopeProvider<?> provider) {
       return new AutoDisposingSubscriberCreator(provider);
     }
 
-    @Override
-    public AutoDisposingSubscriberCreator withScope(Maybe<?> lifecycle) {
+    @Override public AutoDisposingSubscriberCreator withScope(Maybe<?> lifecycle) {
       return new AutoDisposingSubscriberCreator(lifecycle);
     }
   }
 
   private static class ObservableScopeClauseImpl implements ObservableScopeClause {
-    @Override
-    public ObservableSubscribeClause withScope(ScopeProvider provider) {
+    @Override public ObservableSubscribeClause withScope(ScopeProvider provider) {
       return new AutoDisposingObserverCreator(provider);
     }
 
-    @Override
-    public ObservableSubscribeClause withScope(LifecycleScopeProvider<?> provider) {
+    @Override public ObservableSubscribeClause withScope(LifecycleScopeProvider<?> provider) {
       return new AutoDisposingObserverCreator(provider);
     }
 
-    @Override
-    public ObservableSubscribeClause withScope(Maybe<?> lifecycle) {
+    @Override public ObservableSubscribeClause withScope(Maybe<?> lifecycle) {
       return new AutoDisposingObserverCreator(lifecycle);
     }
   }
 
   private static class MaybeScopeClauseImpl implements MaybeScopeClause {
-    @Override
-    public MaybeSubscribeClause withScope(ScopeProvider provider) {
+    @Override public MaybeSubscribeClause withScope(ScopeProvider provider) {
       return new AutoDisposingMaybeObserverCreator(provider);
     }
 
-    @Override
-    public MaybeSubscribeClause withScope(LifecycleScopeProvider<?> provider) {
+    @Override public MaybeSubscribeClause withScope(LifecycleScopeProvider<?> provider) {
       return new AutoDisposingMaybeObserverCreator(provider);
     }
 
-    @Override
-    public MaybeSubscribeClause withScope(Maybe<?> lifecycle) {
+    @Override public MaybeSubscribeClause withScope(Maybe<?> lifecycle) {
       return new AutoDisposingMaybeObserverCreator(lifecycle);
     }
   }
 
   private static class SingleScopeClauseImpl implements SingleScopeClause {
-    @Override
-    public SingleSubscribeClause withScope(ScopeProvider provider) {
+    @Override public SingleSubscribeClause withScope(ScopeProvider provider) {
       return new AutoDisposingSingleObserverCreator(provider);
     }
 
-    @Override
-    public SingleSubscribeClause withScope(LifecycleScopeProvider<?> provider) {
+    @Override public SingleSubscribeClause withScope(LifecycleScopeProvider<?> provider) {
       return new AutoDisposingSingleObserverCreator(provider);
     }
 
-    @Override
-    public SingleSubscribeClause withScope(Maybe<?> lifecycle) {
+    @Override public SingleSubscribeClause withScope(Maybe<?> lifecycle) {
       return new AutoDisposingSingleObserverCreator(lifecycle);
     }
   }
 
   private static class CompletableScopeClauseImpl implements CompletableScopeClause {
-    @Override
-    public CompletableSubscribeClause withScope(ScopeProvider provider) {
+    @Override public CompletableSubscribeClause withScope(ScopeProvider provider) {
       return new AutoDisposingCompletableObserverCreator(provider);
     }
 
-    @Override
-    public CompletableSubscribeClause withScope(LifecycleScopeProvider<?> provider) {
+    @Override public CompletableSubscribeClause withScope(LifecycleScopeProvider<?> provider) {
       return new AutoDisposingCompletableObserverCreator(provider);
     }
 
-    @Override
-    public CompletableSubscribeClause withScope(Maybe<?> lifecycle) {
+    @Override public CompletableSubscribeClause withScope(Maybe<?> lifecycle) {
       return new AutoDisposingCompletableObserverCreator(lifecycle);
     }
   }
@@ -149,8 +134,12 @@ public final class AutoDispose {
   private static class Base {
     protected final Maybe<?> lifecycle;
 
-    Base(ScopeProvider provider) {
-      this(Maybe.defer((Callable<MaybeSource<?>>) provider::requestScope));
+    Base(final ScopeProvider provider) {
+      this(Maybe.defer(new Callable<MaybeSource<?>>() {
+        @Override public MaybeSource<?> call() throws Exception {
+          return provider.requestScope();
+        }
+      }));
     }
 
     Base(LifecycleScopeProvider<?> provider) {
@@ -176,21 +165,17 @@ public final class AutoDispose {
       super(lifecycle);
     }
 
-    @Override
-    public <T> Subscriber<T> empty() {
-      return around(AutoDisposeUtil.EMPTY_CONSUMER,
-          AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
+    @Override public <T> Subscriber<T> empty() {
+      return around(AutoDisposeUtil.EMPTY_CONSUMER, AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
           AutoDisposeUtil.EMPTY_ACTION);
     }
 
-    @Override
-    public <T> Subscriber<T> around(Consumer<? super T> onNext) {
+    @Override public <T> Subscriber<T> around(Consumer<? super T> onNext) {
       checkNotNull(onNext, "onNext == null");
       return around(onNext, AutoDisposeUtil.DEFAULT_ERROR_CONSUMER, AutoDisposeUtil.EMPTY_ACTION);
     }
 
-    @Override
-    public <T> Subscriber<T> around(Consumer<? super T> onNext,
+    @Override public <T> Subscriber<T> around(Consumer<? super T> onNext,
         Consumer<? super Throwable> onError) {
       checkNotNull(onNext, "onNext == null");
       checkNotNull(onError, "onError == null");
@@ -198,8 +183,7 @@ public final class AutoDispose {
     }
 
     @Override
-    public <T> Subscriber<T> around(Consumer<? super T> onNext,
-        Consumer<? super Throwable> onError,
+    public <T> Subscriber<T> around(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
         Action onComplete) {
       checkNotNull(onNext, "onNext == null");
       checkNotNull(onError, "onError == null");
@@ -207,20 +191,30 @@ public final class AutoDispose {
       return around(onNext, onError, onComplete, AutoDisposeUtil.EMPTY_SUBSCRIPTION_CONSUMER);
     }
 
-    @Override
-    public <T> Subscriber<T> around(Subscriber<T> subscriber) {
+    @Override public <T> Subscriber<T> around(final Subscriber<T> subscriber) {
       checkNotNull(subscriber, "subscriber == null");
-      return around(subscriber::onNext,
-          subscriber::onError,
-          subscriber::onComplete,
-          subscriber::onSubscribe);
+      return around(new Consumer<T>() {
+        @Override public void accept(T t1) throws Exception {
+          subscriber.onNext(t1);
+        }
+      }, new Consumer<Throwable>() {
+        @Override public void accept(Throwable t) throws Exception {
+          subscriber.onError(t);
+        }
+      }, new Action() {
+        @Override public void run() throws Exception {
+          subscriber.onComplete();
+        }
+      }, new Consumer<Subscription>() {
+        @Override public void accept(Subscription s) throws Exception {
+          subscriber.onSubscribe(s);
+        }
+      });
     }
 
     @Override
-    public <T> Subscriber<T> around(Consumer<? super T> onNext,
-        Consumer<? super Throwable> onError,
-        Action onComplete,
-        Consumer<? super Subscription> onSubscribe) {
+    public <T> Subscriber<T> around(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
+        Action onComplete, Consumer<? super Subscription> onSubscribe) {
       checkNotNull(onNext, "onNext == null");
       checkNotNull(onError, "onError == null");
       checkNotNull(onComplete, "onComplete == null");
@@ -243,13 +237,11 @@ public final class AutoDispose {
       super(lifecycle);
     }
 
-    @Override
-    public <T> Observer<T> empty() {
+    @Override public <T> Observer<T> empty() {
       return around(AutoDisposeUtil.EMPTY_CONSUMER);
     }
 
-    @Override
-    public <T> Observer<T> around(Consumer<? super T> onNext) {
+    @Override public <T> Observer<T> around(Consumer<? super T> onNext) {
       checkNotNull(onNext, "onNext == null");
       return around(onNext, AutoDisposeUtil.DEFAULT_ERROR_CONSUMER, AutoDisposeUtil.EMPTY_ACTION);
     }
@@ -262,8 +254,7 @@ public final class AutoDispose {
     }
 
     @Override
-    public <T> Observer<T> around(Consumer<? super T> onNext,
-        Consumer<? super Throwable> onError,
+    public <T> Observer<T> around(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
         Action onComplete) {
       checkNotNull(onNext, "onNext == null");
       checkNotNull(onError, "onError == null");
@@ -271,20 +262,30 @@ public final class AutoDispose {
       return around(onNext, onError, onComplete, AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER);
     }
 
-    @Override
-    public <T> Observer<T> around(Observer<T> observer) {
+    @Override public <T> Observer<T> around(final Observer<T> observer) {
       checkNotNull(observer, "observer == null");
-      return around(observer::onNext,
-          observer::onError,
-          observer::onComplete,
-          observer::onSubscribe);
+      return around(new Consumer<T>() {
+        @Override public void accept(T value) throws Exception {
+          observer.onNext(value);
+        }
+      }, new Consumer<Throwable>() {
+        @Override public void accept(Throwable e) throws Exception {
+          observer.onError(e);
+        }
+      }, new Action() {
+        @Override public void run() throws Exception {
+          observer.onComplete();
+        }
+      }, new Consumer<Disposable>() {
+        @Override public void accept(Disposable d) throws Exception {
+          observer.onSubscribe(d);
+        }
+      });
     }
 
     @Override
-    public <T> Observer<T> around(Consumer<? super T> onNext,
-        Consumer<? super Throwable> onError,
-        Action onComplete,
-        Consumer<? super Disposable> onSubscribe) {
+    public <T> Observer<T> around(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
+        Action onComplete, Consumer<? super Disposable> onSubscribe) {
       checkNotNull(onNext, "onNext == null");
       checkNotNull(onError, "onError == null");
       checkNotNull(onComplete, "onComplete == null");
@@ -307,41 +308,55 @@ public final class AutoDispose {
       super(lifecycle);
     }
 
-    @Override
-    public <T> SingleObserver<T> empty() {
+    @Override public <T> SingleObserver<T> empty() {
       return around(AutoDisposeUtil.EMPTY_CONSUMER);
     }
 
-    @Override
-    public <T> SingleObserver<T> around(Consumer<? super T> onSuccess) {
+    @Override public <T> SingleObserver<T> around(Consumer<? super T> onSuccess) {
       checkNotNull(onSuccess, "onSuccess == null");
       return around(onSuccess, AutoDisposeUtil.DEFAULT_ERROR_CONSUMER);
     }
 
     @Override
-    public <T> SingleObserver<T> around(BiConsumer<? super T, ? super Throwable> biConsumer) {
+    public <T> SingleObserver<T> around(final BiConsumer<? super T, ? super Throwable> biConsumer) {
       checkNotNull(biConsumer, "biConsumer == null");
-      return around(v -> biConsumer.accept(v, null), t -> biConsumer.accept(null, t));
+      return around(new Consumer<T>() {
+        @Override public void accept(T v) throws Exception {
+          biConsumer.accept(v, null);
+        }
+      }, new Consumer<Throwable>() {
+        @Override public void accept(Throwable t) throws Exception {
+          biConsumer.accept(null, t);
+        }
+      });
     }
 
-    @Override
-    public <T> SingleObserver<T> around(Consumer<? super T> onSuccess,
+    @Override public <T> SingleObserver<T> around(Consumer<? super T> onSuccess,
         Consumer<? super Throwable> onError) {
       checkNotNull(onSuccess, "onSuccess == null");
       checkNotNull(onError, "onError == null");
       return around(onSuccess, onError, AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER);
     }
 
-    @Override
-    public <T> SingleObserver<T> around(SingleObserver<T> observer) {
+    @Override public <T> SingleObserver<T> around(final SingleObserver<T> observer) {
       checkNotNull(observer, "observer == null");
-      return around(observer::onSuccess, observer::onError, observer::onSubscribe);
+      return around(new Consumer<T>() {
+        @Override public void accept(T value) throws Exception {
+          observer.onSuccess(value);
+        }
+      }, new Consumer<Throwable>() {
+        @Override public void accept(Throwable e) throws Exception {
+          observer.onError(e);
+        }
+      }, new Consumer<Disposable>() {
+        @Override public void accept(Disposable d) throws Exception {
+          observer.onSubscribe(d);
+        }
+      });
     }
 
-    @Override
-    public <T> SingleObserver<T> around(Consumer<? super T> onSuccess,
-        Consumer<? super Throwable> onError,
-        Consumer<? super Disposable> onSubscribe) {
+    @Override public <T> SingleObserver<T> around(Consumer<? super T> onSuccess,
+        Consumer<? super Throwable> onError, Consumer<? super Disposable> onSubscribe) {
       checkNotNull(onSuccess, "onSuccess == null");
       checkNotNull(onError, "onError == null");
       checkNotNull(onSubscribe, "onSubscribe == null");
@@ -363,59 +378,60 @@ public final class AutoDispose {
       super(lifecycle);
     }
 
-    @Override
-    public <T> MaybeObserver<T> empty() {
+    @Override public <T> MaybeObserver<T> empty() {
       return around(AutoDisposeUtil.EMPTY_CONSUMER);
     }
 
-    @Override
-    public <T> MaybeObserver<T> around(Consumer<? super T> onSuccess) {
+    @Override public <T> MaybeObserver<T> around(Consumer<? super T> onSuccess) {
       checkNotNull(onSuccess, "onSuccess == null");
-      return around(onSuccess,
-          AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
+      return around(onSuccess, AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
           AutoDisposeUtil.EMPTY_ACTION);
     }
 
-    @Override
-    public <T> MaybeObserver<T> around(Consumer<? super T> onSuccess,
+    @Override public <T> MaybeObserver<T> around(Consumer<? super T> onSuccess,
         Consumer<? super Throwable> onError) {
       checkNotNull(onSuccess, "onSuccess == null");
       checkNotNull(onError, "onError == null");
       return around(onSuccess, onError, AutoDisposeUtil.EMPTY_ACTION);
     }
 
-    @Override
-    public <T> MaybeObserver<T> around(Consumer<? super T> onSuccess,
-        Consumer<? super Throwable> onError,
-        Action onComplete) {
+    @Override public <T> MaybeObserver<T> around(Consumer<? super T> onSuccess,
+        Consumer<? super Throwable> onError, Action onComplete) {
       checkNotNull(onSuccess, "onSuccess == null");
       checkNotNull(onError, "onError == null");
       checkNotNull(onComplete, "onComplete == null");
       return around(onSuccess, onError, onComplete, AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER);
     }
 
-    @Override
-    public <T> MaybeObserver<T> around(MaybeObserver<T> observer) {
+    @Override public <T> MaybeObserver<T> around(final MaybeObserver<T> observer) {
       checkNotNull(observer, "observer == null");
-      return around(observer::onSuccess,
-          observer::onError,
-          observer::onComplete,
-          observer::onSubscribe);
+      return around(new Consumer<T>() {
+        @Override public void accept(T value) throws Exception {
+          observer.onSuccess(value);
+        }
+      }, new Consumer<Throwable>() {
+        @Override public void accept(Throwable e) throws Exception {
+          observer.onError(e);
+        }
+      }, new Action() {
+        @Override public void run() throws Exception {
+          observer.onComplete();
+        }
+      }, new Consumer<Disposable>() {
+        @Override public void accept(Disposable d) throws Exception {
+          observer.onSubscribe(d);
+        }
+      });
     }
 
-    @Override
-    public <T> MaybeObserver<T> around(Consumer<? super T> onSuccess,
-        Consumer<? super Throwable> onError,
-        Action onComplete,
+    @Override public <T> MaybeObserver<T> around(Consumer<? super T> onSuccess,
+        Consumer<? super Throwable> onError, Action onComplete,
         Consumer<? super Disposable> onSubscribe) {
       checkNotNull(onSuccess, "onSuccess == null");
       checkNotNull(onError, "onError == null");
       checkNotNull(onComplete, "onComplete == null");
       checkNotNull(onSubscribe, "onSubscribe == null");
-      return new AutoDisposingMaybeObserver<>(lifecycle,
-          onSuccess,
-          onError,
-          onComplete,
+      return new AutoDisposingMaybeObserver<>(lifecycle, onSuccess, onError, onComplete,
           onSubscribe);
     }
   }
@@ -434,13 +450,11 @@ public final class AutoDispose {
       super(lifecycle);
     }
 
-    @Override
-    public CompletableObserver empty() {
+    @Override public CompletableObserver empty() {
       return around(AutoDisposeUtil.EMPTY_ACTION);
     }
 
-    @Override
-    public CompletableObserver around(Action action) {
+    @Override public CompletableObserver around(Action action) {
       checkNotNull(action, "action == null");
       return around(action, AutoDisposeUtil.DEFAULT_ERROR_CONSUMER);
     }
@@ -452,15 +466,24 @@ public final class AutoDispose {
       return around(action, onError, AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER);
     }
 
-    @Override
-    public CompletableObserver around(CompletableObserver observer) {
+    @Override public CompletableObserver around(final CompletableObserver observer) {
       checkNotNull(observer, "observer == null");
-      return around(observer::onComplete, observer::onError, observer::onSubscribe);
+      return around(new Action() {
+        @Override public void run() throws Exception {
+          observer.onComplete();
+        }
+      }, new Consumer<Throwable>() {
+        @Override public void accept(Throwable e) throws Exception {
+          observer.onError(e);
+        }
+      }, new Consumer<Disposable>() {
+        @Override public void accept(Disposable d) throws Exception {
+          observer.onSubscribe(d);
+        }
+      });
     }
 
-    @Override
-    public CompletableObserver around(Action action,
-        Consumer<? super Throwable> onError,
+    @Override public CompletableObserver around(Action action, Consumer<? super Throwable> onError,
         Consumer<? super Disposable> onSubscribe) {
       checkNotNull(action, "action == null");
       checkNotNull(onError, "onError == null");

--- a/autodispose/src/main/java/com/uber/autodispose/LifecycleScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/LifecycleScopeProvider.java
@@ -17,19 +17,16 @@ public interface LifecycleScopeProvider<E> {
   /**
    * @return a sequence of lifecycle events.
    */
-  @CheckReturnValue
-  Observable<E> lifecycle();
+  @CheckReturnValue Observable<E> lifecycle();
 
   /**
    * @return a sequence of lifecycle events. It's recommended to back this with a static instance to
-   *         avoid unnecessary object allocationn.
+   * avoid unnecessary object allocationn.
    */
-  @CheckReturnValue
-  Function<E, E> correspondingEvents();
+  @CheckReturnValue Function<E, E> correspondingEvents();
 
   /**
    * @return the last seen lifecycle event, or {@code null} if none.
    */
-  @Nullable
-  E peekLifecycle();
+  @Nullable E peekLifecycle();
 }

--- a/autodispose/src/main/java/com/uber/autodispose/ScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/ScopeProvider.java
@@ -1,11 +1,7 @@
 package com.uber.autodispose;
 
 import io.reactivex.Maybe;
-import io.reactivex.MaybeSource;
-import io.reactivex.Observable;
 import io.reactivex.annotations.CheckReturnValue;
-import io.reactivex.functions.Function;
-import javax.annotation.Nullable;
 
 /**
  * Proves a {@link Maybe} representation of a scope. The emission of this is the signal
@@ -15,6 +11,5 @@ public interface ScopeProvider {
   /**
    * @return a Maybe that, upon emission, will trigger disposal.
    */
-  @CheckReturnValue
-  Maybe<?> requestScope();
+  @CheckReturnValue Maybe<?> requestScope();
 }

--- a/autodispose/src/main/java/com/uber/autodispose/ScopeUtil.java
+++ b/autodispose/src/main/java/com/uber/autodispose/ScopeUtil.java
@@ -1,8 +1,11 @@
 package com.uber.autodispose;
 
 import io.reactivex.Maybe;
+import io.reactivex.MaybeSource;
 import io.reactivex.Observable;
 import io.reactivex.functions.Function;
+import io.reactivex.functions.Predicate;
+import java.util.concurrent.Callable;
 
 /**
  * Utilities for dealing with scopes.
@@ -10,7 +13,17 @@ import io.reactivex.functions.Function;
 public final class ScopeUtil {
 
   private static final Function<Object, LifecycleEndEvent> TRANSFORM_TO_END =
-      o -> LifecycleEndEvent.INSTANCE;
+      new Function<Object, LifecycleEndEvent>() {
+        @Override public LifecycleEndEvent apply(Object o) throws Exception {
+          return LifecycleEndEvent.INSTANCE;
+        }
+      };
+
+  private static final Predicate<Boolean> IDENTITY_BOOLEAN_PREDICATE = new Predicate<Boolean>() {
+    @Override public boolean test(Boolean b) throws Exception {
+      return b;
+    }
+  };
 
   private ScopeUtil() {
     throw new InstantiationError();
@@ -22,33 +35,39 @@ public final class ScopeUtil {
   }
 
   public static <E> Maybe<LifecycleEndEvent> deferredResolvedLifecycle(
-      LifecycleScopeProvider<E> provider,
-      boolean checkStartBoundary,
-      boolean checkEndBoundary) {
-    return Maybe.defer(() -> {
-      E lastEvent = provider.peekLifecycle();
-      if (checkStartBoundary && lastEvent == null) {
-        throw new LifecycleNotStartedException();
-      }
-      E endEvent;
-      try {
-        endEvent = provider.correspondingEvents().apply(lastEvent);
-      } catch (Exception e) {
-        if (checkEndBoundary && e instanceof LifecycleEndedException) {
-          throw e;
-        } else {
-          return Maybe.error(e);
+      final LifecycleScopeProvider<E> provider, final boolean checkStartBoundary,
+      final boolean checkEndBoundary) {
+    return Maybe.defer(new Callable<MaybeSource<? extends LifecycleEndEvent>>() {
+      @Override public MaybeSource<? extends LifecycleEndEvent> call() throws Exception {
+        E lastEvent = provider.peekLifecycle();
+        if (checkStartBoundary && lastEvent == null) {
+          throw new LifecycleNotStartedException();
         }
+        E endEvent;
+        try {
+          endEvent = provider.correspondingEvents()
+              .apply(lastEvent);
+        } catch (Exception e) {
+          if (checkEndBoundary && e instanceof LifecycleEndedException) {
+            throw e;
+          } else {
+            return Maybe.error(e);
+          }
+        }
+        return resolveLifecycleMaybe(provider.lifecycle(), endEvent);
       }
-      return resolveLifecycleMaybe(provider.lifecycle(), endEvent);
     });
   }
 
   public static <E> Maybe<LifecycleEndEvent> resolveLifecycleMaybe(Observable<E> lifecycle,
-      E endEvent) {
+      final E endEvent) {
     return lifecycle.skip(1)
-        .map(e -> e.equals(endEvent))
-        .filter(b -> b)
+        .map(new Function<E, Boolean>() {
+          @Override public Boolean apply(E e) throws Exception {
+            return e.equals(endEvent);
+          }
+        })
+        .filter(IDENTITY_BOOLEAN_PREDICATE)
         .map(TRANSFORM_TO_END)
         .firstElement();
   }

--- a/autodispose/src/main/java/com/uber/autodispose/clause/scope/CompletableScopeClause.java
+++ b/autodispose/src/main/java/com/uber/autodispose/clause/scope/CompletableScopeClause.java
@@ -5,4 +5,4 @@ import com.uber.autodispose.clause.subscribe.CompletableSubscribeClause;
 /**
  * Scope clause for the scope provisioning steps.
  */
-public interface CompletableScopeClause extends ScopeClause<CompletableSubscribeClause> { }
+public interface CompletableScopeClause extends ScopeClause<CompletableSubscribeClause> {}

--- a/autodispose/src/main/java/com/uber/autodispose/clause/scope/FlowableScopeClause.java
+++ b/autodispose/src/main/java/com/uber/autodispose/clause/scope/FlowableScopeClause.java
@@ -5,4 +5,4 @@ import com.uber.autodispose.clause.subscribe.FlowableSubscribeClause;
 /**
  * Scope clause for the scope provisioning steps.
  */
-public interface FlowableScopeClause extends ScopeClause<FlowableSubscribeClause> { }
+public interface FlowableScopeClause extends ScopeClause<FlowableSubscribeClause> {}

--- a/autodispose/src/main/java/com/uber/autodispose/clause/scope/MaybeScopeClause.java
+++ b/autodispose/src/main/java/com/uber/autodispose/clause/scope/MaybeScopeClause.java
@@ -5,4 +5,4 @@ import com.uber.autodispose.clause.subscribe.MaybeSubscribeClause;
 /**
  * Scope clause for the scope provisioning steps.
  */
-public interface MaybeScopeClause extends ScopeClause<MaybeSubscribeClause> { }
+public interface MaybeScopeClause extends ScopeClause<MaybeSubscribeClause> {}

--- a/autodispose/src/main/java/com/uber/autodispose/clause/scope/ObservableScopeClause.java
+++ b/autodispose/src/main/java/com/uber/autodispose/clause/scope/ObservableScopeClause.java
@@ -5,4 +5,4 @@ import com.uber.autodispose.clause.subscribe.ObservableSubscribeClause;
 /**
  * Scope clause for the scope provisioning steps.
  */
-public interface ObservableScopeClause extends ScopeClause<ObservableSubscribeClause> { }
+public interface ObservableScopeClause extends ScopeClause<ObservableSubscribeClause> {}

--- a/autodispose/src/main/java/com/uber/autodispose/clause/scope/ScopeClause.java
+++ b/autodispose/src/main/java/com/uber/autodispose/clause/scope/ScopeClause.java
@@ -14,5 +14,4 @@ public interface ScopeClause<T> {
   T withScope(LifecycleScopeProvider<?> provider);
 
   T withScope(Maybe<?> lifecycle);
-
 }

--- a/autodispose/src/main/java/com/uber/autodispose/clause/scope/SingleScopeClause.java
+++ b/autodispose/src/main/java/com/uber/autodispose/clause/scope/SingleScopeClause.java
@@ -5,4 +5,4 @@ import com.uber.autodispose.clause.subscribe.SingleSubscribeClause;
 /**
  * Scope clause for the scope provisioning steps.
  */
-public interface SingleScopeClause extends ScopeClause<SingleSubscribeClause> { }
+public interface SingleScopeClause extends ScopeClause<SingleSubscribeClause> {}

--- a/autodispose/src/main/java/com/uber/autodispose/clause/subscribe/CompletableSubscribeClause.java
+++ b/autodispose/src/main/java/com/uber/autodispose/clause/subscribe/CompletableSubscribeClause.java
@@ -18,7 +18,6 @@ public interface CompletableSubscribeClause {
 
   CompletableObserver around(CompletableObserver observer);
 
-  CompletableObserver around(Action action,
-      Consumer<? super Throwable> onError,
+  CompletableObserver around(Action action, Consumer<? super Throwable> onError,
       Consumer<? super Disposable> onSubscribe);
 }

--- a/autodispose/src/main/java/com/uber/autodispose/clause/subscribe/FlowableSubscribeClause.java
+++ b/autodispose/src/main/java/com/uber/autodispose/clause/subscribe/FlowableSubscribeClause.java
@@ -16,14 +16,11 @@ public interface FlowableSubscribeClause {
 
   <T> Subscriber<T> around(Consumer<? super T> onNext, Consumer<? super Throwable> onError);
 
-  <T> Subscriber<T> around(Consumer<? super T> onNext,
-      Consumer<? super Throwable> onError,
+  <T> Subscriber<T> around(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
       Action onComplete);
 
   <T> Subscriber<T> around(Subscriber<T> subscriber);
 
-  <T> Subscriber<T> around(Consumer<? super T> onNext,
-      Consumer<? super Throwable> onError,
-      Action onComplete,
-      Consumer<? super Subscription> onSubscribe);
+  <T> Subscriber<T> around(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
+      Action onComplete, Consumer<? super Subscription> onSubscribe);
 }

--- a/autodispose/src/main/java/com/uber/autodispose/clause/subscribe/MaybeSubscribeClause.java
+++ b/autodispose/src/main/java/com/uber/autodispose/clause/subscribe/MaybeSubscribeClause.java
@@ -14,17 +14,13 @@ public interface MaybeSubscribeClause {
 
   <T> MaybeObserver<T> around(Consumer<? super T> onSuccess);
 
-  <T> MaybeObserver<T> around(Consumer<? super T> onSuccess,
-      Consumer<? super Throwable> onError);
+  <T> MaybeObserver<T> around(Consumer<? super T> onSuccess, Consumer<? super Throwable> onError);
 
-  <T> MaybeObserver<T> around(Consumer<? super T> onSuccess,
-      Consumer<? super Throwable> onError,
+  <T> MaybeObserver<T> around(Consumer<? super T> onSuccess, Consumer<? super Throwable> onError,
       Action onComplete);
 
   <T> MaybeObserver<T> around(MaybeObserver<T> observer);
 
-  <T> MaybeObserver<T> around(Consumer<? super T> onSuccess,
-      Consumer<? super Throwable> onError,
-      Action onComplete,
-      Consumer<? super Disposable> onSubscribe);
+  <T> MaybeObserver<T> around(Consumer<? super T> onSuccess, Consumer<? super Throwable> onError,
+      Action onComplete, Consumer<? super Disposable> onSubscribe);
 }

--- a/autodispose/src/main/java/com/uber/autodispose/clause/subscribe/ObservableSubscribeClause.java
+++ b/autodispose/src/main/java/com/uber/autodispose/clause/subscribe/ObservableSubscribeClause.java
@@ -16,14 +16,11 @@ public interface ObservableSubscribeClause {
 
   <T> Observer<T> around(Consumer<? super T> onNext, Consumer<? super Throwable> onError);
 
-  <T> Observer<T> around(Consumer<? super T> onNext,
-      Consumer<? super Throwable> onError,
+  <T> Observer<T> around(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
       Action onComplete);
 
   <T> Observer<T> around(Observer<T> observer);
 
-  <T> Observer<T> around(Consumer<? super T> onNext,
-      Consumer<? super Throwable> onError,
-      Action onComplete,
-      Consumer<? super Disposable> onSubscribe);
+  <T> Observer<T> around(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
+      Action onComplete, Consumer<? super Disposable> onSubscribe);
 }

--- a/autodispose/src/main/java/com/uber/autodispose/clause/subscribe/SingleSubscribeClause.java
+++ b/autodispose/src/main/java/com/uber/autodispose/clause/subscribe/SingleSubscribeClause.java
@@ -16,12 +16,10 @@ public interface SingleSubscribeClause {
 
   <T> SingleObserver<T> around(BiConsumer<? super T, ? super Throwable> biConsumer);
 
-  <T> SingleObserver<T> around(Consumer<? super T> onSuccess,
-      Consumer<? super Throwable> onError);
+  <T> SingleObserver<T> around(Consumer<? super T> onSuccess, Consumer<? super Throwable> onError);
 
   <T> SingleObserver<T> around(SingleObserver<T> observer);
 
-  <T> SingleObserver<T> around(Consumer<? super T> onSuccess,
-      Consumer<? super Throwable> onError,
+  <T> SingleObserver<T> around(Consumer<? super T> onSuccess, Consumer<? super Throwable> onError,
       Consumer<? super Disposable> onSubscribe);
 }

--- a/autodispose/src/main/java/com/uber/autodispose/internal/AutoDisposableHelper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/internal/AutoDisposableHelper.java
@@ -149,13 +149,11 @@ public enum AutoDisposableHelper implements Disposable {
     RxJavaPlugins.onError(new IllegalStateException("Disposable already set!"));
   }
 
-  @Override
-  public void dispose() {
+  @Override public void dispose() {
     // deliberately no-op
   }
 
-  @Override
-  public boolean isDisposed() {
+  @Override public boolean isDisposed() {
     return true;
   }
 }

--- a/autodispose/src/main/java/com/uber/autodispose/internal/AutoDisposeUtil.java
+++ b/autodispose/src/main/java/com/uber/autodispose/internal/AutoDisposeUtil.java
@@ -13,53 +13,43 @@ public class AutoDisposeUtil {
   }
 
   public static final Action EMPTY_ACTION = new Action() {
-    @Override
-    public void run() { }
+    @Override public void run() {}
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
       return "AutoDisposingEmptyAction";
     }
   };
 
   public static final Consumer<Object> EMPTY_CONSUMER = new Consumer<Object>() {
-    @Override
-    public void accept(Object v) { }
+    @Override public void accept(Object v) {}
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
       return "AutoDisposingEmptyConsumer";
     }
   };
 
   public static final Consumer<Throwable> DEFAULT_ERROR_CONSUMER = new Consumer<Throwable>() {
-    @Override
-    public void accept(Throwable throwable) throws Exception { }
+    @Override public void accept(Throwable throwable) throws Exception {}
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
       return "AutoDisposingEmptyErrorConsumer";
     }
   };
 
   public static final Consumer<Disposable> EMPTY_DISPOSABLE_CONSUMER = new Consumer<Disposable>() {
-    @Override
-    public void accept(Disposable d) throws Exception { }
+    @Override public void accept(Disposable d) throws Exception {}
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
       return "AutoDisposingEmptyDisposableConsumer";
     }
   };
 
   public static final Consumer<Subscription> EMPTY_SUBSCRIPTION_CONSUMER =
       new Consumer<Subscription>() {
-        @Override
-        public void accept(Subscription d) throws Exception {
+        @Override public void accept(Subscription d) throws Exception {
         }
 
-        @Override
-        public String toString() {
+        @Override public String toString() {
           return "AutoDisposingEmptySubscriptionConsumer";
         }
       };
@@ -69,19 +59,20 @@ public class AutoDisposeUtil {
     return c != null ? c : (Consumer<T>) EMPTY_CONSUMER;
   }
 
-  public static Consumer<? super Throwable> emptyErrorConsumerIfNull(
+  @SuppressWarnings("unchecked") public static Consumer<? super Throwable> emptyErrorConsumerIfNull(
       @Nullable Consumer<? super Throwable> c) {
-    return c != null ? c : DEFAULT_ERROR_CONSUMER;
+    return (Consumer<? super Throwable>) (c != null ? c : DEFAULT_ERROR_CONSUMER);
   }
 
-  public static Consumer<? super Disposable> emptyDisposableIfNull(
+  @SuppressWarnings("unchecked") public static Consumer<? super Disposable> emptyDisposableIfNull(
       @Nullable Consumer<? super Disposable> c) {
-    return c != null ? c : EMPTY_DISPOSABLE_CONSUMER;
+    return (Consumer<? super Disposable>) (c != null ? c : EMPTY_DISPOSABLE_CONSUMER);
   }
 
+  @SuppressWarnings("unchecked")
   public static Consumer<? super Subscription> emptySubscriptionIfNull(
       @Nullable Consumer<? super Subscription> c) {
-    return c != null ? c : EMPTY_SUBSCRIPTION_CONSUMER;
+    return (Consumer<? super Subscription>) (c != null ? c : EMPTY_SUBSCRIPTION_CONSUMER);
   }
 
   public static Action emptyActionIfNull(@Nullable Action a) {

--- a/autodispose/src/main/java/com/uber/autodispose/internal/AutoSubscriptionHelper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/internal/AutoSubscriptionHelper.java
@@ -34,13 +34,11 @@ public enum AutoSubscriptionHelper implements Subscription {
    */
   CANCELLED;
 
-  @Override
-  public void request(long n) {
+  @Override public void request(long n) {
     // deliberately ignored
   }
 
-  @Override
-  public void cancel() {
+  @Override public void cancel() {
     // deliberately ignored
   }
 
@@ -213,8 +211,7 @@ public enum AutoSubscriptionHelper implements Subscription {
    * @param s the new Subscription, not null (verified)
    * @return true if the Subscription was set the first time
    */
-  public static boolean deferredSetOnce(AtomicReference<Subscription> field,
-      AtomicLong requested,
+  public static boolean deferredSetOnce(AtomicReference<Subscription> field, AtomicLong requested,
       Subscription s) {
     if (AutoSubscriptionHelper.setOnce(field, s)) {
       long r = requested.getAndSet(0L);
@@ -234,8 +231,7 @@ public enum AutoSubscriptionHelper implements Subscription {
    * @param requested the current requested amount
    * @param n the request amount, positive (verified)
    */
-  public static void deferredRequest(AtomicReference<Subscription> field,
-      AtomicLong requested,
+  public static void deferredRequest(AtomicReference<Subscription> field, AtomicLong requested,
       long n) {
     Subscription s = field.get();
     if (s != null) {

--- a/autodispose/src/test/java/com/uber/autodispose/RecordingObserver.java
+++ b/autodispose/src/test/java/com/uber/autodispose/RecordingObserver.java
@@ -19,32 +19,27 @@ public final class RecordingObserver<T>
 
   private final BlockingDeque<Object> events = new LinkedBlockingDeque<>();
 
-  @Override
-  public void onError(Throwable e) {
+  @Override public void onError(Throwable e) {
     System.out.println(TAG + ": onError - " + e);
     events.addLast(new OnError(e));
   }
 
-  @Override
-  public void onComplete() {
+  @Override public void onComplete() {
     System.out.println(TAG + ": onCompleted");
     events.addLast(new OnCompleted());
   }
 
-  @Override
-  public void onSubscribe(Disposable d) {
+  @Override public void onSubscribe(Disposable d) {
     System.out.println(TAG + ": onSubscribe");
     events.addLast(new OnSubscribe(d));
   }
 
-  @Override
-  public void onSuccess(T value) {
+  @Override public void onSuccess(T value) {
     System.out.println(TAG + ": onSuccess - " + value);
     events.addLast(new OnSuccess(value));
   }
 
-  @Override
-  public void onNext(T t) {
+  @Override public void onNext(T t) {
     System.out.println(TAG + ": onNext - " + t);
     events.addLast(new OnNext(t));
   }
@@ -57,8 +52,8 @@ public final class RecordingObserver<T>
       throw new RuntimeException(e);
     }
     if (event == null) {
-      throw new NoSuchElementException("No event found while waiting for "
-          + wanted.getSimpleName());
+      throw new NoSuchElementException(
+          "No event found while waiting for " + wanted.getSimpleName());
     }
     assertThat(event).isInstanceOf(wanted);
     return wanted.cast(event);
@@ -111,15 +106,13 @@ public final class RecordingObserver<T>
       this.value = value;
     }
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
       return "OnNext[" + value + "]";
     }
   }
 
   private final class OnCompleted {
-    @Override
-    public String toString() {
+    @Override public String toString() {
       return "OnCompleted";
     }
   }
@@ -131,8 +124,7 @@ public final class RecordingObserver<T>
       this.throwable = throwable;
     }
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
       return "OnError[" + throwable + "]";
     }
   }
@@ -144,8 +136,7 @@ public final class RecordingObserver<T>
       this.disposable = disposable;
     }
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
       return "OnSubscribe";
     }
   }
@@ -157,8 +148,7 @@ public final class RecordingObserver<T>
       this.value = value;
     }
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
       return "OnSuccess[" + value + "]";
     }
   }

--- a/autodispose/src/test/java/com/uber/autodispose/TestUtil.java
+++ b/autodispose/src/test/java/com/uber/autodispose/TestUtil.java
@@ -8,43 +8,44 @@ import io.reactivex.subjects.BehaviorSubject;
 import javax.annotation.Nonnull;
 
 final class TestUtil {
-  private static final Function<Integer, Integer> CORRESPONDING_EVENTS = lastEvent -> {
-    switch (lastEvent) {
-      case 0:
-        return 3;
-      case 1:
-        return 2;
-      default:
-        throw new LifecycleEndedException();
-    }
-  };
+  private static final Function<Integer, Integer> CORRESPONDING_EVENTS =
+      new Function<Integer, Integer>() {
+        @Override public Integer apply(Integer lastEvent) throws Exception {
+          switch (lastEvent) {
+            case 0:
+              return 3;
+            case 1:
+              return 2;
+            default:
+              throw new LifecycleEndedException();
+          }
+        }
+      };
 
   private TestUtil() {
     throw new InstantiationError();
   }
 
-  static ScopeProvider makeProvider(
-      final MaybeSubject<Integer> scope) {
-    return () -> scope;
+  static ScopeProvider makeProvider(final MaybeSubject<Integer> scope) {
+    return new ScopeProvider() {
+      @Override public Maybe<?> requestScope() {
+        return scope;
+      }
+    };
   }
 
   static LifecycleScopeProvider<Integer> makeLifecycleProvider(
       final BehaviorSubject<Integer> lifecycle) {
     return new LifecycleScopeProvider<Integer>() {
-      @Nonnull
-      @Override
-      public Observable<Integer> lifecycle() {
+      @Nonnull @Override public Observable<Integer> lifecycle() {
         return lifecycle;
       }
 
-      @Nonnull
-      @Override
-      public Function<Integer, Integer> correspondingEvents() {
+      @Nonnull @Override public Function<Integer, Integer> correspondingEvents() {
         return CORRESPONDING_EVENTS;
       }
 
-      @Override
-      public Integer peekLifecycle() {
+      @Override public Integer peekLifecycle() {
         return lifecycle.getValue();
       }
     };

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,7 +14,6 @@ def build = [
     gradlePlugins: [
         android: 'com.android.tools.build:gradle:2.3.0-alpha3',
         kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
-        retrolambda: 'me.tatarka:gradle-retrolambda:3.4.0',
         versions: 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
     ]
 ]


### PR DESCRIPTION
This is nothing functional, just all java 7 backporting, removal of retrolambda, and a runover of the autoformatter afterward to be safe.

Resolves #10 