### PR TITLE
Add mavencentral badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,13 +162,18 @@ Download
 --------
 
 Java:
+
+[![Maven Central](https://img.shields.io/maven-central/v/com.uber.autodispose/autodispose.svg)](https://mvnrepository.com/artifact/com.uber.autodispose/autodispose)
+
 ```gradle
-compile 'com.uber.autodispose:autodispose:0.1.0'
+compile 'com.uber.autodispose:autodispose:x.y.z'
 ```
 
 Android extensions:
+
+[![Maven Central](https://img.shields.io/maven-central/v/com.uber.autodispose/autodispose-android.svg)](https://mvnrepository.com/artifact/com.uber.autodispose/autodispose-android)
 ```gradle
-compile 'com.uber.autodispose:autodispose-android:0.1.0'
+compile 'com.uber.autodispose:autodispose-android:x.y.z'
 ```
 
 Kotlin extensions (coming soon):


### PR DESCRIPTION
This makes it so the current version is always listed with a link to the artifact details, and we don't have to manually update the README to always point to the same version.

Looks like this

<img width="930" alt="screen shot 2017-03-20 at 12 55 23 pm" src="https://cloud.githubusercontent.com/assets/1361086/24118863/8b11a92a-0d6c-11e7-878f-0fdc8acf31ee.png">
