### PR TITLE
Add kotlin module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ tmp/
 
 # TeXlipse plugin
 .texlipse
+
+# kotlin
+annotations/

--- a/README.md
+++ b/README.md
@@ -164,9 +164,15 @@ Java:
 compile 'com.uber.autodispose:autodispose:TODO'
 ```
 
-Android components:
+Android extensions:
 ```gradle
 compile 'com.uber.autodispose:autodispose-android:TODO'
+```
+```
+
+Kotlin extensions:
+```gradle
+compile 'com.uber.autodispose:autodispose-kotlin:TODO'
 ```
 
 Snapshots of the development version are available in [Sonatype's snapshots repository][snapshots].

--- a/autodispose-android/gradle.properties
+++ b/autodispose-android/gradle.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-POM_NAME=AutoDispose (Android components)
+POM_NAME=AutoDispose (Android Extensions)
 POM_ARTIFACT_ID=autodispose-android
 POM_PACKAGING=aar

--- a/autodispose-android/gradle.properties
+++ b/autodispose-android/gradle.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-POM_NAME=AutoDispose-android
+POM_NAME=AutoDispose (Android components)
 POM_ARTIFACT_ID=autodispose-android
 POM_PACKAGING=aar

--- a/autodispose-kotlin/build.gradle
+++ b/autodispose-kotlin/build.gradle
@@ -1,0 +1,19 @@
+buildscript {
+  dependencies {
+    classpath deps.build.gradlePlugins.kotlin
+  }
+}
+
+apply plugin: 'java'
+apply plugin: 'kotlin'
+
+dependencies {
+  compile deps.kotlin.stdLib
+  compile project(':autodispose')
+
+  testCompile deps.rx.rxJava2Extensions
+  testCompile deps.test.junit
+  testCompile deps.test.truth
+}
+
+apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/autodispose-kotlin/build.gradle
+++ b/autodispose-kotlin/build.gradle
@@ -4,14 +4,12 @@ buildscript {
   }
 }
 
-apply plugin: 'java'
 apply plugin: 'kotlin'
 
 dependencies {
-  compile deps.kotlin.stdLib
+  compile deps.kotlin.stdlib
   compile project(':autodispose')
 
-  testCompile deps.rx.rxJava2Extensions
   testCompile deps.test.junit
   testCompile deps.test.truth
 }

--- a/autodispose-kotlin/gradle.properties
+++ b/autodispose-kotlin/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=AutoDispose Kotlin
+POM_ARTIFACT_ID=autodispose-kotlin
+POM_PACKAGING=jar

--- a/autodispose-kotlin/gradle.properties
+++ b/autodispose-kotlin/gradle.properties
@@ -1,3 +1,3 @@
-POM_NAME=AutoDispose Kotlin
+POM_NAME=AutoDispose (Kotlin Extensions)
 POM_ARTIFACT_ID=autodispose-kotlin
 POM_PACKAGING=jar

--- a/autodispose-kotlin/src/main/kotlin/com/uber/autodispose/kotlin/autodispose.kt
+++ b/autodispose-kotlin/src/main/kotlin/com/uber/autodispose/kotlin/autodispose.kt
@@ -1,138 +1,149 @@
+/*
+ * Copyright (c) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @file:Suppress("NOTHING_TO_INLINE")
 
 package com.uber.autodispose.kotlin
 
-import com.uber.autodispose.AutoDispose
-import com.uber.autodispose.LifecycleProvider
-import com.uber.autodispose.internal.AutoDisposeUtil
-import com.uber.autodispose.internal.AutoDisposeUtil.emptyConsumer
+import com.uber.autodispose.CompletableScoper
+import com.uber.autodispose.CompletableSubscribeProxy
+import com.uber.autodispose.FlowableScoper
+import com.uber.autodispose.FlowableSubscribeProxy
+import com.uber.autodispose.LifecycleScopeProvider
+import com.uber.autodispose.MaybeScoper
+import com.uber.autodispose.MaybeSubscribeProxy
+import com.uber.autodispose.ObservableScoper
+import com.uber.autodispose.ObservableSubscribeProxy
+import com.uber.autodispose.ScopeProvider
+import com.uber.autodispose.SingleScoper
+import com.uber.autodispose.SingleSubscribeProxy
 import io.reactivex.Completable
-import io.reactivex.CompletableObserver
 import io.reactivex.Flowable
 import io.reactivex.Maybe
-import io.reactivex.MaybeObserver
 import io.reactivex.Observable
-import io.reactivex.Observer
 import io.reactivex.Single
-import io.reactivex.SingleObserver
 import io.reactivex.annotations.CheckReturnValue
-import io.reactivex.disposables.Disposable
-import io.reactivex.functions.Action
-import io.reactivex.functions.BiConsumer
-import io.reactivex.functions.Consumer
-import org.reactivestreams.Subscriber
-import org.reactivestreams.Subscription
 
+/**
+ * Extension that proxies to [Flowable.to] + [FlowableScoper]'s [Maybe] constructor.
+ */
 @CheckReturnValue
-inline fun <T> Observer<T>.disposeOn(provider: LifecycleProvider<Any>): Observer<T>
-    = AutoDispose.observable(provider).around(this)
+inline fun <T> Flowable<T>.autoDisposeWith(scope: Maybe<*>): FlowableSubscribeProxy<T>
+    = this.to(FlowableScoper<T>(scope))
 
+/**
+ * Extension that proxies to [Observable.to] + [ObservableScoper]'s [Maybe] constructor.
+ */
 @CheckReturnValue
-inline fun <T> SingleObserver<T>.disposeOn(provider: LifecycleProvider<Any>): SingleObserver<T>
-    = AutoDispose.single(provider).around(this)
+inline fun <T> Observable<T>.autoDisposeWith(scope: Maybe<*>): ObservableSubscribeProxy<T>
+    = this.to(ObservableScoper<T>(scope))
 
+/**
+ * Extension that proxies to [Single.to] + [SingleScoper]'s [Maybe] constructor.
+ */
 @CheckReturnValue
-inline fun <T> MaybeObserver<T>.disposeOn(provider: LifecycleProvider<Any>): MaybeObserver<T>
-    = AutoDispose.maybe(provider).around(this)
+inline fun <T> Single<T>.autoDisposeWith(scope: Maybe<*>): SingleSubscribeProxy<T>
+    = this.to(SingleScoper<T>(scope))
 
+/**
+ * Extension that proxies to [Maybe.to] + [MaybeScoper]'s [Maybe] constructor.
+ */
 @CheckReturnValue
-inline fun CompletableObserver.disposeOn(provider: LifecycleProvider<Any>): CompletableObserver
-    = AutoDispose.completable(provider).around(this)
+inline fun <T> Maybe<T>.autoDisposeWith(scope: Maybe<*>): MaybeSubscribeProxy<T>
+    = this.to(MaybeScoper<T>(scope))
 
+/**
+ * Extension that proxies to [Completable.to] + [CompletableScoper]'s [Maybe] constructor.
+ */
 @CheckReturnValue
-inline fun <T> Subscriber<T>.cancelOn(provider: LifecycleProvider<Any>): Subscriber<T>
-    = AutoDispose.flowable(provider).around(this)
+inline fun Completable.autoDisposeWith(scope: Maybe<*>): CompletableSubscribeProxy
+    = this.to(CompletableScoper(scope))
 
+/**
+ * Extension that proxies to [Flowable.to] + [FlowableScoper]'s [ScopeProvider] constructor.
+ */
 @CheckReturnValue
-inline fun <T> Observer<T>.disposeOn(lifecycle: Maybe<Any>): Observer<T>
-    = AutoDispose.observable(lifecycle).around(this)
+inline fun <T> Flowable<T>.autoDisposeWith(provider: ScopeProvider): FlowableSubscribeProxy<T>
+    = this.to(FlowableScoper<T>(provider))
 
+/**
+ * Extension that proxies to [Observable.to] + [ObservableScoper]'s [ScopeProvider] constructor.
+ */
 @CheckReturnValue
-inline fun <T> SingleObserver<T>.disposeOn(lifecycle: Maybe<Any>): SingleObserver<T>
-    = AutoDispose.single(lifecycle).around(this)
+inline fun <T> Observable<T>.autoDisposeWith(provider: ScopeProvider): ObservableSubscribeProxy<T>
+    = this.to(ObservableScoper<T>(provider))
 
+/**
+ * Extension that proxies to [Single.to] + [SingleScoper]'s [ScopeProvider] constructor.
+ */
 @CheckReturnValue
-inline fun <T> MaybeObserver<T>.disposeOn(lifecycle: Maybe<Any>): MaybeObserver<T>
-    = AutoDispose.maybe(lifecycle).around(this)
+inline fun <T> Single<T>.autoDisposeWith(provider: ScopeProvider): SingleSubscribeProxy<T>
+    = this.to(SingleScoper<T>(provider))
 
+/**
+ * Extension that proxies to [Maybe.to] + [MaybeScoper]'s [ScopeProvider] constructor.
+ */
 @CheckReturnValue
-inline fun CompletableObserver.disposeOn(lifecycle: Maybe<Any>): CompletableObserver
-    = AutoDispose.completable(lifecycle).around(this)
+inline fun <T> Maybe<T>.autoDisposeWith(provider: ScopeProvider): MaybeSubscribeProxy<T>
+    = this.to(MaybeScoper<T>(provider))
 
+/**
+ * Extension that proxies to [Completable.to] + [CompletableScoper]'s [ScopeProvider] constructor.
+ */
 @CheckReturnValue
-inline fun <T> Subscriber<T>.cancelOn(lifecycle: Maybe<Any>): Subscriber<T>
-    = AutoDispose.flowable(lifecycle).around(this)
+inline fun Completable.autoDisposeWith(provider: ScopeProvider): CompletableSubscribeProxy
+    = this.to(CompletableScoper(provider))
 
-inline fun <T> Flowable<T>.subscribeAutoDispose(provider: LifecycleProvider<Any>,
-    onNext: Consumer<in T> = emptyConsumer(),
-    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
-    onComplete: Action = AutoDisposeUtil.EMPTY_ACTION,
-    onSubscribe: Consumer<in Subscription> = AutoDisposeUtil.EMPTY_SUBSCRIPTION_CONSUMER)
-    = subscribe(AutoDispose.flowable(provider).around(onNext, onError, onComplete, onSubscribe))
+/**
+ * Extension that proxies to [Flowable.to] + [FlowableScoper]'s [LifecycleScopeProvider]
+ * constructor.
+ */
+@CheckReturnValue
+inline fun <T> Flowable<T>.autoDisposeWith(
+    provider: LifecycleScopeProvider<*>): FlowableSubscribeProxy<T>
+    = this.to(FlowableScoper<T>(provider))
 
-inline fun <T> Observable<T>.subscribeAutoDispose(provider: LifecycleProvider<Any>,
-    onNext: Consumer<in T> = emptyConsumer(),
-    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
-    onComplete: Action = AutoDisposeUtil.EMPTY_ACTION,
-    onSubscribe: Consumer<in Disposable> = AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER)
-    = subscribe(AutoDispose.observable(provider).around(onNext, onError, onComplete, onSubscribe))
+/**
+ * Extension that proxies to [Observable.to] + [ObservableScoper]'s [LifecycleScopeProvider]
+ * constructor.
+ */
+@CheckReturnValue
+inline fun <T> Observable<T>.autoDisposeWith(
+    provider: LifecycleScopeProvider<*>): ObservableSubscribeProxy<T>
+    = this.to(ObservableScoper<T>(provider))
 
-inline fun <T> Maybe<T>.subscribeAutoDispose(provider: LifecycleProvider<Any>,
-    onSuccess: Consumer<in T> = emptyConsumer(),
-    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
-    onComplete: Action = AutoDisposeUtil.EMPTY_ACTION,
-    onSubscribe: Consumer<in Disposable> = AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER)
-    = subscribe(AutoDispose.maybe(provider).around(onSuccess, onError, onComplete, onSubscribe))
+/**
+ * Extension that proxies to [Single.to] + [SingleScoper]'s [LifecycleScopeProvider] constructor.
+ */
+@CheckReturnValue
+inline fun <T> Single<T>.autoDisposeWith(provider: LifecycleScopeProvider<*>): SingleSubscribeProxy<T>
+    = this.to(SingleScoper<T>(provider))
 
-inline fun <T> Single<T>.subscribeAutoDispose(provider: LifecycleProvider<Any>,
-    biConsumer: BiConsumer<in T, in Throwable>)
-    = subscribe(AutoDispose.single(provider).around(biConsumer))
+/**
+ * Extension that proxies to [Maybe.to] + [MaybeScoper]'s [LifecycleScopeProvider] constructor.
+ */
+@CheckReturnValue
+inline fun <T> Maybe<T>.autoDisposeWith(provider: LifecycleScopeProvider<*>): MaybeSubscribeProxy<T>
+    = this.to(MaybeScoper<T>(provider))
 
-inline fun <T> Single<T>.subscribeAutoDispose(provider: LifecycleProvider<Any>,
-    onSuccess: Consumer<in T> = emptyConsumer(),
-    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
-    onSubscribe: Consumer<in Disposable> = AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER)
-    = subscribe(AutoDispose.single(provider).around(onSuccess, onError, onSubscribe))
+/**
+ * Extension that proxies to [Completable.to] + [CompletableScoper]'s [LifecycleScopeProvider]
+ * constructor.
+ */
+@CheckReturnValue
+inline fun Completable.autoDisposeWith(provider: LifecycleScopeProvider<*>): CompletableSubscribeProxy
+    = this.to(CompletableScoper(provider))
 
-inline fun Completable.subscribeAutoDispose(provider: LifecycleProvider<Any>,
-    onComplete: Action = AutoDisposeUtil.EMPTY_ACTION,
-    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
-    onSubscribe: Consumer<in Disposable> = AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER)
-    = subscribe(AutoDispose.completable(provider).around(onComplete, onError, onSubscribe))
-
-inline fun <T> Flowable<T>.subscribeAutoDispose(lifecycle: Maybe<Any>,
-    onNext: Consumer<in T> = emptyConsumer(),
-    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
-    onComplete: Action = AutoDisposeUtil.EMPTY_ACTION,
-    onSubscribe: Consumer<in Subscription> = AutoDisposeUtil.EMPTY_SUBSCRIPTION_CONSUMER)
-    = subscribe(AutoDispose.flowable(lifecycle).around(onNext, onError, onComplete, onSubscribe))
-
-inline fun <T> Observable<T>.subscribeAutoDispose(lifecycle: Maybe<Any>,
-    onNext: Consumer<in T> = emptyConsumer(),
-    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
-    onComplete: Action = AutoDisposeUtil.EMPTY_ACTION,
-    onSubscribe: Consumer<in Disposable> = AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER)
-    = subscribe(AutoDispose.observable(lifecycle).around(onNext, onError, onComplete, onSubscribe))
-
-inline fun <T> Maybe<T>.subscribeAutoDispose(lifecycle: Maybe<Any>,
-    onSuccess: Consumer<in T> = emptyConsumer(),
-    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
-    onComplete: Action = AutoDisposeUtil.EMPTY_ACTION,
-    onSubscribe: Consumer<in Disposable> = AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER)
-    = subscribe(AutoDispose.maybe(lifecycle).around(onSuccess, onError, onComplete, onSubscribe))
-
-inline fun <T> Single<T>.subscribeAutoDispose(lifecycle: Maybe<Any>,
-    biConsumer: BiConsumer<in T, in Throwable>)
-    = subscribe(AutoDispose.single(lifecycle).around(biConsumer))
-
-inline fun <T> Single<T>.subscribeAutoDispose(lifecycle: Maybe<Any>,
-    onSuccess: Consumer<in T> = emptyConsumer(),
-    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
-    onSubscribe: Consumer<in Disposable> = AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER)
-    = subscribe(AutoDispose.single(lifecycle).around(onSuccess, onError, onSubscribe))
-
-inline fun Completable.subscribeAutoDispose(lifecycle: Maybe<Any>,
-    onComplete: Action = AutoDisposeUtil.EMPTY_ACTION,
-    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
-    onSubscribe: Consumer<in Disposable> = AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER)
-    = subscribe(AutoDispose.completable(lifecycle).around(onComplete, onError, onSubscribe))

--- a/autodispose-kotlin/src/main/kotlin/com/uber/autodispose/kotlin/autodispose.kt
+++ b/autodispose-kotlin/src/main/kotlin/com/uber/autodispose/kotlin/autodispose.kt
@@ -1,0 +1,138 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package com.uber.autodispose.kotlin
+
+import com.uber.autodispose.AutoDispose
+import com.uber.autodispose.LifecycleProvider
+import com.uber.autodispose.internal.AutoDisposeUtil
+import com.uber.autodispose.internal.AutoDisposeUtil.emptyConsumer
+import io.reactivex.Completable
+import io.reactivex.CompletableObserver
+import io.reactivex.Flowable
+import io.reactivex.Maybe
+import io.reactivex.MaybeObserver
+import io.reactivex.Observable
+import io.reactivex.Observer
+import io.reactivex.Single
+import io.reactivex.SingleObserver
+import io.reactivex.annotations.CheckReturnValue
+import io.reactivex.disposables.Disposable
+import io.reactivex.functions.Action
+import io.reactivex.functions.BiConsumer
+import io.reactivex.functions.Consumer
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+
+@CheckReturnValue
+inline fun <T> Observer<T>.disposeOn(provider: LifecycleProvider<Any>): Observer<T>
+    = AutoDispose.observable(provider).around(this)
+
+@CheckReturnValue
+inline fun <T> SingleObserver<T>.disposeOn(provider: LifecycleProvider<Any>): SingleObserver<T>
+    = AutoDispose.single(provider).around(this)
+
+@CheckReturnValue
+inline fun <T> MaybeObserver<T>.disposeOn(provider: LifecycleProvider<Any>): MaybeObserver<T>
+    = AutoDispose.maybe(provider).around(this)
+
+@CheckReturnValue
+inline fun CompletableObserver.disposeOn(provider: LifecycleProvider<Any>): CompletableObserver
+    = AutoDispose.completable(provider).around(this)
+
+@CheckReturnValue
+inline fun <T> Subscriber<T>.cancelOn(provider: LifecycleProvider<Any>): Subscriber<T>
+    = AutoDispose.flowable(provider).around(this)
+
+@CheckReturnValue
+inline fun <T> Observer<T>.disposeOn(lifecycle: Maybe<Any>): Observer<T>
+    = AutoDispose.observable(lifecycle).around(this)
+
+@CheckReturnValue
+inline fun <T> SingleObserver<T>.disposeOn(lifecycle: Maybe<Any>): SingleObserver<T>
+    = AutoDispose.single(lifecycle).around(this)
+
+@CheckReturnValue
+inline fun <T> MaybeObserver<T>.disposeOn(lifecycle: Maybe<Any>): MaybeObserver<T>
+    = AutoDispose.maybe(lifecycle).around(this)
+
+@CheckReturnValue
+inline fun CompletableObserver.disposeOn(lifecycle: Maybe<Any>): CompletableObserver
+    = AutoDispose.completable(lifecycle).around(this)
+
+@CheckReturnValue
+inline fun <T> Subscriber<T>.cancelOn(lifecycle: Maybe<Any>): Subscriber<T>
+    = AutoDispose.flowable(lifecycle).around(this)
+
+inline fun <T> Flowable<T>.subscribeAutoDispose(provider: LifecycleProvider<Any>,
+    onNext: Consumer<in T> = emptyConsumer(),
+    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
+    onComplete: Action = AutoDisposeUtil.EMPTY_ACTION,
+    onSubscribe: Consumer<in Subscription> = AutoDisposeUtil.EMPTY_SUBSCRIPTION_CONSUMER)
+    = subscribe(AutoDispose.flowable(provider).around(onNext, onError, onComplete, onSubscribe))
+
+inline fun <T> Observable<T>.subscribeAutoDispose(provider: LifecycleProvider<Any>,
+    onNext: Consumer<in T> = emptyConsumer(),
+    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
+    onComplete: Action = AutoDisposeUtil.EMPTY_ACTION,
+    onSubscribe: Consumer<in Disposable> = AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER)
+    = subscribe(AutoDispose.observable(provider).around(onNext, onError, onComplete, onSubscribe))
+
+inline fun <T> Maybe<T>.subscribeAutoDispose(provider: LifecycleProvider<Any>,
+    onSuccess: Consumer<in T> = emptyConsumer(),
+    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
+    onComplete: Action = AutoDisposeUtil.EMPTY_ACTION,
+    onSubscribe: Consumer<in Disposable> = AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER)
+    = subscribe(AutoDispose.maybe(provider).around(onSuccess, onError, onComplete, onSubscribe))
+
+inline fun <T> Single<T>.subscribeAutoDispose(provider: LifecycleProvider<Any>,
+    biConsumer: BiConsumer<in T, in Throwable>)
+    = subscribe(AutoDispose.single(provider).around(biConsumer))
+
+inline fun <T> Single<T>.subscribeAutoDispose(provider: LifecycleProvider<Any>,
+    onSuccess: Consumer<in T> = emptyConsumer(),
+    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
+    onSubscribe: Consumer<in Disposable> = AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER)
+    = subscribe(AutoDispose.single(provider).around(onSuccess, onError, onSubscribe))
+
+inline fun Completable.subscribeAutoDispose(provider: LifecycleProvider<Any>,
+    onComplete: Action = AutoDisposeUtil.EMPTY_ACTION,
+    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
+    onSubscribe: Consumer<in Disposable> = AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER)
+    = subscribe(AutoDispose.completable(provider).around(onComplete, onError, onSubscribe))
+
+inline fun <T> Flowable<T>.subscribeAutoDispose(lifecycle: Maybe<Any>,
+    onNext: Consumer<in T> = emptyConsumer(),
+    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
+    onComplete: Action = AutoDisposeUtil.EMPTY_ACTION,
+    onSubscribe: Consumer<in Subscription> = AutoDisposeUtil.EMPTY_SUBSCRIPTION_CONSUMER)
+    = subscribe(AutoDispose.flowable(lifecycle).around(onNext, onError, onComplete, onSubscribe))
+
+inline fun <T> Observable<T>.subscribeAutoDispose(lifecycle: Maybe<Any>,
+    onNext: Consumer<in T> = emptyConsumer(),
+    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
+    onComplete: Action = AutoDisposeUtil.EMPTY_ACTION,
+    onSubscribe: Consumer<in Disposable> = AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER)
+    = subscribe(AutoDispose.observable(lifecycle).around(onNext, onError, onComplete, onSubscribe))
+
+inline fun <T> Maybe<T>.subscribeAutoDispose(lifecycle: Maybe<Any>,
+    onSuccess: Consumer<in T> = emptyConsumer(),
+    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
+    onComplete: Action = AutoDisposeUtil.EMPTY_ACTION,
+    onSubscribe: Consumer<in Disposable> = AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER)
+    = subscribe(AutoDispose.maybe(lifecycle).around(onSuccess, onError, onComplete, onSubscribe))
+
+inline fun <T> Single<T>.subscribeAutoDispose(lifecycle: Maybe<Any>,
+    biConsumer: BiConsumer<in T, in Throwable>)
+    = subscribe(AutoDispose.single(lifecycle).around(biConsumer))
+
+inline fun <T> Single<T>.subscribeAutoDispose(lifecycle: Maybe<Any>,
+    onSuccess: Consumer<in T> = emptyConsumer(),
+    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
+    onSubscribe: Consumer<in Disposable> = AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER)
+    = subscribe(AutoDispose.single(lifecycle).around(onSuccess, onError, onSubscribe))
+
+inline fun Completable.subscribeAutoDispose(lifecycle: Maybe<Any>,
+    onComplete: Action = AutoDisposeUtil.EMPTY_ACTION,
+    onError: Consumer<in Throwable> = AutoDisposeUtil.DEFAULT_ERROR_CONSUMER,
+    onSubscribe: Consumer<in Disposable> = AutoDisposeUtil.EMPTY_DISPOSABLE_CONSUMER)
+    = subscribe(AutoDispose.completable(lifecycle).around(onComplete, onError, onSubscribe))

--- a/autodispose-kotlin/src/test/kotlin/com/uber/autodispose/kotlin/AutoDisposeKotlinTest.kt
+++ b/autodispose-kotlin/src/test/kotlin/com/uber/autodispose/kotlin/AutoDisposeKotlinTest.kt
@@ -60,8 +60,8 @@ class AutoDisposeKotlinTest {
     }
 
     override fun correspondingEvents(): Function<LifecycleEvent, LifecycleEvent> {
-      return Function { event ->
-        when (event) {
+      return Function {
+        when (it) {
           is Start -> End()
           is End -> throw LifecycleEndedException()
         }
@@ -74,7 +74,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(scopeMaybe)
         .subscribe(o)
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
     o.assertComplete()
   }
 
@@ -86,7 +86,7 @@ class AutoDisposeKotlinTest {
 
     subject.onNext("Hello")
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
 
     scopeMaybe.onSuccess(Object())
 
@@ -100,7 +100,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(scopeProvider)
         .subscribe(o)
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
     o.assertComplete()
   }
 
@@ -112,7 +112,7 @@ class AutoDisposeKotlinTest {
 
     subject.onNext("Hello")
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
 
     scopeMaybe.onSuccess(Object())
 
@@ -126,7 +126,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(lifecycle)
         .subscribe(o)
 
-    o.assertError { t -> t is LifecycleNotStartedException }
+    o.assertError { it is LifecycleNotStartedException }
   }
 
   @Test fun observable_lifecycleNormalCompletion() {
@@ -135,7 +135,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(lifecycle)
         .subscribe(o)
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
     o.assertComplete()
   }
 
@@ -148,7 +148,7 @@ class AutoDisposeKotlinTest {
 
     subject.onNext("Hello")
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
 
     lifecycleEvents.onNext(End())
 
@@ -164,7 +164,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(lifecycle)
         .subscribe(o)
 
-    o.assertError { t -> t is LifecycleEndedException }
+    o.assertError { it is LifecycleEndedException }
   }
 
   @Test fun flowable_maybeNormalCompletion() {
@@ -172,7 +172,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(scopeMaybe)
         .subscribe(s)
 
-    s.assertValue { v -> v == "Hello" }
+    s.assertValue { it == "Hello" }
     s.assertComplete()
   }
 
@@ -184,7 +184,7 @@ class AutoDisposeKotlinTest {
 
     subject.onNext("Hello")
 
-    s.assertValue { v -> v == "Hello" }
+    s.assertValue { it == "Hello" }
 
     scopeMaybe.onSuccess(Object())
 
@@ -198,7 +198,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(scopeProvider)
         .subscribe(s)
 
-    s.assertValue { v -> v == "Hello" }
+    s.assertValue { it == "Hello" }
     s.assertComplete()
   }
 
@@ -210,7 +210,7 @@ class AutoDisposeKotlinTest {
 
     subject.onNext("Hello")
 
-    s.assertValue { v -> v == "Hello" }
+    s.assertValue { it == "Hello" }
 
     scopeMaybe.onSuccess(Object())
 
@@ -224,7 +224,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(lifecycle)
         .subscribe(s)
 
-    s.assertError { t -> t is LifecycleNotStartedException }
+    s.assertError { it is LifecycleNotStartedException }
   }
 
   @Test fun flowable_lifecycleNormalCompletion() {
@@ -233,7 +233,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(lifecycle)
         .subscribe(s)
 
-    s.assertValue { v -> v == "Hello" }
+    s.assertValue { it == "Hello" }
     s.assertComplete()
   }
 
@@ -246,7 +246,7 @@ class AutoDisposeKotlinTest {
 
     subject.onNext("Hello")
 
-    s.assertValue { v -> v == "Hello" }
+    s.assertValue { it == "Hello" }
 
     lifecycleEvents.onNext(End())
 
@@ -262,7 +262,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(lifecycle)
         .subscribe(s)
 
-    s.assertError { t -> t is LifecycleEndedException }
+    s.assertError { it is LifecycleEndedException }
   }
 
   @Test fun maybe_maybeNormalCompletion() {
@@ -270,7 +270,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(scopeMaybe)
         .subscribe(o)
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
     o.assertComplete()
   }
 
@@ -282,7 +282,7 @@ class AutoDisposeKotlinTest {
 
     subject.onSuccess("Hello")
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
 
     scopeMaybe.onSuccess(Object())
 
@@ -296,7 +296,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(scopeProvider)
         .subscribe(o)
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
     o.assertComplete()
   }
 
@@ -308,7 +308,7 @@ class AutoDisposeKotlinTest {
 
     subject.onSuccess("Hello")
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
 
     scopeMaybe.onSuccess(Object())
 
@@ -322,7 +322,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(lifecycle)
         .subscribe(o)
 
-    o.assertError { t -> t is LifecycleNotStartedException }
+    o.assertError { it is LifecycleNotStartedException }
   }
 
   @Test fun maybe_lifecycleNormalCompletion() {
@@ -331,7 +331,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(lifecycle)
         .subscribe(o)
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
     o.assertComplete()
   }
 
@@ -356,7 +356,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(lifecycle)
         .subscribe(o)
 
-    o.assertError { t -> t is LifecycleEndedException }
+    o.assertError { it is LifecycleEndedException }
   }
 
   @Test fun single_maybeNormalCompletion() {
@@ -364,7 +364,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(scopeMaybe)
         .subscribe(o)
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
     o.assertComplete()
   }
 
@@ -376,7 +376,7 @@ class AutoDisposeKotlinTest {
 
     subject.onSuccess("Hello")
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
 
     scopeMaybe.onSuccess(Object())
 
@@ -390,7 +390,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(scopeProvider)
         .subscribe(o)
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
     o.assertComplete()
   }
 
@@ -402,7 +402,7 @@ class AutoDisposeKotlinTest {
 
     subject.onSuccess("Hello")
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
 
     scopeMaybe.onSuccess(Object())
 
@@ -416,7 +416,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(lifecycle)
         .subscribe(o)
 
-    o.assertError { t -> t is LifecycleNotStartedException }
+    o.assertError { it is LifecycleNotStartedException }
   }
 
   @Test fun single_lifecycleNormalCompletion() {
@@ -425,7 +425,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(lifecycle)
         .subscribe(o)
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
     o.assertComplete()
   }
 
@@ -450,7 +450,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(lifecycle)
         .subscribe(o)
 
-    o.assertError { t -> t is LifecycleEndedException }
+    o.assertError { it is LifecycleEndedException }
   }
 
   @Test fun completable_maybeNormalCompletion() {
@@ -469,7 +469,7 @@ class AutoDisposeKotlinTest {
 
     subject.onNext("Hello")
 
-    o.assertValue { v -> v == "Hello" }
+    o.assertValue { it == "Hello" }
 
     scopeMaybe.onSuccess(Object())
 
@@ -506,7 +506,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(lifecycle)
         .subscribe(o)
 
-    o.assertError { t -> t is LifecycleNotStartedException }
+    o.assertError { it is LifecycleNotStartedException }
   }
 
   @Test fun completable_lifecycleNormalCompletion() {
@@ -539,7 +539,7 @@ class AutoDisposeKotlinTest {
         .autoDisposeWith(lifecycle)
         .subscribe(o)
 
-    o.assertError { t -> t is LifecycleEndedException }
+    o.assertError { it is LifecycleEndedException }
   }
 
 }

--- a/autodispose-kotlin/src/test/kotlin/com/uber/autodispose/kotlin/AutoDisposeKotlinTest.kt
+++ b/autodispose-kotlin/src/test/kotlin/com/uber/autodispose/kotlin/AutoDisposeKotlinTest.kt
@@ -1,0 +1,545 @@
+/*
+ * Copyright (c) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose.kotlin
+
+import com.uber.autodispose.LifecycleEndedException
+import com.uber.autodispose.LifecycleNotStartedException
+import com.uber.autodispose.LifecycleScopeProvider
+import com.uber.autodispose.ScopeProvider
+import com.uber.autodispose.kotlin.LifecycleEvent.End
+import com.uber.autodispose.kotlin.LifecycleEvent.Start
+import io.reactivex.BackpressureStrategy.ERROR
+import io.reactivex.Completable
+import io.reactivex.Flowable
+import io.reactivex.Maybe
+import io.reactivex.Observable
+import io.reactivex.Single
+import io.reactivex.functions.Function
+import io.reactivex.observers.TestObserver
+import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.subjects.CompletableSubject
+import io.reactivex.subjects.MaybeSubject
+import io.reactivex.subjects.PublishSubject
+import io.reactivex.subjects.SingleSubject
+import io.reactivex.subscribers.TestSubscriber
+import org.junit.Test
+
+sealed class LifecycleEvent {
+  class Start: LifecycleEvent()
+  class End: LifecycleEvent()
+}
+
+class AutoDisposeKotlinTest {
+
+  val o = TestObserver<String>()
+  val s = TestSubscriber<String>()
+  val scopeMaybe = MaybeSubject.create<Any>()
+  val scopeProvider = ScopeProvider { scopeMaybe }
+  val lifecycleEvents = BehaviorSubject.create<LifecycleEvent>()
+  val lifecycle = object : LifecycleScopeProvider<LifecycleEvent> {
+    override fun lifecycle(): Observable<LifecycleEvent> {
+      return lifecycleEvents
+    }
+
+    override fun peekLifecycle(): LifecycleEvent? {
+      return lifecycleEvents.value
+    }
+
+    override fun correspondingEvents(): Function<LifecycleEvent, LifecycleEvent> {
+      return Function { event ->
+        when (event) {
+          is Start -> End()
+          is End -> throw LifecycleEndedException()
+        }
+      }
+    }
+  }
+
+  @Test fun observable_maybeNormalCompletion() {
+    Observable.just("Hello")
+        .autoDisposeWith(scopeMaybe)
+        .subscribe(o)
+
+    o.assertValue { v -> v == "Hello" }
+    o.assertComplete()
+  }
+
+  @Test fun observable_maybeNormalInterrupted() {
+    val subject = PublishSubject.create<String>()
+    subject
+        .autoDisposeWith(scopeMaybe)
+        .subscribe(o)
+
+    subject.onNext("Hello")
+
+    o.assertValue { v -> v == "Hello" }
+
+    scopeMaybe.onSuccess(Object())
+
+    // https://github.com/ReactiveX/RxJava/issues/5178
+//    assertThat(o.isDisposed).isTrue()
+//    o.assertNotSubscribed()
+  }
+
+  @Test fun observable_scopeProviderNormalCompletion() {
+    Observable.just("Hello")
+        .autoDisposeWith(scopeProvider)
+        .subscribe(o)
+
+    o.assertValue { v -> v == "Hello" }
+    o.assertComplete()
+  }
+
+  @Test fun observable_scopeProviderNormalInterrupted() {
+    val subject = PublishSubject.create<String>()
+    subject
+        .autoDisposeWith(scopeProvider)
+        .subscribe(o)
+
+    subject.onNext("Hello")
+
+    o.assertValue { v -> v == "Hello" }
+
+    scopeMaybe.onSuccess(Object())
+
+    // https://github.com/ReactiveX/RxJava/issues/5178
+//    assertThat(o.isDisposed).isTrue()
+//    o.assertNotSubscribed()
+  }
+
+  @Test fun observable_lifecycleNotStarted() {
+    Observable.just("Hello")
+        .autoDisposeWith(lifecycle)
+        .subscribe(o)
+
+    o.assertError { t -> t is LifecycleNotStartedException }
+  }
+
+  @Test fun observable_lifecycleNormalCompletion() {
+    lifecycleEvents.onNext(Start())
+    Observable.just("Hello")
+        .autoDisposeWith(lifecycle)
+        .subscribe(o)
+
+    o.assertValue { v -> v == "Hello" }
+    o.assertComplete()
+  }
+
+  @Test fun observable_lifecycleNormalInterrupted() {
+    lifecycleEvents.onNext(Start())
+    val subject = PublishSubject.create<String>()
+    subject
+        .autoDisposeWith(lifecycle)
+        .subscribe(o)
+
+    subject.onNext("Hello")
+
+    o.assertValue { v -> v == "Hello" }
+
+    lifecycleEvents.onNext(End())
+
+    // https://github.com/ReactiveX/RxJava/issues/5178
+//    assertThat(o.isDisposed).isTrue()
+//    o.assertNotSubscribed()
+  }
+
+  @Test fun observable_lifecycleEnded() {
+    lifecycleEvents.onNext(Start())
+    lifecycleEvents.onNext(End())
+    Observable.just("Hello")
+        .autoDisposeWith(lifecycle)
+        .subscribe(o)
+
+    o.assertError { t -> t is LifecycleEndedException }
+  }
+
+  @Test fun flowable_maybeNormalCompletion() {
+    Flowable.just("Hello")
+        .autoDisposeWith(scopeMaybe)
+        .subscribe(s)
+
+    s.assertValue { v -> v == "Hello" }
+    s.assertComplete()
+  }
+
+  @Test fun flowable_maybeNormalInterrupted() {
+    val subject = PublishSubject.create<String>()
+    subject.toFlowable(ERROR)
+        .autoDisposeWith(scopeMaybe)
+        .subscribe(s)
+
+    subject.onNext("Hello")
+
+    s.assertValue { v -> v == "Hello" }
+
+    scopeMaybe.onSuccess(Object())
+
+    // https://github.com/ReactiveX/RxJava/issues/5178
+//    assertThat(s.isDisposed).isTrue()
+//    s.assertNotSubscribed()
+  }
+
+  @Test fun flowable_scopeProviderNormalCompletion() {
+    Flowable.just("Hello")
+        .autoDisposeWith(scopeProvider)
+        .subscribe(s)
+
+    s.assertValue { v -> v == "Hello" }
+    s.assertComplete()
+  }
+
+  @Test fun flowable_scopeProviderNormalInterrupted() {
+    val subject = PublishSubject.create<String>()
+    subject.toFlowable(ERROR)
+        .autoDisposeWith(scopeProvider)
+        .subscribe(s)
+
+    subject.onNext("Hello")
+
+    s.assertValue { v -> v == "Hello" }
+
+    scopeMaybe.onSuccess(Object())
+
+    // https://github.com/ReactiveX/RxJava/issues/5178
+//    assertThat(s.isDisposed).isTrue()
+//    s.assertNotSubscribed()
+  }
+
+  @Test fun flowable_lifecycleNotStarted() {
+    Flowable.just("Hello")
+        .autoDisposeWith(lifecycle)
+        .subscribe(s)
+
+    s.assertError { t -> t is LifecycleNotStartedException }
+  }
+
+  @Test fun flowable_lifecycleNormalCompletion() {
+    lifecycleEvents.onNext(Start())
+    Flowable.just("Hello")
+        .autoDisposeWith(lifecycle)
+        .subscribe(s)
+
+    s.assertValue { v -> v == "Hello" }
+    s.assertComplete()
+  }
+
+  @Test fun flowable_lifecycleNormalInterrupted() {
+    lifecycleEvents.onNext(Start())
+    val subject = PublishSubject.create<String>()
+    subject.toFlowable(ERROR)
+        .autoDisposeWith(lifecycle)
+        .subscribe(s)
+
+    subject.onNext("Hello")
+
+    s.assertValue { v -> v == "Hello" }
+
+    lifecycleEvents.onNext(End())
+
+    // https://github.com/ReactiveX/RxJava/issues/5178
+//    assertThat(s.isDisposed).isTrue()
+//    s.assertNotSubscribed()
+  }
+
+  @Test fun flowable_lifecycleEnded() {
+    lifecycleEvents.onNext(Start())
+    lifecycleEvents.onNext(End())
+    Flowable.just("Hello")
+        .autoDisposeWith(lifecycle)
+        .subscribe(s)
+
+    s.assertError { t -> t is LifecycleEndedException }
+  }
+
+  @Test fun maybe_maybeNormalCompletion() {
+    Maybe.just("Hello")
+        .autoDisposeWith(scopeMaybe)
+        .subscribe(o)
+
+    o.assertValue { v -> v == "Hello" }
+    o.assertComplete()
+  }
+
+  @Test fun maybe_maybeNormalInterrupted() {
+    val subject = MaybeSubject.create<String>()
+    subject
+        .autoDisposeWith(scopeMaybe)
+        .subscribe(o)
+
+    subject.onSuccess("Hello")
+
+    o.assertValue { v -> v == "Hello" }
+
+    scopeMaybe.onSuccess(Object())
+
+    // https://github.com/ReactiveX/RxJava/issues/5178
+//    assertThat(o.isDisposed).isTrue()
+//    o.assertNotSubscribed()
+  }
+
+  @Test fun maybe_scopeProviderNormalCompletion() {
+    Maybe.just("Hello")
+        .autoDisposeWith(scopeProvider)
+        .subscribe(o)
+
+    o.assertValue { v -> v == "Hello" }
+    o.assertComplete()
+  }
+
+  @Test fun maybe_scopeProviderNormalInterrupted() {
+    val subject = MaybeSubject.create<String>()
+    subject
+        .autoDisposeWith(scopeProvider)
+        .subscribe(o)
+
+    subject.onSuccess("Hello")
+
+    o.assertValue { v -> v == "Hello" }
+
+    scopeMaybe.onSuccess(Object())
+
+    // https://github.com/ReactiveX/RxJava/issues/5178
+//    assertThat(o.isDisposed).isTrue()
+//    o.assertNotSubscribed()
+  }
+
+  @Test fun maybe_lifecycleNotStarted() {
+    Maybe.just("Hello")
+        .autoDisposeWith(lifecycle)
+        .subscribe(o)
+
+    o.assertError { t -> t is LifecycleNotStartedException }
+  }
+
+  @Test fun maybe_lifecycleNormalCompletion() {
+    lifecycleEvents.onNext(Start())
+    Maybe.just("Hello")
+        .autoDisposeWith(lifecycle)
+        .subscribe(o)
+
+    o.assertValue { v -> v == "Hello" }
+    o.assertComplete()
+  }
+
+  @Test fun maybe_lifecycleNormalInterrupted() {
+    lifecycleEvents.onNext(Start())
+    val subject = PublishSubject.create<String>()
+    subject
+        .autoDisposeWith(lifecycle)
+        .subscribe(o)
+
+    lifecycleEvents.onNext(End())
+
+    // https://github.com/ReactiveX/RxJava/issues/5178
+//    assertThat(o.isDisposed).isTrue()
+//    o.assertNotSubscribed()
+  }
+
+  @Test fun maybe_lifecycleEnded() {
+    lifecycleEvents.onNext(Start())
+    lifecycleEvents.onNext(End())
+    Maybe.just("Hello")
+        .autoDisposeWith(lifecycle)
+        .subscribe(o)
+
+    o.assertError { t -> t is LifecycleEndedException }
+  }
+
+  @Test fun single_maybeNormalCompletion() {
+    Single.just("Hello")
+        .autoDisposeWith(scopeMaybe)
+        .subscribe(o)
+
+    o.assertValue { v -> v == "Hello" }
+    o.assertComplete()
+  }
+
+  @Test fun single_maybeNormalInterrupted() {
+    val subject = SingleSubject.create<String>()
+    subject
+        .autoDisposeWith(scopeMaybe)
+        .subscribe(o)
+
+    subject.onSuccess("Hello")
+
+    o.assertValue { v -> v == "Hello" }
+
+    scopeMaybe.onSuccess(Object())
+
+    // https://github.com/ReactiveX/RxJava/issues/5178
+//    assertThat(o.isDisposed).isTrue()
+//    o.assertNotSubscribed()
+  }
+
+  @Test fun single_scopeProviderNormalCompletion() {
+    Single.just("Hello")
+        .autoDisposeWith(scopeProvider)
+        .subscribe(o)
+
+    o.assertValue { v -> v == "Hello" }
+    o.assertComplete()
+  }
+
+  @Test fun single_scopeProviderNormalInterrupted() {
+    val subject = SingleSubject.create<String>()
+    subject
+        .autoDisposeWith(scopeProvider)
+        .subscribe(o)
+
+    subject.onSuccess("Hello")
+
+    o.assertValue { v -> v == "Hello" }
+
+    scopeMaybe.onSuccess(Object())
+
+    // https://github.com/ReactiveX/RxJava/issues/5178
+//    assertThat(o.isDisposed).isTrue()
+//    o.assertNotSubscribed()
+  }
+
+  @Test fun single_lifecycleNotStarted() {
+    Single.just("Hello")
+        .autoDisposeWith(lifecycle)
+        .subscribe(o)
+
+    o.assertError { t -> t is LifecycleNotStartedException }
+  }
+
+  @Test fun single_lifecycleNormalCompletion() {
+    lifecycleEvents.onNext(Start())
+    Single.just("Hello")
+        .autoDisposeWith(lifecycle)
+        .subscribe(o)
+
+    o.assertValue { v -> v == "Hello" }
+    o.assertComplete()
+  }
+
+  @Test fun single_lifecycleNormalInterrupted() {
+    lifecycleEvents.onNext(Start())
+    val subject = PublishSubject.create<String>()
+    subject
+        .autoDisposeWith(lifecycle)
+        .subscribe(o)
+
+    lifecycleEvents.onNext(End())
+
+    // https://github.com/ReactiveX/RxJava/issues/5178
+//    assertThat(o.isDisposed).isTrue()
+//    o.assertNotSubscribed()
+  }
+
+  @Test fun single_lifecycleEnded() {
+    lifecycleEvents.onNext(Start())
+    lifecycleEvents.onNext(End())
+    Single.just("Hello")
+        .autoDisposeWith(lifecycle)
+        .subscribe(o)
+
+    o.assertError { t -> t is LifecycleEndedException }
+  }
+
+  @Test fun completable_maybeNormalCompletion() {
+    Completable.complete()
+        .autoDisposeWith(scopeMaybe)
+        .subscribe(o)
+
+    o.assertComplete()
+  }
+
+  @Test fun completable_maybeNormalInterrupted() {
+    val subject = PublishSubject.create<String>()
+    subject
+        .autoDisposeWith(scopeMaybe)
+        .subscribe(o)
+
+    subject.onNext("Hello")
+
+    o.assertValue { v -> v == "Hello" }
+
+    scopeMaybe.onSuccess(Object())
+
+    // https://github.com/ReactiveX/RxJava/issues/5178
+//    assertThat(o.isDisposed).isTrue()
+//    o.assertNotSubscribed()
+  }
+
+  @Test fun completable_scopeProviderNormalCompletion() {
+    Completable.complete()
+        .autoDisposeWith(scopeProvider)
+        .subscribe(o)
+
+    o.assertComplete()
+  }
+
+  @Test fun completable_scopeProviderNormalInterrupted() {
+    val subject = CompletableSubject.create()
+    subject
+        .autoDisposeWith(scopeProvider)
+        .subscribe(o)
+
+    subject.onComplete()
+
+    scopeMaybe.onSuccess(Object())
+
+    // https://github.com/ReactiveX/RxJava/issues/5178
+//    assertThat(o.isDisposed).isTrue()
+//    o.assertNotSubscribed()
+  }
+
+  @Test fun completable_lifecycleNotStarted() {
+    Completable.complete()
+        .autoDisposeWith(lifecycle)
+        .subscribe(o)
+
+    o.assertError { t -> t is LifecycleNotStartedException }
+  }
+
+  @Test fun completable_lifecycleNormalCompletion() {
+    lifecycleEvents.onNext(Start())
+    Completable.complete()
+        .autoDisposeWith(lifecycle)
+        .subscribe(o)
+
+    o.assertComplete()
+  }
+
+  @Test fun completable_lifecycleNormalInterrupted() {
+    lifecycleEvents.onNext(Start())
+    val subject = CompletableSubject.create()
+    subject
+        .autoDisposeWith(lifecycle)
+        .subscribe(o)
+
+    lifecycleEvents.onNext(End())
+
+    // https://github.com/ReactiveX/RxJava/issues/5178
+//    assertThat(o.isDisposed).isTrue()
+//    o.assertNotSubscribed()
+  }
+
+  @Test fun completable_lifecycleEnded() {
+    lifecycleEvents.onNext(Start())
+    lifecycleEvents.onNext(End())
+    Completable.complete()
+        .autoDisposeWith(lifecycle)
+        .subscribe(o)
+
+    o.assertError { t -> t is LifecycleEndedException }
+  }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,3 +17,4 @@
 rootProject.name = 'autodispose-root'
 include ':autodispose'
 include ':autodispose-android'
+include ':autodispose-kotlin'


### PR DESCRIPTION
Resolves #7

This tacks on convenience extension functions to RxJava types, such that you can just do this:

```kotlin
myObservable
    .doWhatever()
    .autoDisposeWith(this)
    .subscribe()
```

Did some opportunistic project house cleaning as well
