### PR TITLE
RxJava 2.0.5, Android Gradle plugin 2.3.0-beta3

### DIFF
--- a/autodispose/build.gradle
+++ b/autodispose/build.gradle
@@ -27,7 +27,6 @@ dependencies {
   compile deps.rx.java
   compile deps.misc.jsr305Annotations
 
-  testCompile deps.rx.rxJava2Extensions
   testCompile deps.test.junit
   testCompile deps.test.truth
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -16,13 +16,13 @@
 
 package com.uber.autodispose;
 
-import hu.akarnokd.rxjava2.subjects.CompletableSubject;
-import hu.akarnokd.rxjava2.subjects.MaybeSubject;
 import io.reactivex.Completable;
 import io.reactivex.CompletableEmitter;
 import io.reactivex.CompletableOnSubscribe;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subjects.CompletableSubject;
+import io.reactivex.subjects.MaybeSubject;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -16,12 +16,12 @@
 
 package com.uber.autodispose;
 
-import hu.akarnokd.rxjava2.subjects.MaybeSubject;
 import io.reactivex.Maybe;
 import io.reactivex.MaybeEmitter;
 import io.reactivex.MaybeOnSubscribe;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subjects.MaybeSubject;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -16,12 +16,12 @@
 
 package com.uber.autodispose;
 
-import hu.akarnokd.rxjava2.subjects.MaybeSubject;
 import io.reactivex.Observable;
 import io.reactivex.ObservableEmitter;
 import io.reactivex.ObservableOnSubscribe;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subjects.PublishSubject;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -16,13 +16,13 @@
 
 package com.uber.autodispose;
 
-import hu.akarnokd.rxjava2.subjects.MaybeSubject;
-import hu.akarnokd.rxjava2.subjects.SingleSubject;
 import io.reactivex.Single;
 import io.reactivex.SingleEmitter;
 import io.reactivex.SingleOnSubscribe;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subjects.MaybeSubject;
+import io.reactivex.subjects.SingleSubject;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -16,7 +16,6 @@
 
 package com.uber.autodispose;
 
-import hu.akarnokd.rxjava2.subjects.MaybeSubject;
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
 import io.reactivex.FlowableEmitter;
@@ -24,6 +23,7 @@ import io.reactivex.FlowableOnSubscribe;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/autodispose/src/test/java/com/uber/autodispose/TestUtil.java
+++ b/autodispose/src/test/java/com/uber/autodispose/TestUtil.java
@@ -16,11 +16,11 @@
 
 package com.uber.autodispose;
 
-import hu.akarnokd.rxjava2.subjects.MaybeSubject;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.functions.Function;
 import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subjects.MaybeSubject;
 import javax.annotation.Nonnull;
 
 final class TestUtil {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -28,7 +28,7 @@ def build = [
     targetSdkVersion: 25,
 
     gradlePlugins: [
-        android: 'com.android.tools.build:gradle:2.3.0-beta2',
+        android: 'com.android.tools.build:gradle:2.3.0-beta3',
         kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
     ]
 ]
@@ -43,8 +43,7 @@ def misc = [
 
 def rx = [
     android: 'io.reactivex.rxjava2:rxandroid:2.0.1',
-    java: 'io.reactivex.rxjava2:rxjava:2.0.4',
-    rxJava2Extensions: 'com.github.akarnokd:rxjava2-extensions:0.14.3'
+    java: 'io.reactivex.rxjava2:rxjava:2.0.5'
 ]
 
 def support = [


### PR DESCRIPTION
This lets us drop the extensions dependency since the new subjects are in RxJava itself now