### PR TITLE
Make scoper generics more flexible

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/FlowableScoper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/FlowableScoper.java
@@ -45,7 +45,7 @@ import org.reactivestreams.Subscription;
  * @param <T> the stream type.
  */
 public class FlowableScoper<T> extends Scoper
-    implements Function<Flowable<T>, FlowableSubscribeProxy<T>> {
+    implements Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> {
 
   public FlowableScoper(ScopeProvider provider) {
     super(provider);
@@ -59,7 +59,8 @@ public class FlowableScoper<T> extends Scoper
     super(lifecycle);
   }
 
-  @Override public FlowableSubscribeProxy<T> apply(final Flowable<T> source) throws Exception {
+  @Override public FlowableSubscribeProxy<T> apply(final Flowable<? extends T> source)
+      throws Exception {
     return new FlowableSubscribeProxy<T>() {
       @Override public Disposable subscribe() {
         return new AutoDisposeFlowable<>(source, scope()).subscribe();

--- a/autodispose/src/main/java/com/uber/autodispose/MaybeScoper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/MaybeScoper.java
@@ -42,7 +42,8 @@ import io.reactivex.functions.Function;
  *
  * @param <T> the stream type.
  */
-public class MaybeScoper<T> extends Scoper implements Function<Maybe<T>, MaybeSubscribeProxy<T>> {
+public class MaybeScoper<T> extends Scoper
+    implements Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> {
 
   public MaybeScoper(ScopeProvider provider) {
     super(provider);
@@ -56,7 +57,8 @@ public class MaybeScoper<T> extends Scoper implements Function<Maybe<T>, MaybeSu
     super(lifecycle);
   }
 
-  @Override public MaybeSubscribeProxy<T> apply(final Maybe<T> maybeSource) throws Exception {
+  @Override public MaybeSubscribeProxy<T> apply(final Maybe<? extends T> maybeSource)
+      throws Exception {
     return new MaybeSubscribeProxy<T>() {
       @Override public Disposable subscribe() {
         return new AutoDisposeMaybe<>(maybeSource, scope()).subscribe();

--- a/autodispose/src/main/java/com/uber/autodispose/ObservableScoper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/ObservableScoper.java
@@ -44,7 +44,7 @@ import io.reactivex.functions.Function;
  * @param <T> the stream type.
  */
 public class ObservableScoper<T> extends Scoper
-    implements Function<Observable<T>, ObservableSubscribeProxy<T>> {
+    implements Function<Observable<? extends T>, ObservableSubscribeProxy<T>> {
 
   public ObservableScoper(ScopeProvider provider) {
     super(provider);
@@ -58,7 +58,7 @@ public class ObservableScoper<T> extends Scoper
     super(lifecycle);
   }
 
-  @Override public ObservableSubscribeProxy<T> apply(final Observable<T> observableSource)
+  @Override public ObservableSubscribeProxy<T> apply(final Observable<? extends T> observableSource)
       throws Exception {
     return new ObservableSubscribeProxy<T>() {
       @Override public Disposable subscribe() {

--- a/autodispose/src/main/java/com/uber/autodispose/SingleScoper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/SingleScoper.java
@@ -44,7 +44,7 @@ import io.reactivex.functions.Function;
  * @param <T> the stream type.
  */
 public class SingleScoper<T> extends Scoper
-    implements Function<Single<T>, SingleSubscribeProxy<T>> {
+    implements Function<Single<? extends T>, SingleSubscribeProxy<T>> {
 
   public SingleScoper(ScopeProvider provider) {
     super(provider);
@@ -58,7 +58,8 @@ public class SingleScoper<T> extends Scoper
     super(lifecycle);
   }
 
-  @Override public SingleSubscribeProxy<T> apply(final Single<T> singleSource) throws Exception {
+  @Override public SingleSubscribeProxy<T> apply(final Single<? extends T> singleSource)
+      throws Exception {
     return new SingleSubscribeProxy<T>() {
       @Override public Disposable subscribe() {
         return new AutoDisposeSingle<>(singleSource, scope()).subscribe();

--- a/autodispose/src/test/java/com/uber/autodispose/AClass.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AClass.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose;
+
+public class AClass {}

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -19,6 +19,7 @@ package com.uber.autodispose;
 import io.reactivex.Maybe;
 import io.reactivex.MaybeEmitter;
 import io.reactivex.MaybeOnSubscribe;
+import io.reactivex.Observable;
 import io.reactivex.annotations.NonNull;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;
@@ -52,6 +53,22 @@ public class AutoDisposeMaybeObserverTest {
     o.assertNoMoreEvents();
     assertThat(source.hasObservers()).isFalse();
     assertThat(lifecycle.hasObservers()).isFalse();
+  }
+
+  @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
+    Maybe.just(new BClass())
+        .to(new MaybeScoper<AClass>(Maybe.never()))
+        .subscribe(new Consumer<AClass>() {
+          @Override public void accept(@NonNull AClass aClass) throws Exception {
+
+          }
+        });
+  }
+
+  @Test public void autoDispose_noGenericsOnEmpty_isFine() {
+    Maybe.just(new BClass())
+        .to(new MaybeScoper<>(Maybe.never()))
+        .subscribe();
   }
 
   @Test public void autoDispose_withMaybe_interrupted() {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -16,11 +16,15 @@
 
 package com.uber.autodispose;
 
+import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.ObservableEmitter;
 import io.reactivex.ObservableOnSubscribe;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.disposables.Disposables;
 import io.reactivex.functions.Cancellable;
+import io.reactivex.functions.Consumer;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
@@ -53,6 +57,22 @@ public class AutoDisposeObserverTest {
     assertThat(d.isDisposed()).isFalse();   // Because it completed normally, was not disposed.
     assertThat(source.hasObservers()).isFalse();
     assertThat(lifecycle.hasObservers()).isFalse();
+  }
+
+  @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
+    Observable.just(new BClass())
+        .to(new ObservableScoper<AClass>(Maybe.never()))
+        .subscribe(new Consumer<AClass>() {
+          @Override public void accept(@NonNull AClass aClass) throws Exception {
+
+          }
+        });
+  }
+
+  @Test public void autoDispose_noGenericsOnEmpty_isFine() {
+    Observable.just(new BClass())
+        .to(new ObservableScoper<>(Maybe.never()))
+        .subscribe();
   }
 
   @Test public void autoDispose_withMaybe_interrupted() {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -16,10 +16,14 @@
 
 package com.uber.autodispose;
 
+import io.reactivex.Maybe;
+import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.SingleEmitter;
 import io.reactivex.SingleOnSubscribe;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.functions.Cancellable;
+import io.reactivex.functions.Consumer;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subjects.SingleSubject;
@@ -51,6 +55,22 @@ public class AutoDisposeSingleObserverTest {
     o.assertNoMoreEvents();
     assertThat(source.hasObservers()).isFalse();
     assertThat(lifecycle.hasObservers()).isFalse();
+  }
+
+  @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
+    Single.just(new BClass())
+        .to(new SingleScoper<AClass>(Maybe.never()))
+        .subscribe(new Consumer<AClass>() {
+          @Override public void accept(@NonNull AClass aClass) throws Exception {
+
+          }
+        });
+  }
+
+  @Test public void autoDispose_noGenericsOnEmpty_isFine() {
+    Single.just(new BClass())
+        .to(new SingleScoper<>(Maybe.never()))
+        .subscribe();
   }
 
   @Test public void autoDispose_withMaybe_interrupted() {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -20,8 +20,12 @@ import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
 import io.reactivex.FlowableEmitter;
 import io.reactivex.FlowableOnSubscribe;
+import io.reactivex.Maybe;
+import io.reactivex.Single;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Cancellable;
+import io.reactivex.functions.Consumer;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
@@ -55,6 +59,22 @@ public class AutoDisposeSubscriberTest {
     assertThat(d.isDisposed()).isFalse();   // Because it completes normally
     assertThat(source.hasSubscribers()).isFalse();
     assertThat(lifecycle.hasObservers()).isFalse();
+  }
+
+  @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
+    Flowable.just(new BClass())
+        .to(new FlowableScoper<AClass>(Maybe.never()))
+        .subscribe(new Consumer<AClass>() {
+          @Override public void accept(@NonNull AClass aClass) throws Exception {
+
+          }
+        });
+  }
+
+  @Test public void autoDispose_noGenericsOnEmpty_isFine() {
+    Flowable.just(new BClass())
+        .to(new FlowableScoper<>(Maybe.never()))
+        .subscribe();
   }
 
   @Test public void autoDispose_withMaybe_interrupted() {

--- a/autodispose/src/test/java/com/uber/autodispose/BClass.java
+++ b/autodispose/src/test/java/com/uber/autodispose/BClass.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose;
+
+public final class BClass extends AClass {}


### PR DESCRIPTION
This allows two things:

Upcasting generics downstream

```java
Observable.just(someDog)
    .to(new ObservableScoper<Mammal>(this))
    .subscribe((mammal) -> ...);
```

No generics on empty

```java
Observable.just(something)
    .to(new ObservableScoper<>(this))
    .subscribe();
```