### PR TITLE
Converter strawman

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposeObservable.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposeObservable.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose;
+
+import io.reactivex.Maybe;
+import io.reactivex.Observable;
+import io.reactivex.ObservableSource;
+import io.reactivex.Observer;
+
+final class AutoDisposeObservable<T> extends Observable<T> {
+
+  private final ObservableSource<T> source;
+  private final Maybe<?> lifecycle;
+
+  AutoDisposeObservable(ObservableSource<T> source, Maybe<?> lifecycle) {
+    this.source = source;
+    this.lifecycle = lifecycle;
+  }
+
+  @Override protected void subscribeActual(Observer<? super T> observer) {
+    source.subscribe(AutoDispose.observable().scopeWith(lifecycle).around(observer));
+  }
+}

--- a/autodispose/src/main/java/com/uber/autodispose/clause/subscribe/ObservableSubscribeDelegate.java
+++ b/autodispose/src/main/java/com/uber/autodispose/clause/subscribe/ObservableSubscribeDelegate.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose.clause.subscribe;
+
+import io.reactivex.Observable;
+import io.reactivex.Observer;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Action;
+import io.reactivex.functions.Consumer;
+
+/**
+ * Subscribe clause for the around steps that match Observable's subscribe overloads.
+ */
+public interface ObservableSubscribeDelegate<T> {
+
+  /**
+   * Proxy for {@link Observable#subscribe()}
+   *
+   * @return a {@link Disposable}
+   */
+  Disposable subscribe();
+
+  /**
+   * Proxy for {@link Observable#subscribe(Consumer)}
+   *
+   * @return a {@link Disposable}
+   */
+  Disposable subscribe(Consumer<? super T> onNext);
+
+  /**
+   * Proxy for {@link Observable#subscribe(Consumer, Consumer)}
+   *
+   * @return a {@link Disposable}
+   */
+  Disposable subscribe(Consumer<? super T> onNext,
+      Consumer<? super Throwable> onError);
+
+  /**
+   * Proxy for {@link Observable#subscribe(Consumer, Consumer, Action)}
+   *
+   * @return a {@link Disposable}
+   */
+  Disposable subscribe(Consumer<? super T> onNext,
+      Consumer<? super Throwable> onError, Action onComplete);
+
+  /**
+   * Proxy for {@link Observable#subscribe(Consumer, Consumer, Action, Consumer)}
+   *
+   * @return a {@link Disposable}
+   */
+  Disposable subscribe(Consumer<? super T> onNext,
+      Consumer<? super Throwable> onError,
+      Action onComplete,
+      Consumer<? super Disposable> onSubscribe);
+
+  /**
+   * Proxy for {@link Observable#subscribe(Observer)}
+   */
+  void subscribe(Observer<T> observer);
+
+  /**
+   * Proxy for {@link Observable#subscribeWith(Observer)}
+   *
+   * @return an {@link Observer}
+   */
+  <E extends Observer<? super T>> E subscribeWith(E observer);
+}


### PR DESCRIPTION
This is a demo of implementing a converter-based approach, up for discussion. Ignore the ugly bits of the implementation (it would be cleaned up), but the gist of it would be this:

- Most of the meat of AutoDispose is still reused. This just eliminates the fluent API intermediary
- Use the corresponding to() methods in RxJava types to coerce to a different type, in this case a delegate interface that mirrors all that type's subscribe APIs.
- The delegate just proxies these calls to an internal AutoDispose version of that type, which under the hood just does what the current AutoDispose implementation does (the observer component decorating) in its subscribeActual() implementation.
- There is precedent for this with ParallelFlowable, which works similarly
- The delegate ensures we can't have ordering issues like we did with `compose()`, as the only API you can call after that is its `subscribe()` overloads.
- Gets us closer to "Don't break the chain", but with the same sort of caveats around type inferencing as RxLifecycle has if we go with a static entry point approach. For apt comparison, see the demo in AutoDisposingObserverTest, interesting bits copied below.
- Would be a migration for us internally, but potentially something that structural find and replace could do.

```java
// Current
Observable.just(1)
    .subscribe(AutoDispose.observable()
        .scopeWith(lifecycle)
        .around(new Consumer<Integer>() {
          @Override public void accept(@NonNull Integer integer) throws Exception {

          }
        }));

// New "scoper", autocompletes nicely but not as pretty
Observable.just(1)
    .to(new AutoDispose.ObservableScoper<Integer>(lifecycle))
    .subscribe(new Consumer<Integer>() {
      @Override public void accept(@NonNull Integer integer) throws Exception {

      }
    });

// Static API, no autocomplete but pretty. Not fixed by Java 8 either :|
Observable.just(1)
    .to(AutoDispose.<Integer>scopedObservable(lifecycle))
    .subscribe(new Consumer<Integer>() {
      @Override public void accept(@NonNull Integer integer) throws Exception {

      }
    });
```
