### PR TITLE
Remove findbugs JSR305 annotations dependency

### DIFF
--- a/autodispose/build.gradle
+++ b/autodispose/build.gradle
@@ -25,7 +25,6 @@ test {
 
 dependencies {
   compile deps.rx.java
-  compileOnly deps.misc.jsr305Annotations
 
   testCompile deps.test.junit
   testCompile deps.test.truth

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposeUtil.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposeUtil.java
@@ -16,10 +16,10 @@
 
 package com.uber.autodispose;
 
+import io.reactivex.annotations.Nullable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Action;
 import io.reactivex.functions.Consumer;
-import javax.annotation.Nullable;
 import org.reactivestreams.Subscription;
 
 final class AutoDisposeUtil {

--- a/autodispose/src/main/java/com/uber/autodispose/LifecycleScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/LifecycleScopeProvider.java
@@ -18,8 +18,8 @@ package com.uber.autodispose;
 
 import io.reactivex.Observable;
 import io.reactivex.annotations.CheckReturnValue;
+import io.reactivex.annotations.Nullable;
 import io.reactivex.functions.Function;
-import javax.annotation.Nullable;
 
 /**
  * An interface that, when implemented, provides information to AutoDispose to allow it to resolve

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -37,10 +37,6 @@ def kotlin = [
     stdlib: "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
 ]
 
-def misc = [
-    jsr305Annotations: 'com.google.code.findbugs:jsr305:3.0.1'
-]
-
 def rx = [
     android: 'io.reactivex.rxjava2:rxandroid:2.0.1',
     java: 'io.reactivex.rxjava2:rxjava:2.0.6'
@@ -60,7 +56,6 @@ def test = [
 ext.deps = [
     "build": build,
     "kotlin": kotlin,
-    "misc": misc,
     "rx": rx,
     "support": support,
     "test": test,


### PR DESCRIPTION
No longer need it since these are in rxjava now, plus that dependency is a bit of a headache