### PR TITLE
Add AutoDisposeViewHolder Android component

### DIFF
--- a/autodispose-android/build.gradle
+++ b/autodispose-android/build.gradle
@@ -46,7 +46,8 @@ dependencies {
   androidTestCompile deps.support.annotations
   androidTestCompile deps.test.junit
   androidTestCompile deps.test.truth
-  androidTestCompile deps.test.androidRunner
+  androidTestCompile deps.test.androidEspresso
+  androidTestCompile deps.test.androidRules
   androidTestCompile deps.test.androidRules
 
 }

--- a/autodispose-android/build.gradle
+++ b/autodispose-android/build.gradle
@@ -42,6 +42,7 @@ dependencies {
   compile deps.rx.java
   compile deps.rx.android
   compile deps.support.annotations
+  compile deps.support.recyclerview
   androidTestCompile deps.support.annotations
   androidTestCompile deps.test.junit
   androidTestCompile deps.test.truth

--- a/autodispose-android/src/androidTest/AndroidManifest.xml
+++ b/autodispose-android/src/androidTest/AndroidManifest.xml
@@ -17,7 +17,11 @@
 <manifest package="com.uber.autodispose.android"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
+  <uses-permission android:name="android.permission.DISABLE_KEYGUARD"/>
+  <uses-permission android:name="android.permission.WAKE_LOCK"/>
+
   <application>
     <activity android:name=".ViewScopeProviderTestActivity"/>
+    <activity android:name=".AutoDisposeViewHolderTestActivity"/>
   </application>
 </manifest>

--- a/autodispose-android/src/androidTest/AndroidManifest.xml
+++ b/autodispose-android/src/androidTest/AndroidManifest.xml
@@ -18,6 +18,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application>
-    <activity android:name=".AutoDisposeTestActivity"/>
+    <activity android:name=".ViewScopeProviderTestActivity"/>
   </application>
 </manifest>

--- a/autodispose-android/src/androidTest/java/com/uber/autodispose/android/AutoDisposeViewHolderTest.java
+++ b/autodispose-android/src/androidTest/java/com/uber/autodispose/android/AutoDisposeViewHolderTest.java
@@ -49,7 +49,7 @@ import static com.google.common.truth.Truth.assertThat;
  * lines up with the number of disposals. We can't monitor recycling + immediate disposable directly
  * because it's actually async.
  */
-@RunWith(AndroidJUnit4.class) public final class AutoDisposeViewHolderViewTest {
+@RunWith(AndroidJUnit4.class) public final class AutoDisposeViewHolderTest {
   @Rule public final ActivityTestRule<AutoDisposeViewHolderTestActivity> activityRule =
       new ActivityTestRule<>(AutoDisposeViewHolderTestActivity.class);
 

--- a/autodispose-android/src/androidTest/java/com/uber/autodispose/android/AutoDisposeViewHolderTestActivity.java
+++ b/autodispose-android/src/androidTest/java/com/uber/autodispose/android/AutoDisposeViewHolderTestActivity.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose.android;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+
+public final class AutoDisposeViewHolderTestActivity extends Activity {
+  RecyclerView recyclerView;
+
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    recyclerView = new RecyclerView(this);
+    recyclerView.setId(android.R.id.primary);
+    recyclerView.setLayoutManager(new LinearLayoutManager(this));
+    setContentView(recyclerView);
+  }
+}

--- a/autodispose-android/src/androidTest/java/com/uber/autodispose/android/AutoDisposeViewHolderViewTest.java
+++ b/autodispose-android/src/androidTest/java/com/uber/autodispose/android/AutoDisposeViewHolderViewTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.swipeDown;
 import static android.support.test.espresso.action.ViewActions.swipeUp;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static com.google.common.truth.Truth.assertThat;
@@ -46,7 +47,7 @@ import static com.google.common.truth.Truth.assertThat;
 /**
  * Bit of an odd one, but this test works by flinging the list and ensuring the number of recycles
  * lines up with the number of disposals. We can't monitor recycling + immediate disposable directly
- *  because it's actually async.
+ * because it's actually async.
  */
 @RunWith(AndroidJUnit4.class) public final class AutoDisposeViewHolderViewTest {
   @Rule public final ActivityTestRule<AutoDisposeViewHolderTestActivity> activityRule =
@@ -93,7 +94,17 @@ import static com.google.common.truth.Truth.assertThat;
     instrumentation.waitForIdleSync();
     int disposeCount = disposeCounter.get();
     int recycledCount = recycledCounter.get();
-    Log.d("TEST", "Counts are " + disposeCount + " and " + recycledCount);
+    Log.d("TEST", "Counts after swipe up are " + disposeCount + " and " + recycledCount);
+    assertThat(disposeCount).isGreaterThan(0);
+    assertThat(recycledCount).isGreaterThan(0);
+    assertThat(disposeCount).isEqualTo(recycledCount);
+
+    // Swipe back down to confirm rebinding also behaves correctly.
+    interaction.perform(swipeDown());
+    instrumentation.waitForIdleSync();
+    disposeCount = disposeCounter.get();
+    recycledCount = recycledCounter.get();
+    Log.d("TEST", "Counts after swipe down are " + disposeCount + " and " + recycledCount);
     assertThat(disposeCount).isGreaterThan(0);
     assertThat(recycledCount).isGreaterThan(0);
     assertThat(disposeCount).isEqualTo(recycledCount);

--- a/autodispose-android/src/androidTest/java/com/uber/autodispose/android/AutoDisposeViewHolderViewTest.java
+++ b/autodispose-android/src/androidTest/java/com/uber/autodispose/android/AutoDisposeViewHolderViewTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose.android;
+
+import android.app.Instrumentation;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.v7.widget.RecyclerView;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import com.uber.autodispose.ObservableScoper;
+import io.reactivex.Observable;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.Action;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.swipeUp;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Bit of an odd one, but this test works by flinging the list and ensuring the number of recycles
+ * lines up with the number of disposals. We can't monitor recycling + immediate disposable directly
+ *  because it's actually async.
+ */
+@RunWith(AndroidJUnit4.class) public final class AutoDisposeViewHolderViewTest {
+  @Rule public final ActivityTestRule<AutoDisposeViewHolderTestActivity> activityRule =
+      new ActivityTestRule<>(AutoDisposeViewHolderTestActivity.class);
+
+  private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+  private final AtomicInteger recycledCounter = new AtomicInteger();
+  private final AtomicInteger disposeCounter = new AtomicInteger();
+
+  private RecyclerView view;
+  private ViewInteraction interaction;
+  private ViewDirtyIdlingResource viewDirtyIdler;
+
+  @Before public void setUp() {
+    AutoDisposeViewHolderTestActivity activity = activityRule.getActivity();
+    view = activity.recyclerView;
+    interaction = onView(withId(android.R.id.primary));
+    viewDirtyIdler = new ViewDirtyIdlingResource(activity);
+    Espresso.registerIdlingResources(viewDirtyIdler);
+  }
+
+  @After public void tearDown() {
+    Espresso.unregisterIdlingResources(viewDirtyIdler);
+  }
+
+  @Test public void basicTest() {
+    final Adapter adapter = new Adapter();
+    final RecyclerView.RecyclerListener delegateListener =
+        AutoDisposeViewHolder.newRecyclerListener();
+    view.setRecyclerListener(new RecyclerView.RecyclerListener() {
+      @Override public void onViewRecycled(RecyclerView.ViewHolder h) {
+        delegateListener.onViewRecycled(h);
+        recycledCounter.incrementAndGet();
+      }
+    });
+
+    instrumentation.runOnMainSync(new Runnable() {
+      @Override public void run() {
+        view.setAdapter(adapter);
+      }
+    });
+
+    interaction.perform(swipeUp());
+    instrumentation.waitForIdleSync();
+    int disposeCount = disposeCounter.get();
+    int recycledCount = recycledCounter.get();
+    Log.d("TEST", "Counts are " + disposeCount + " and " + recycledCount);
+    assertThat(disposeCount).isGreaterThan(0);
+    assertThat(recycledCount).isGreaterThan(0);
+    assertThat(disposeCount).isEqualTo(recycledCount);
+  }
+
+  private class Adapter extends RecyclerView.Adapter<ViewHolder> {
+
+    public Adapter() {
+      setHasStableIds(true);
+    }
+
+    @Override public ViewHolder onCreateViewHolder(ViewGroup parent, int position) {
+      TextView v = (TextView) LayoutInflater.from(parent.getContext())
+          .inflate(android.R.layout.simple_list_item_1, parent, false);
+      return new ViewHolder(v);
+    }
+
+    @Override public void onBindViewHolder(ViewHolder holder, int position) {
+      holder.textView.setText(String.valueOf(position));
+
+      holder.disposable = Observable.never()
+          .doOnDispose(new Action() {
+            @Override public void run() throws Exception {
+              disposeCounter.incrementAndGet();
+            }
+          })
+          .to(new ObservableScoper<>(holder))
+          .subscribe();
+    }
+
+    @Override public int getItemCount() {
+      return 100;
+    }
+
+    @Override public long getItemId(int position) {
+      return position;
+    }
+  }
+
+  private static class ViewHolder extends AutoDisposeViewHolder {
+
+    Disposable disposable;
+    TextView textView;
+
+    ViewHolder(TextView itemView) {
+      super(itemView);
+      this.textView = itemView;
+    }
+  }
+}

--- a/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewDirtyIdlingResource.java
+++ b/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewDirtyIdlingResource.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose.android;
+
+import android.app.Activity;
+import android.support.test.espresso.IdlingResource;
+import android.view.View;
+
+/**
+ * Borrowed from RxBinding - https://git.io/vyS0h.
+ */
+public final class ViewDirtyIdlingResource implements IdlingResource {
+  private final View decorView;
+  private ResourceCallback resourceCallback;
+
+  ViewDirtyIdlingResource(Activity activity) {
+    decorView = activity.getWindow()
+        .getDecorView();
+  }
+
+  @Override public String getName() {
+    return "view dirty";
+  }
+
+  @Override public boolean isIdleNow() {
+    boolean clean = !decorView.isDirty();
+    if (clean) {
+      resourceCallback.onTransitionToIdle();
+    }
+    return clean;
+  }
+
+  @Override public void registerIdleTransitionCallback(ResourceCallback resourceCallback) {
+    this.resourceCallback = resourceCallback;
+  }
+}

--- a/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
+++ b/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
@@ -35,15 +35,15 @@ import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(AndroidJUnit4.class) public final class ViewScopeProviderTest {
 
-  @Rule public final ActivityTestRule<AutoDisposeTestActivity> activityRule =
-      new ActivityTestRule<>(AutoDisposeTestActivity.class);
+  @Rule public final ActivityTestRule<ViewScopeProviderTestActivity> activityRule =
+      new ActivityTestRule<>(ViewScopeProviderTestActivity.class);
 
   private final Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
   private FrameLayout parent;
   private View child;
 
   @Before public void setUp() {
-    AutoDisposeTestActivity activity = activityRule.getActivity();
+    ViewScopeProviderTestActivity activity = activityRule.getActivity();
     parent = activity.parent;
     child = activity.child;
   }

--- a/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTestActivity.java
+++ b/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTestActivity.java
@@ -21,7 +21,7 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.FrameLayout;
 
-public final class AutoDisposeTestActivity extends Activity {
+public final class ViewScopeProviderTestActivity extends Activity {
   FrameLayout parent;
   View child;
 

--- a/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeAndroidUtil.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeAndroidUtil.java
@@ -18,14 +18,16 @@ package com.uber.autodispose.android;
 
 import android.os.Build;
 import android.os.Looper;
+import android.support.annotation.AnyThread;
 import android.support.annotation.RestrictTo;
+import android.support.annotation.UiThread;
 import android.view.View;
 
 import static android.support.annotation.RestrictTo.Scope.LIBRARY;
 
 @RestrictTo(LIBRARY)
 class AutoDisposeAndroidUtil {
-  static boolean isMainThread() {
+  @AnyThread static boolean isMainThread() {
     try {
       return Looper.myLooper() == Looper.getMainLooper();
     } catch (Exception e) {
@@ -34,7 +36,7 @@ class AutoDisposeAndroidUtil {
     }
   }
 
-  static boolean isAttached(View view) {
+  @UiThread static boolean isAttached(View view) {
     return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && view.isAttachedToWindow())
         || view.getWindowToken() != null;
   }

--- a/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeViewHolder.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeViewHolder.java
@@ -61,6 +61,21 @@ public abstract class AutoDisposeViewHolder extends RecyclerView.ViewHolder
   }
 
   /**
+   * Convenience creator for a RecyclerListener that can be registered via
+   * {@link RecyclerView#setRecyclerListener}. The returned listener will automatically signal
+   * recycle events to {@link AutoDisposeViewHolder} holders recycled by the RecyclerView.
+   *
+   * @return the listener.
+   */
+  public static RecyclerView.RecyclerListener newRecyclerListener() {
+    return new RecyclerView.RecyclerListener() {
+      @Override public void onViewRecycled(RecyclerView.ViewHolder holder) {
+        AutoDisposeViewHolder.onViewRecycled(holder);
+      }
+    };
+  }
+
+  /**
    * Proxy for {@link RecyclerView.Adapter#onViewRecycled} method to unbind a holder if it's an
    * RxViewHolder instance.
    *

--- a/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeViewHolder.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeViewHolder.java
@@ -18,7 +18,6 @@ package com.uber.autodispose.android;
 
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
-import com.uber.autodispose.ScopeProvider;
 import io.reactivex.Maybe;
 import io.reactivex.subjects.MaybeSubject;
 
@@ -29,9 +28,12 @@ import io.reactivex.subjects.MaybeSubject;
  * subscriptions with AutoDispose to the ViewHolder. Just make sure to implement and call
  * {@link #onViewRecycled} from your corresponding {@link RecyclerView.Adapter#onViewRecycled}
  * method to ensure proper scoping.
+ * <p>
+ * While this is a reference implementation, any ViewHolder can implement
+ * {@link RecycleAwareViewHolder} and leverage {@link #onViewRecycled} to signal.
  */
 public abstract class AutoDisposeViewHolder extends RecyclerView.ViewHolder
-    implements ScopeProvider {
+    implements RecycleAwareViewHolder {
 
   private MaybeSubject<Object> unbindNotifier;
 
@@ -39,7 +41,7 @@ public abstract class AutoDisposeViewHolder extends RecyclerView.ViewHolder
     super(itemView);
   }
 
-  private void onUnBind() {
+  @Override public void onRecycled() {
     emitUnBindIfPresent();
   }
 
@@ -63,7 +65,7 @@ public abstract class AutoDisposeViewHolder extends RecyclerView.ViewHolder
   /**
    * Convenience creator for a RecyclerListener that can be registered via
    * {@link RecyclerView#setRecyclerListener}. The returned listener will automatically signal
-   * recycle events to {@link AutoDisposeViewHolder} holders recycled by the RecyclerView.
+   * recycle events to {@link RecycleAwareViewHolder} holders recycled by the RecyclerView.
    *
    * @return the listener.
    */
@@ -76,14 +78,14 @@ public abstract class AutoDisposeViewHolder extends RecyclerView.ViewHolder
   }
 
   /**
-   * Proxy for {@link RecyclerView.Adapter#onViewRecycled} method to unbind a holder if it's an
-   * RxViewHolder instance.
+   * Proxy for {@link RecyclerView.Adapter#onViewRecycled} method to unbind a holder if it's a
+   * {@link RecycleAwareViewHolder} instance.
    *
    * @param holder the holder to check.
    */
   public static void onViewRecycled(RecyclerView.ViewHolder holder) {
-    if (holder instanceof AutoDisposeViewHolder) {
-      ((AutoDisposeViewHolder) holder).onUnBind();
+    if (holder instanceof RecycleAwareViewHolder) {
+      ((RecycleAwareViewHolder) holder).onRecycled();
     }
   }
 }

--- a/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeViewHolder.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeViewHolder.java
@@ -16,6 +16,7 @@
 
 package com.uber.autodispose.android;
 
+import android.support.annotation.UiThread;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import io.reactivex.Maybe;
@@ -32,6 +33,7 @@ import io.reactivex.subjects.MaybeSubject;
  * While this is a reference implementation, any ViewHolder can implement
  * {@link RecycleAwareViewHolder} and leverage {@link #onViewRecycled} to signal.
  */
+@UiThread
 public abstract class AutoDisposeViewHolder extends RecyclerView.ViewHolder
     implements RecycleAwareViewHolder {
 

--- a/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeViewHolder.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeViewHolder.java
@@ -46,9 +46,8 @@ public abstract class AutoDisposeViewHolder extends RecyclerView.ViewHolder
   }
 
   private MaybeSubject<?> getOrInitNotifier() {
-    if (unbindNotifier == null) {
-      unbindNotifier = MaybeSubject.create();
-    }
+    emitUnBindIfPresent();
+    unbindNotifier = MaybeSubject.create();
     return unbindNotifier;
   }
 

--- a/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeViewHolder.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeViewHolder.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose.android;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import com.uber.autodispose.ScopeProvider;
+import io.reactivex.Maybe;
+import io.reactivex.subjects.MaybeSubject;
+
+/**
+ * A ViewHolder implementation that facilitates AutoDispose scope binding for RxJava subscriptions
+ * in RecyclerViews. You can extend from this base class, or copy its logic into your own ViewHolder
+ * implementations and use this as a reference. When hooked up properly, you can safely scope
+ * subscriptions with AutoDispose to the ViewHolder. Just make sure to implement and call
+ * {@link #onViewRecycled} from your corresponding {@link RecyclerView.Adapter#onViewRecycled} 
+ * method to ensure proper scoping.
+ */
+public abstract class AutoDisposeViewHolder extends RecyclerView.ViewHolder 
+    implements ScopeProvider {
+
+  private MaybeSubject<Object> unbindNotifier;
+
+  public AutoDisposeViewHolder(View itemView) {
+    super(itemView);
+  }
+
+  private void onUnBind() {
+    emitUnBindIfPresent();
+  }
+
+  private MaybeSubject<?> getOrInitNotifier() {
+    if (unbindNotifier == null) {
+      unbindNotifier = MaybeSubject.create();
+    }
+    return unbindNotifier;
+  }
+
+  private void emitUnBindIfPresent() {
+    if (unbindNotifier != null && !unbindNotifier.hasComplete()) {
+      unbindNotifier.onSuccess(new Object());
+    }
+  }
+
+  @Override public Maybe<?> requestScope() {
+    return getOrInitNotifier();
+  }
+
+  /**
+   * Proxy for {@link RecyclerView.Adapter#onViewRecycled} method to unbind a holder if it's an
+   * RxViewHolder instance.
+   *
+   * @param holder the holder to check.
+   */
+  public static void onViewRecycled(RecyclerView.ViewHolder holder) {
+    if (holder instanceof AutoDisposeViewHolder) {
+      ((AutoDisposeViewHolder) holder).onUnBind();
+    }
+  }
+}

--- a/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeViewHolder.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeViewHolder.java
@@ -27,10 +27,10 @@ import io.reactivex.subjects.MaybeSubject;
  * in RecyclerViews. You can extend from this base class, or copy its logic into your own ViewHolder
  * implementations and use this as a reference. When hooked up properly, you can safely scope
  * subscriptions with AutoDispose to the ViewHolder. Just make sure to implement and call
- * {@link #onViewRecycled} from your corresponding {@link RecyclerView.Adapter#onViewRecycled} 
+ * {@link #onViewRecycled} from your corresponding {@link RecyclerView.Adapter#onViewRecycled}
  * method to ensure proper scoping.
  */
-public abstract class AutoDisposeViewHolder extends RecyclerView.ViewHolder 
+public abstract class AutoDisposeViewHolder extends RecyclerView.ViewHolder
     implements ScopeProvider {
 
   private MaybeSubject<Object> unbindNotifier;

--- a/autodispose-android/src/main/java/com/uber/autodispose/android/RecycleAwareViewHolder.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/RecycleAwareViewHolder.java
@@ -16,6 +16,7 @@
 
 package com.uber.autodispose.android;
 
+import android.support.annotation.UiThread;
 import android.support.v7.widget.RecyclerView;
 import com.uber.autodispose.ScopeProvider;
 
@@ -30,5 +31,6 @@ public interface RecycleAwareViewHolder extends ScopeProvider {
   /**
    * Callback to signal that the ViewHolder has been recycled.
    */
+  @UiThread
   void onRecycled();
 }

--- a/autodispose-android/src/main/java/com/uber/autodispose/android/RecycleAwareViewHolder.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/RecycleAwareViewHolder.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose.android;
+
+import android.support.v7.widget.RecyclerView;
+import com.uber.autodispose.ScopeProvider;
+
+/**
+ * A simple interface for {@link RecyclerView.ViewHolder}s to implement to support unbinding from
+ * {@link AutoDisposeViewHolder#onViewRecycled}.
+ *
+ * @see AutoDisposeViewHolder for a reference implementation.
+ */
+public interface RecycleAwareViewHolder extends ScopeProvider {
+
+  /**
+   * Callback to signal that the ViewHolder has been recycled.
+   */
+  void onRecycled();
+}

--- a/autodispose-android/src/main/java/com/uber/autodispose/android/ViewScopeProvider.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/ViewScopeProvider.java
@@ -16,6 +16,7 @@
 
 package com.uber.autodispose.android;
 
+import android.support.annotation.UiThread;
 import android.view.View;
 import com.uber.autodispose.LifecycleScopeProvider;
 import com.uber.autodispose.OutsideLifecycleException;
@@ -33,7 +34,8 @@ import static com.uber.autodispose.android.ViewLifecycleEvent.DETACH;
  *      .empty();
  * </code></pre>
  */
-public class ViewScopeProvider implements LifecycleScopeProvider<ViewLifecycleEvent> {
+@UiThread
+public final class ViewScopeProvider implements LifecycleScopeProvider<ViewLifecycleEvent> {
   private static final Function<ViewLifecycleEvent, ViewLifecycleEvent> CORRESPONDING_EVENTS =
       new Function<ViewLifecycleEvent, ViewLifecycleEvent>() {
         @Override public ViewLifecycleEvent apply(ViewLifecycleEvent lastEvent) throws Exception {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -43,7 +43,8 @@ def rx = [
 ]
 
 def support = [
-    annotations: "com.android.support:support-annotations:${versions.support}"
+    annotations: "com.android.support:support-annotations:${versions.support}",
+    recyclerview: "com.android.support:recyclerview-v7:${versions.support}"
 ]
 
 def test = [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -48,6 +48,7 @@ def support = [
 ]
 
 def test = [
+    androidEspresso: 'com.android.support.test.espresso:espresso-core:2.2.1',
     androidRunner: "com.android.support.test:runner:${versions.androidTest}",
     androidRules: "com.android.support.test:rules:${versions.androidTest}",
     junit: 'junit:junit:4.12',


### PR DESCRIPTION
This adds a ViewHolder implementation/reference for using AutoDispose on recyclerviews. Due to the nature of how RecyclerViews work, just relying on `View` detaches is not a good enough heuristic, and instead we need to listen for view recycling changes.

The philosophy is this:

`AutoDisposeViewHolder` is the reference implementation, and it implements the `RecycleAwareViewHolder` interface. Others can use this as their base class if they want, or just copy its implementation out into theirs. As long as they implement `RecycleAwareViewHolder`, they can reuse the view recycling helpers. This is also super easy to push up into a base RecyclerView class, which is something we do.

It has two static helpers for usage:
  - `onViewRecycled`: This is a proxy for the same method on `RecyclerView.Adapter` that you can call from your adapter or a `RecyclerView.RecyclerListener` implementation.
  - `newRecyclerListener`: Convenience method that gives you a new listeners that just sends a call out to `AutoDisposeViewHolder#onViewRecycled`.

The helpers make it easy to hook up with the RecyclerView/Adapter, though ideally a future version of RecyclerView would have an additive API for adding listeners in the future that could make this simpler.

In code:

```java

myRecyclerView.setRecyclerListener(AutoDisposeViewHolder.newRecyclerListener());

// Rest of your stuff

static class ViewHolder extends AutoDisposeViewHolder {
    // Stuff
}
```

-----

The test is a bit wonky. See the doc on the `AutoDisposeViewHolderTest` class for details.

-----

For review - I recommend reviewing commit by commit. Read them in order, leave comments, etc. Each is pretty isolated and digestible, then at the end you can approve/request changes as needed (approval/request changes is _not_ per-commit).