### PR TITLE
Introduce LifecycleObservable

### DIFF
--- a/autodispose-android/src/main/java/com/uber/autodispose/android/ViewScopeProvider.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/ViewScopeProvider.java
@@ -17,6 +17,7 @@
 package com.uber.autodispose.android;
 
 import android.view.View;
+import com.uber.autodispose.LifecycleObservable;
 import com.uber.autodispose.LifecycleScopeProvider;
 import com.uber.autodispose.OutsideLifecycleException;
 import io.reactivex.Observable;
@@ -67,8 +68,8 @@ public class ViewScopeProvider implements LifecycleScopeProvider<ViewLifecycleEv
     lifecycle = new ViewAttachEventsObservable(view);
   }
 
-  @Override public Observable<ViewLifecycleEvent> lifecycle() {
-    return lifecycle;
+  @Override public LifecycleObservable<ViewLifecycleEvent> lifecycle() {
+    return lifecycle.to(LifecycleObservable.<ViewLifecycleEvent>converter());
   }
 
   @Override public Function<ViewLifecycleEvent, ViewLifecycleEvent> correspondingEvents() {

--- a/autodispose/build.gradle
+++ b/autodispose/build.gradle
@@ -28,6 +28,7 @@ dependencies {
   compile deps.misc.jsr305Annotations
 
   testCompile deps.test.junit
+  testCompile deps.test.mockito
   testCompile deps.test.truth
 }
 

--- a/autodispose/src/main/java/com/uber/autodispose/BehaviorObservable.java
+++ b/autodispose/src/main/java/com/uber/autodispose/BehaviorObservable.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.functions.Function;
+import io.reactivex.subjects.BehaviorSubject;
+
+/**
+ * An Observable whose behavior is similar to that of a {@link BehaviorSubject} but read-only.
+ */
+public final class BehaviorObservable<T> extends Observable<T> {
+
+  private interface BehaviorFunction<T> extends Function<Observable<T>, BehaviorObservable<T>> {}
+
+  private static final BehaviorFunction<?> BEHAVIOR_OBSERVABLE_FUNCTION =
+      new BehaviorFunction<Object>() {
+        @Override public BehaviorObservable<Object> apply(Observable<Object> upstream)
+            throws Exception {
+          return wrap(upstream);
+        }
+      };
+
+  private final Observable<T> actual;
+
+  /**
+   * Wraps an Observable to a BehaviorObservable
+   *
+   * @param <T> the stream type.
+   * @return a BehaviorObservable representation.
+   */
+  public static <T> BehaviorObservable<T> wrap(Observable<T> other) {
+    return new BehaviorObservable<>(other);
+  }
+
+  /**
+   * Converts an Observable to a BehaviorObservable. Intended to be used with
+   * {@link Observable#to(Function)}.
+   *
+   * <pre><code>
+   *   BehaviorSubject.createDefault(1)
+   *       .to(BehaviorObservable.converter())
+   *       .subscribe();
+   * </code></pre>
+   *
+   * @param <T> the stream type.
+   * @return a converter function.
+   */
+  @SuppressWarnings("unchecked") public static <T> BehaviorFunction<T> converter() {
+    return (BehaviorFunction<T>) BEHAVIOR_OBSERVABLE_FUNCTION;
+  }
+
+  private BehaviorObservable(Observable<T> actual) {
+    this.actual = actual;
+  }
+
+  @Override protected void subscribeActual(Observer<? super T> observer) {
+    actual.subscribe(observer);
+  }
+}

--- a/autodispose/src/main/java/com/uber/autodispose/LifecycleObservable.java
+++ b/autodispose/src/main/java/com/uber/autodispose/LifecycleObservable.java
@@ -18,8 +18,12 @@ package com.uber.autodispose;
 
 import io.reactivex.Observable;
 import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Function;
+import io.reactivex.observers.DisposableObserver;
 import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subjects.Subject;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * An Observable whose behavior is similar to that of a {@link BehaviorSubject} but read-only, for
@@ -37,6 +41,9 @@ public final class LifecycleObservable<T> extends Observable<T> {
         }
       };
 
+  private final AtomicReference<Disposable> subjectDisposable = new AtomicReference<>();
+  private volatile BehaviorSubject<T> subject = BehaviorSubject.create();
+  private volatile Subject<T> serializedSubject = subject.toSerialized();
   private final Observable<T> actual;
 
   /**
@@ -61,6 +68,116 @@ public final class LifecycleObservable<T> extends Observable<T> {
   }
 
   @Override protected void subscribeActual(Observer<? super T> observer) {
-    actual.subscribe(observer);
+    // Subscribe the subject to the observer, track disposal so we can clear the behavior
+    // subscription later.
+    subject.subscribe(new LifecycleObserver(observer) {
+      @Override void onDispose() {
+        Disposable d = subjectDisposable.get();
+        if (d != null && !d.isDisposed()) {
+          d.dispose();
+        }
+      }
+    });
+    subjectDisposable.set(actual.subscribeWith(new DisposableObserver<T>() {
+      @Override public void onNext(T t) {
+        serializedSubject.onNext(t);
+      }
+
+      @Override public void onError(Throwable e) {
+        serializedSubject.onError(e);
+      }
+
+      @Override public void onComplete() {
+        serializedSubject.onComplete();
+      }
+    }));
+  }
+
+  /**
+   * Passthrough to {@link BehaviorSubject#getThrowable()}
+   */
+  public Throwable getThrowable() {
+    return subject.getThrowable();
+  }
+
+  /**
+   * Passthrough to {@link BehaviorSubject#getValue()}
+   */
+  public T getValue() {
+    return subject.getValue();
+  }
+
+  /**
+   * Passthrough to {@link BehaviorSubject#getValues()}
+   */
+  public Object[] getValues() {
+    return subject.getValues();
+  }
+
+  /**
+   * Passthrough to {@link BehaviorSubject#hasComplete()}
+   */
+  public boolean hasComplete() {
+    return subject.hasComplete();
+  }
+
+  /**
+   * Passthrough to {@link BehaviorSubject#hasThrowable()}
+   */
+  public boolean hasThrowable() {
+    return subject.hasThrowable();
+  }
+
+  /**
+   * Passthrough to {@link BehaviorSubject#getValues(Object[])}
+   */
+  public T[] getValues(T[] array) {
+    return subject.getValues(array);
+  }
+
+  /**
+   * Passthrough to {@link BehaviorSubject#hasValue()}
+   */
+  public boolean hasValue() {
+    return subject.hasValue();
+  }
+
+  abstract class LifecycleObserver implements Observer<T>, Disposable {
+
+    private final AtomicReference<Disposable> disposableRef = new AtomicReference<>();
+    final Observer<? super T> actual;
+
+    private LifecycleObserver(Observer<? super T> actual) {
+      this.actual = actual;
+    }
+
+    @Override public void onNext(T t) {
+      actual.onNext(t);
+    }
+
+    @Override public void onError(Throwable e) {
+      actual.onError(e);
+    }
+
+    @Override public void onComplete() {
+      actual.onComplete();
+    }
+
+    @Override public void dispose() {
+      AutoDisposableHelper.dispose(disposableRef);
+      onDispose();
+    }
+
+    @Override public boolean isDisposed() {
+      return AutoDisposableHelper.isDisposed(disposableRef.get());
+    }
+
+    abstract void onDispose();
+
+    @Override public void onSubscribe(Disposable d) {
+      if (AutoDisposableHelper.setOnce(disposableRef, d)) {
+        actual.onSubscribe(this);
+      }
+    }
   }
 }

--- a/autodispose/src/main/java/com/uber/autodispose/LifecycleObservable.java
+++ b/autodispose/src/main/java/com/uber/autodispose/LifecycleObservable.java
@@ -22,31 +22,22 @@ import io.reactivex.functions.Function;
 import io.reactivex.subjects.BehaviorSubject;
 
 /**
- * An Observable whose behavior is similar to that of a {@link BehaviorSubject} but read-only.
+ * An Observable whose behavior is similar to that of a {@link BehaviorSubject} but read-only, for
+ * use with {@link LifecycleScopeProvider}.
  */
-public final class BehaviorObservable<T> extends Observable<T> {
+public final class LifecycleObservable<T> extends Observable<T> {
 
-  private interface BehaviorFunction<T> extends Function<Observable<T>, BehaviorObservable<T>> {}
+  private interface BehaviorFunction<T> extends Function<Observable<T>, LifecycleObservable<T>> {}
 
   private static final BehaviorFunction<?> BEHAVIOR_OBSERVABLE_FUNCTION =
       new BehaviorFunction<Object>() {
-        @Override public BehaviorObservable<Object> apply(Observable<Object> upstream)
+        @Override public LifecycleObservable<Object> apply(Observable<Object> upstream)
             throws Exception {
-          return wrap(upstream);
+          return new LifecycleObservable<>(upstream);
         }
       };
 
   private final Observable<T> actual;
-
-  /**
-   * Wraps an Observable to a BehaviorObservable
-   *
-   * @param <T> the stream type.
-   * @return a BehaviorObservable representation.
-   */
-  public static <T> BehaviorObservable<T> wrap(Observable<T> other) {
-    return new BehaviorObservable<>(other);
-  }
 
   /**
    * Converts an Observable to a BehaviorObservable. Intended to be used with
@@ -54,7 +45,7 @@ public final class BehaviorObservable<T> extends Observable<T> {
    *
    * <pre><code>
    *   BehaviorSubject.createDefault(1)
-   *       .to(BehaviorObservable.converter())
+   *       .to(LifecycleObservable.converter())
    *       .subscribe();
    * </code></pre>
    *
@@ -65,7 +56,7 @@ public final class BehaviorObservable<T> extends Observable<T> {
     return (BehaviorFunction<T>) BEHAVIOR_OBSERVABLE_FUNCTION;
   }
 
-  private BehaviorObservable(Observable<T> actual) {
+  private LifecycleObservable(Observable<T> actual) {
     this.actual = actual;
   }
 

--- a/autodispose/src/main/java/com/uber/autodispose/LifecycleObservable.java
+++ b/autodispose/src/main/java/com/uber/autodispose/LifecycleObservable.java
@@ -70,6 +70,14 @@ public final class LifecycleObservable<T> extends Observable<T> {
   @Override protected void subscribeActual(Observer<? super T> observer) {
     // Subscribe the subject to the observer, track disposal so we can clear the behavior
     // subscription later.
+
+    // If we're given an already-disposed disposable observer, we should just not do anything
+    // But what about the observer contract? Short circuiting also crashes some operators.
+    //if (observer instanceof Disposable) {
+    //  if (((Disposable) observer).isDisposed()) {
+    //    return;
+    //  }
+    //}
     subject.subscribe(new LifecycleObserver(observer) {
       @Override void onDispose() {
         Disposable d = subjectDisposable.get();

--- a/autodispose/src/main/java/com/uber/autodispose/LifecycleScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/LifecycleScopeProvider.java
@@ -32,11 +32,11 @@ public interface LifecycleScopeProvider<E> {
   /**
    * @return a sequence of lifecycle events.
    */
-  @CheckReturnValue BehaviorObservable<E> lifecycle();
+  @CheckReturnValue LifecycleObservable<E> lifecycle();
 
   /**
    * @return a sequence of lifecycle events. It's recommended to back this with a static instance to
-   * avoid unnecessary object allocationn.
+   * avoid unnecessary object allocation.
    */
   @CheckReturnValue Function<E, E> correspondingEvents();
 

--- a/autodispose/src/main/java/com/uber/autodispose/LifecycleScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/LifecycleScopeProvider.java
@@ -16,7 +16,6 @@
 
 package com.uber.autodispose;
 
-import io.reactivex.Observable;
 import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.functions.Function;
 import javax.annotation.Nullable;
@@ -33,7 +32,7 @@ public interface LifecycleScopeProvider<E> {
   /**
    * @return a sequence of lifecycle events.
    */
-  @CheckReturnValue Observable<E> lifecycle();
+  @CheckReturnValue BehaviorObservable<E> lifecycle();
 
   /**
    * @return a sequence of lifecycle events. It's recommended to back this with a static instance to

--- a/autodispose/src/test/java/com/uber/autodispose/LifecycleObservableTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/LifecycleObservableTest.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Function;
+import io.reactivex.observers.DefaultObserver;
+import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subjects.PublishSubject;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Slimmed down version of RxJava's BehaviorSubject tests, tuned for testing {@link
+ * LifecycleObservable}.
+ */
+public class LifecycleObservableTest {
+
+  private final Throwable testException = new Throwable();
+
+  @Test public void testThatSubscriberReceivesDefaultValueAndSubsequentEvents() {
+    BehaviorSubject<String> subject = BehaviorSubject.createDefault("default");
+    LifecycleObservable<String> lo = subject.to(LifecycleObservable.<String>converter());
+
+    Observer<String> observer = mockObserver();
+    lo.subscribe(observer);
+
+    subject.onNext("one");
+    subject.onNext("two");
+    subject.onNext("three");
+
+    verify(observer, times(1)).onNext("default");
+    verify(observer, times(1)).onNext("one");
+    verify(observer, times(1)).onNext("two");
+    verify(observer, times(1)).onNext("three");
+    verify(observer, never()).onError(testException);
+    verify(observer, never()).onComplete();
+  }
+
+  @Test public void testThatSubscriberReceivesDefaultValueAndSubsequentEvents_publishing() {
+    PublishSubject<String> subject = PublishSubject.create();
+    LifecycleObservable<String> lo = subject.to(LifecycleObservable.<String>converter());
+
+    Observer<String> observer = mockObserver();
+    lo.subscribe(observer);
+
+    subject.onNext("default");
+    subject.onNext("one");
+    subject.onNext("two");
+    subject.onNext("three");
+
+    verify(observer, times(1)).onNext("default");
+    verify(observer, times(1)).onNext("one");
+    verify(observer, times(1)).onNext("two");
+    verify(observer, times(1)).onNext("three");
+    verify(observer, never()).onError(testException);
+    verify(observer, never()).onComplete();
+  }
+
+  @Test public void testThatSubscriberReceivesLatestAndThenSubsequentEvents() {
+    BehaviorSubject<String> subject = BehaviorSubject.createDefault("default");
+    LifecycleObservable<String> lo = subject.to(LifecycleObservable.<String>converter());
+
+    subject.onNext("one");
+
+    Observer<String> observer = mockObserver();
+    lo.subscribe(observer);
+
+    subject.onNext("two");
+    subject.onNext("three");
+
+    verify(observer, never()).onNext("default");
+    verify(observer, times(1)).onNext("one");
+    verify(observer, times(1)).onNext("two");
+    verify(observer, times(1)).onNext("three");
+    verify(observer, never()).onError(testException);
+    verify(observer, never()).onComplete();
+  }
+
+  @Test public void testThatSubscriberReceivesLatestAndThenSubsequentEvents_publishing() {
+    PublishSubject<String> subject = PublishSubject.create();
+    LifecycleObservable<String> lo = subject.to(LifecycleObservable.<String>converter());
+
+    subject.onNext("default");
+
+    Observer<String> observer = mockObserver();
+    lo.subscribe(observer);
+
+    subject.onNext("one");
+    subject.onNext("two");
+    subject.onNext("three");
+
+    verify(observer, never()).onNext("default");
+    verify(observer, times(1)).onNext("one");
+    verify(observer, times(1)).onNext("two");
+    verify(observer, times(1)).onNext("three");
+    verify(observer, never()).onError(testException);
+    verify(observer, never()).onComplete();
+  }
+
+  @Test public void testSubscribeThenOnComplete() {
+    BehaviorSubject<String> subject = BehaviorSubject.createDefault("default");
+    LifecycleObservable<String> lo = subject.to(LifecycleObservable.<String>converter());
+
+    Observer<String> observer = mockObserver();
+    lo.subscribe(observer);
+
+    subject.onNext("one");
+    subject.onComplete();
+
+    verify(observer, times(1)).onNext("default");
+    verify(observer, times(1)).onNext("one");
+    verify(observer, never()).onError(any(Throwable.class));
+    verify(observer, times(1)).onComplete();
+  }
+
+  @Test public void testSubscribeToCompletedOnlyEmitsOnComplete() {
+    BehaviorSubject<String> subject = BehaviorSubject.createDefault("default");
+    LifecycleObservable<String> lo = subject.to(LifecycleObservable.<String>converter());
+    subject.onNext("one");
+    subject.onComplete();
+
+    Observer<String> observer = mockObserver();
+    lo.subscribe(observer);
+
+    verify(observer, never()).onNext("default");
+    verify(observer, never()).onNext("one");
+    verify(observer, never()).onError(any(Throwable.class));
+    verify(observer, times(1)).onComplete();
+  }
+
+  @Test public void testSubscribeToErrorOnlyEmitsOnError() {
+    BehaviorSubject<String> subject = BehaviorSubject.createDefault("default");
+    LifecycleObservable<String> lo = subject.to(LifecycleObservable.<String>converter());
+    subject.onNext("one");
+    RuntimeException re = new RuntimeException("test error");
+    subject.onError(re);
+
+    Observer<String> observer = mockObserver();
+    lo.subscribe(observer);
+
+    verify(observer, never()).onNext("default");
+    verify(observer, never()).onNext("one");
+    verify(observer, times(1)).onError(re);
+    verify(observer, never()).onComplete();
+  }
+
+  @Test(timeout = 1000) public void testUnsubscriptionCase() {
+    BehaviorSubject<String> src = BehaviorSubject.createDefault("null");
+    LifecycleObservable<String> lo = src.to(LifecycleObservable.<String>converter());
+
+    for (int i = 0; i < 10; i++) {
+      final Observer<Object> o = mockObserver();
+      InOrder inOrder = inOrder(o);
+      String v = "" + i;
+      src.onNext(v);
+      System.out.printf("Turn: %d%n", i);
+      lo.firstElement()
+          .toObservable()
+          .flatMap(new Function<String, Observable<String>>() {
+            @Override public Observable<String> apply(String t1) {
+              return Observable.just(t1 + ", " + t1);
+            }
+          })
+          .subscribe(new DefaultObserver<String>() {
+            @Override public void onNext(String t) {
+              o.onNext(t);
+            }
+
+            @Override public void onError(Throwable e) {
+              o.onError(e);
+            }
+
+            @Override public void onComplete() {
+              o.onComplete();
+            }
+          });
+      inOrder.verify(o)
+          .onNext(v + ", " + v);
+      inOrder.verify(o)
+          .onComplete();
+      verify(o, never()).onError(any(Throwable.class));
+    }
+  }
+
+  @Test public void testCurrentStateMethodsNormalEmptyStart() {
+    BehaviorSubject<Object> as = BehaviorSubject.create();
+    LifecycleObservable<Object> lo = as.to(LifecycleObservable.converter());
+
+    lo.subscribe();
+
+    assertFalse(lo.hasValue());
+    assertFalse(lo.hasThrowable());
+    assertFalse(lo.hasComplete());
+    assertNull(lo.getValue());
+    assertNull(lo.getThrowable());
+
+    as.onNext(1);
+
+    assertTrue(lo.hasValue());
+    assertFalse(lo.hasThrowable());
+    assertFalse(lo.hasComplete());
+    assertEquals(1, lo.getValue());
+    assertNull(lo.getThrowable());
+
+    as.onComplete();
+
+    assertFalse(lo.hasValue());
+    assertFalse(lo.hasThrowable());
+    assertTrue(lo.hasComplete());
+    assertNull(lo.getValue());
+    assertNull(lo.getThrowable());
+  }
+
+  @Test public void testCurrentStateMethodsNormalSomeStart() {
+    BehaviorSubject<Object> as = BehaviorSubject.createDefault((Object) 1);
+    LifecycleObservable<Object> lo = as.to(LifecycleObservable.converter());
+    lo.subscribe();
+
+    assertTrue(lo.hasValue());
+    assertFalse(lo.hasThrowable());
+    assertFalse(lo.hasComplete());
+    assertEquals(1, lo.getValue());
+    assertNull(lo.getThrowable());
+
+    as.onNext(2);
+
+    assertTrue(lo.hasValue());
+    assertFalse(lo.hasThrowable());
+    assertFalse(lo.hasComplete());
+    assertEquals(2, lo.getValue());
+    assertNull(lo.getThrowable());
+
+    as.onComplete();
+    assertFalse(lo.hasValue());
+    assertFalse(lo.hasThrowable());
+    assertTrue(lo.hasComplete());
+    assertNull(lo.getValue());
+    assertNull(lo.getThrowable());
+  }
+
+  @Test public void testCurrentStateMethodsEmpty() {
+    BehaviorSubject<Object> as = BehaviorSubject.create();
+    LifecycleObservable<Object> lo = as.to(LifecycleObservable.converter());
+    lo.subscribe();
+
+    assertFalse(lo.hasValue());
+    assertFalse(lo.hasThrowable());
+    assertFalse(lo.hasComplete());
+    assertNull(lo.getValue());
+    assertNull(lo.getThrowable());
+
+    as.onComplete();
+
+    assertFalse(lo.hasValue());
+    assertFalse(lo.hasThrowable());
+    assertTrue(lo.hasComplete());
+    assertNull(lo.getValue());
+    assertNull(lo.getThrowable());
+  }
+
+  @Test public void testCurrentStateMethodsError() {
+    BehaviorSubject<Object> as = BehaviorSubject.create();
+    LifecycleObservable<Object> lo = as.to(LifecycleObservable.converter());
+    lo.subscribe(LifecycleObservableTest.mockObserver());
+
+    assertFalse(lo.hasValue());
+    assertFalse(lo.hasThrowable());
+    assertFalse(lo.hasComplete());
+    assertNull(lo.getValue());
+    assertNull(lo.getThrowable());
+
+    as.onError(new TestException());
+
+    assertFalse(lo.hasValue());
+    assertTrue(lo.hasThrowable());
+    assertFalse(lo.hasComplete());
+    assertNull(lo.getValue());
+    assertTrue(lo.getThrowable() instanceof TestException);
+  }
+
+  @Test public void cancelOnArrival() {
+    BehaviorSubject<Object> p = BehaviorSubject.create();
+    LifecycleObservable<Object> lo = p.to(LifecycleObservable.converter());
+
+    assertFalse(p.hasObservers());
+
+    lo.test(true)
+        .assertEmpty();
+
+    assertFalse(p.hasObservers());
+  }
+
+  @Test public void innerDisposed() {
+    BehaviorSubject.create()
+        .to(LifecycleObservable.converter())
+        .subscribe(new Observer<Object>() {
+          @Override public void onSubscribe(Disposable d) {
+            assertFalse(d.isDisposed());
+
+            d.dispose();
+
+            assertTrue(d.isDisposed());
+          }
+
+          @Override public void onNext(Object value) {
+
+          }
+
+          @Override public void onError(Throwable e) {
+
+          }
+
+          @Override public void onComplete() {
+
+          }
+        });
+  }
+
+  /**
+   * Mocks an Observer with the proper receiver type.
+   *
+   * @param <T> the value type
+   * @return the mocked observer
+   */
+  @SuppressWarnings("unchecked") private static <T> Observer<T> mockObserver() {
+    return mock(Observer.class);
+  }
+}

--- a/autodispose/src/test/java/com/uber/autodispose/TestUtil.java
+++ b/autodispose/src/test/java/com/uber/autodispose/TestUtil.java
@@ -17,7 +17,6 @@
 package com.uber.autodispose;
 
 import io.reactivex.Maybe;
-import io.reactivex.Observable;
 import io.reactivex.functions.Function;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
@@ -53,8 +52,8 @@ final class TestUtil {
   static LifecycleScopeProvider<Integer> makeLifecycleProvider(
       final BehaviorSubject<Integer> lifecycle) {
     return new LifecycleScopeProvider<Integer>() {
-      @Nonnull @Override public BehaviorObservable<Integer> lifecycle() {
-        return lifecycle.to(BehaviorObservable.<Integer>converter());
+      @Nonnull @Override public LifecycleObservable<Integer> lifecycle() {
+        return lifecycle.to(LifecycleObservable.<Integer>converter());
       }
 
       @Nonnull @Override public Function<Integer, Integer> correspondingEvents() {

--- a/autodispose/src/test/java/com/uber/autodispose/TestUtil.java
+++ b/autodispose/src/test/java/com/uber/autodispose/TestUtil.java
@@ -53,8 +53,8 @@ final class TestUtil {
   static LifecycleScopeProvider<Integer> makeLifecycleProvider(
       final BehaviorSubject<Integer> lifecycle) {
     return new LifecycleScopeProvider<Integer>() {
-      @Nonnull @Override public Observable<Integer> lifecycle() {
-        return lifecycle;
+      @Nonnull @Override public BehaviorObservable<Integer> lifecycle() {
+        return lifecycle.to(BehaviorObservable.<Integer>converter());
       }
 
       @Nonnull @Override public Function<Integer, Integer> correspondingEvents() {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,55 +14,38 @@
  * limitations under the License.
  */
 
-def versions = [
-    androidTest: '0.5',
-    kotlin: '1.0.6',
-    support: '25.2.0'
-]
+def versions = [androidTest: '0.5',
+                kotlin     : '1.0.6',
+                support    : '25.2.0']
 
-def build = [
-    buildToolsVersion: '25.0.2',
-    compileSdkVersion: 25,
-    ci: 'true' == System.getenv('CI'),
-    minSdkVersion: 14,
-    targetSdkVersion: 25,
+def build = [buildToolsVersion: '25.0.2',
+             compileSdkVersion: 25,
+             ci               : 'true' == System.getenv('CI'),
+             minSdkVersion    : 14,
+             targetSdkVersion : 25,
 
-    gradlePlugins: [
-        android: 'com.android.tools.build:gradle:2.3.0-rc1',
-        kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
-    ]
-]
+             gradlePlugins    : [android: 'com.android.tools.build:gradle:2.3.0-rc1',
+                                 kotlin : "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"]]
 
-def kotlin = [
-    stdlib: "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
-]
+def kotlin = [stdlib: "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"]
 
-def misc = [
-    jsr305Annotations: 'com.google.code.findbugs:jsr305:3.0.1'
-]
+def misc = [jsr305Annotations: 'com.google.code.findbugs:jsr305:3.0.1']
 
-def rx = [
-    android: 'io.reactivex.rxjava2:rxandroid:2.0.1',
-    java: 'io.reactivex.rxjava2:rxjava:2.0.6'
-]
+def rx = [android: 'io.reactivex.rxjava2:rxandroid:2.0.1',
+          java   : 'io.reactivex.rxjava2:rxjava:2.0.6']
 
-def support = [
-    annotations: "com.android.support:support-annotations:${versions.support}"
-]
+def support = [annotations: "com.android.support:support-annotations:${versions.support}"]
 
-def test = [
-    androidRunner: "com.android.support.test:runner:${versions.androidTest}",
-    androidRules: "com.android.support.test:rules:${versions.androidTest}",
-    junit: 'junit:junit:4.12',
-    truth: 'com.google.truth:truth:0.32'
-]
+def test = [androidRunner: "com.android.support.test:runner:${versions.androidTest}",
+            androidRules : "com.android.support.test:rules:${versions.androidTest}",
+            mockito      : 'org.mockito:mockito-core:2.7.11',
+            junit        : 'junit:junit:4.12',
+            truth        : 'com.google.truth:truth:0.32']
 
-ext.deps = [
-    "build": build,
-    "kotlin": kotlin,
-    "misc": misc,
-    "rx": rx,
-    "support": support,
-    "test": test,
-    "versions": versions
-]
+ext.deps = ["build"   : build,
+            "kotlin"  : kotlin,
+            "misc"    : misc,
+            "rx"      : rx,
+            "support" : support,
+            "test"    : test,
+            "versions": versions]


### PR DESCRIPTION
This is more of a proposal/exploration. We want to make the Observable behavior explicit for LifecycleScopeProvider, so this introduces `LifecycleObservable`. It's a thin shim just there to have its behavior documented in the type system and forces the implementer to think about its behavior.

Some things we might want to add:
- BehaviorSubject's `getValue()` API
- Verification that it is indeed behaving the way we expect

In use, it's easy to convert to it:

```java
myObservable
    .to(LifecycleObservable.converter())
```