### PR TITLE
Fix ErrorsRule to fix master tests

### DIFF
--- a/autodispose/src/test/java/com/uber/autodispose/LambdaCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/LambdaCompletableObserverTest.java
@@ -130,8 +130,10 @@ import static org.junit.Assert.assertTrue;
     CompositeException ex = errors.takeCompositeException();
     List<Throwable> ce = ex.getExceptions();
     assertThat(ce).hasSize(2);
-    assertThat(ce.get(0)).hasMessage("Outer");
-    assertThat(ce.get(1)).hasMessage("Inner");
+    assertThat(ce.get(0)).hasMessageThat()
+        .isEqualTo("Outer");
+    assertThat(ce.get(1)).hasMessageThat()
+        .isEqualTo("Inner");
   }
 
   @Test public void onCompleteThrows() {
@@ -160,7 +162,7 @@ import static org.junit.Assert.assertTrue;
 
     assertTrue(o.isDisposed());
 
-    assertThat(errors.take()).isInstanceOf(TestException.class);
+    assertThat(errors.takeThrowableFromUndeliverableException()).isInstanceOf(TestException.class);
   }
 
   @Test @Ignore public void badSourceOnSubscribe() {

--- a/autodispose/src/test/java/com/uber/autodispose/LambdaMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/LambdaMaybeObserverTest.java
@@ -144,8 +144,10 @@ import static org.junit.Assert.assertTrue;
     CompositeException ex = errors.takeCompositeException();
     List<Throwable> ce = ex.getExceptions();
     assertThat(ce).hasSize(2);
-    assertThat(ce.get(0)).hasMessage("Outer");
-    assertThat(ce.get(1)).hasMessage("Inner");
+    assertThat(ce.get(0)).hasMessageThat()
+        .isEqualTo("Outer");
+    assertThat(ce.get(1)).hasMessageThat()
+        .isEqualTo("Inner");
   }
 
   @Test public void onCompleteThrows() {
@@ -177,7 +179,7 @@ import static org.junit.Assert.assertTrue;
 
     assertTrue(o.isDisposed());
 
-    assertThat(errors.take()).isInstanceOf(TestException.class);
+    assertThat(errors.takeThrowableFromUndeliverableException()).isInstanceOf(TestException.class);
   }
 
   @Test @Ignore public void badSourceOnSubscribe() {

--- a/autodispose/src/test/java/com/uber/autodispose/LambdaObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/LambdaObserverTest.java
@@ -144,8 +144,10 @@ import static org.junit.Assert.assertTrue;
     CompositeException ex = errors.takeCompositeException();
     List<Throwable> ce = ex.getExceptions();
     assertThat(ce).hasSize(2);
-    assertThat(ce.get(0)).hasMessage("Outer");
-    assertThat(ce.get(1)).hasMessage("Inner");
+    assertThat(ce.get(0)).hasMessageThat()
+        .isEqualTo("Outer");
+    assertThat(ce.get(1)).hasMessageThat()
+        .isEqualTo("Inner");
   }
 
   @Test public void onCompleteThrows() {
@@ -177,7 +179,7 @@ import static org.junit.Assert.assertTrue;
 
     assertTrue(o.isDisposed());
 
-    assertThat(errors.take()).isInstanceOf(TestException.class);
+    assertThat(errors.takeThrowableFromUndeliverableException()).isInstanceOf(TestException.class);
   }
 
   @Test @Ignore public void badSourceOnSubscribe() {

--- a/autodispose/src/test/java/com/uber/autodispose/LambdaSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/LambdaSingleObserverTest.java
@@ -125,8 +125,10 @@ import static org.junit.Assert.assertTrue;
     CompositeException ex = errors.takeCompositeException();
     List<Throwable> ce = ex.getExceptions();
     assertThat(ce).hasSize(2);
-    assertThat(ce.get(0)).hasMessage("Outer");
-    assertThat(ce.get(1)).hasMessage("Inner");
+    assertThat(ce.get(0)).hasMessageThat()
+        .isEqualTo("Outer");
+    assertThat(ce.get(1)).hasMessageThat()
+        .isEqualTo("Inner");
   }
 
   @Test @Ignore public void badSourceOnSubscribe() {

--- a/autodispose/src/test/java/com/uber/autodispose/LambdaSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/LambdaSubscriberTest.java
@@ -144,8 +144,10 @@ public class LambdaSubscriberTest {
       CompositeException ex = errors.takeCompositeException();
       List<Throwable> ce = ex.getExceptions();
       assertThat(ce).hasSize(2);
-      assertThat(ce.get(0)).hasMessage("Outer");
-      assertThat(ce.get(1)).hasMessage("Inner");
+      assertThat(ce.get(0)).hasMessageThat()
+          .isEqualTo("Outer");
+      assertThat(ce.get(1)).hasMessageThat()
+          .isEqualTo("Inner");
     } finally {
       RxJavaPlugins.reset();
     }
@@ -182,7 +184,8 @@ public class LambdaSubscriberTest {
 
       assertTrue(o.isDisposed());
 
-      assertThat(errors.take()).isInstanceOf(TestException.class);
+      assertThat(errors.takeThrowableFromUndeliverableException()).isInstanceOf(TestException
+          .class);
     } finally {
       RxJavaPlugins.reset();
     }

--- a/autodispose/src/test/java/com/uber/autodispose/RxErrorsRule.java
+++ b/autodispose/src/test/java/com/uber/autodispose/RxErrorsRule.java
@@ -1,6 +1,7 @@
 package com.uber.autodispose;
 
 import io.reactivex.exceptions.CompositeException;
+import io.reactivex.exceptions.UndeliverableException;
 import io.reactivex.functions.Consumer;
 import io.reactivex.plugins.RxJavaPlugins;
 import java.util.ArrayList;
@@ -49,6 +50,12 @@ import static com.google.common.truth.Truth.assertThat;
       throw new NoSuchElementException("No errors recorded.");
     }
     return error;
+  }
+
+  public Throwable takeThrowableFromUndeliverableException() {
+    Throwable error = take();
+    assertThat(error).isInstanceOf(UndeliverableException.class);
+    return error.getCause();
   }
 
   public CompositeException takeCompositeException() {


### PR DESCRIPTION
RxJava 2.0.6 introduced `UndeliverableException`, which wraps everything that goes to `RxJavaPlugins#onError()` that isn't an RxJava exception (to better distinguish between different types of exceptions).

Also opportunistically fixed a deprecation from the bump to Truth 0.32 (the `hasMessageThat()` business)

This was missed because the lambda observer tests (#3) went into master and then the deps bump (#38) went in after, but we don't have CI turned on to check that the tests would have failed in between those two changes.