### PR TITLE
Add plugin API for handling OutsideLifecycleExceptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ public interface ScopeProvider {
 This is particularly useful for objects with simple scopes ("stop when I stop") or very custom state
 that requires custom handling.
 
+#### Plugins
+
+When a lifecycle has not started or has already ended, `AutoDispose` will send an error event with an
+ `OutsideLifecycleException` to downstream consumers. If you want to customize this behavior, you can use 
+ `AutoDisposePlugins` to intercept these exceptions and rethrow something else or nothing at all.
+
 ### Behavior
 
 The created observer encapsulates the parameters of `around` to create a disposable, auto-disposing

--- a/autodispose-android/src/androidTest/java/com/uber/autodispose/android/RecordingObserver.java
+++ b/autodispose-android/src/androidTest/java/com/uber/autodispose/android/RecordingObserver.java
@@ -133,14 +133,14 @@ public final class RecordingObserver<T>
     }
   }
 
-  private final class OnCompleted {
+  private static final class OnCompleted {
     @Override
     public String toString() {
       return "OnCompleted";
     }
   }
 
-  private final class OnError {
+  private static final class OnError {
     private final Throwable throwable;
 
     private OnError(Throwable throwable) {
@@ -153,7 +153,7 @@ public final class RecordingObserver<T>
     }
   }
 
-  private final class OnSubscribe {
+  private static final class OnSubscribe {
     private final Disposable disposable;
 
     private OnSubscribe(Disposable disposable) {

--- a/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
+++ b/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
@@ -27,7 +27,6 @@ import com.uber.autodispose.OutsideLifecycleException;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.subjects.PublishSubject;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -87,7 +86,7 @@ import static com.google.common.truth.Truth.assertThat;
     d.dispose();
   }
 
-  @Test @Ignore("Temporarily ignored until https://github.com/uber/AutoDispose/issues/67")
+  @Test
   public void observable_offMainThread_shouldFail() {
     RecordingObserver<Integer> o = new RecordingObserver<>();
     PublishSubject<Integer> subject = PublishSubject.create();

--- a/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
+++ b/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
@@ -27,6 +27,7 @@ import com.uber.autodispose.OutsideLifecycleException;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.subjects.PublishSubject;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -86,7 +87,8 @@ import static com.google.common.truth.Truth.assertThat;
     d.dispose();
   }
 
-  @Test public void observable_offMainThread_shouldFail() {
+  @Test @Ignore("Temporarily ignored until https://github.com/uber/AutoDispose/issues/67")
+  public void observable_offMainThread_shouldFail() {
     RecordingObserver<Integer> o = new RecordingObserver<>();
     PublishSubject<Integer> subject = PublishSubject.create();
 

--- a/autodispose-android/src/main/java/com/uber/autodispose/android/ViewAttachEventsObservable.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/ViewAttachEventsObservable.java
@@ -38,6 +38,7 @@ final class ViewAttachEventsObservable extends Observable<ViewLifecycleEvent> {
   @Override protected void subscribeActual(Observer<? super ViewLifecycleEvent> observer) {
     if (!isMainThread()) {
       observer.onError(new IllegalStateException("Views can only be bound to on the main thread!"));
+      return;
     }
 
     if (AutoDisposeAndroidUtil.isAttached(view)) {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposableHelper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposableHelper.java
@@ -75,6 +75,19 @@ enum AutoDisposableHelper implements Disposable {
   }
 
   /**
+   * Atomically sets the field to the given non-null Disposable and returns true
+   * or returns false if the field is non-null.
+   *
+   * @param field the target field
+   * @param d the disposable to set, not null
+   * @return true if the operation succeeded, false
+   */
+  static boolean setIfNotSet(AtomicReference<Disposable> field, Disposable d) {
+    AutoDisposeUtil.checkNotNull(d, "d is null");
+    return field.compareAndSet(null, d);
+  }
+
+  /**
    * Atomically replaces the Disposable in the field with the given new Disposable
    * but does not dispose the old one.
    *

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
@@ -24,10 +24,10 @@ import io.reactivex.plugins.RxJavaPlugins;
 /**
  * Utility class to inject handlers to certain standard AutoDispose operations.
  */
-public class AutoDisposePlugins {
+public final class AutoDisposePlugins {
 
     @Nullable
-    static volatile Consumer<? super OutsideLifecycleException> outsideLifecycleHandler;
+    private static volatile Consumer<? super OutsideLifecycleException> outsideLifecycleHandler;
 
     /**
      * Prevents changing the plugins.
@@ -36,7 +36,8 @@ public class AutoDisposePlugins {
 
     /**
      * Prevents changing the plugins from then on.
-     * <p>This allows container-like environments to prevent client messing with plugins.</p>
+     *
+     * This allows container-like environments to prevent client messing with plugins.
      */
     public static void lockdown() {
         lockdown = true;
@@ -67,30 +68,6 @@ public class AutoDisposePlugins {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
         outsideLifecycleHandler = handler;
-    }
-
-    /**
-     * Called when an outside lifecycle error occurs.
-     * @param error the error to report
-     */
-    public static void onOutsideLifecycleException(@NonNull OutsideLifecycleException error) {
-        Consumer<? super  OutsideLifecycleException> f = outsideLifecycleHandler;
-
-        if (error == null) {
-            RxJavaPlugins.onError(
-                    new NullPointerException("onOutsideLifecycleException called with null. Null values are generally "
-                    + "not allowed in 2.x operators and sources.")
-            );
-        }
-
-        if (f != null) {
-            try {
-                f.accept(error);
-                return;
-            } catch (Throwable e) {
-                RxJavaPlugins.onError(e);
-            }
-        }
     }
 
     /**

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose;
+
+import io.reactivex.annotations.NonNull;
+import io.reactivex.annotations.Nullable;
+import io.reactivex.functions.Consumer;
+import io.reactivex.plugins.RxJavaPlugins;
+
+/**
+ * Utility class to inject handlers to certain standard AutoDispose operations.
+ */
+public class AutoDisposePlugins {
+
+    @Nullable
+    static volatile Consumer<? super OutsideLifecycleException> outsideLifecycleHandler;
+
+    /**
+     * Prevents changing the plugins.
+     */
+    static volatile boolean lockdown;
+
+    /**
+     * Prevents changing the plugins from then on.
+     * <p>This allows container-like environments to prevent client messing with plugins.</p>
+     */
+    public static void lockdown() {
+        lockdown = true;
+    }
+
+    /**
+     * Returns true if the plugins were locked down.
+     *
+     * @return true if the plugins were locked down
+     */
+    public static boolean isLockdown() {
+        return lockdown;
+    }
+
+    /**
+     * @return the consumer for handling {@link OutsideLifecycleException}.
+     */
+    @Nullable
+    public static Consumer<? super OutsideLifecycleException> getOutsideLifecycleHandler() {
+        return outsideLifecycleHandler;
+    }
+
+    /**
+     * @param handler the consumer for handling {@link OutsideLifecycleException} to set, null allowed
+     */
+    public static void setOutsideLifecycleHandler(@Nullable Consumer<? super OutsideLifecycleException> handler) {
+        if (lockdown) {
+            throw new IllegalStateException("Plugins can't be changed anymore");
+        }
+        outsideLifecycleHandler = handler;
+    }
+
+    /**
+     * Called when an outside lifecycle error occurs.
+     * @param error the error to report
+     */
+    public static void onOutsideLifecycleException(@NonNull OutsideLifecycleException error) {
+        Consumer<? super  OutsideLifecycleException> f = outsideLifecycleHandler;
+
+        if (error == null) {
+            RxJavaPlugins.onError(
+                    new NullPointerException("onOutsideLifecycleException called with null. Null values are generally "
+                    + "not allowed in 2.x operators and sources.")
+            );
+        }
+
+        if (f != null) {
+            try {
+                f.accept(error);
+                return;
+            } catch (Throwable e) {
+                RxJavaPlugins.onError(e);
+            }
+        }
+    }
+
+    /**
+     * Removes all handlers and resets to default behavior.
+     */
+    public static void reset() {
+        setOutsideLifecycleHandler(null);
+    }
+}

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
@@ -16,64 +16,65 @@
 
 package com.uber.autodispose;
 
-import io.reactivex.annotations.NonNull;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.functions.Consumer;
-import io.reactivex.plugins.RxJavaPlugins;
 
 /**
  * Utility class to inject handlers to certain standard AutoDispose operations.
  */
 public final class AutoDisposePlugins {
 
-    @Nullable
-    private static volatile Consumer<? super OutsideLifecycleException> outsideLifecycleHandler;
+  private AutoDisposePlugins() { }
 
-    /**
-     * Prevents changing the plugins.
-     */
-    static volatile boolean lockdown;
+  @Nullable
+  private static volatile Consumer<? super OutsideLifecycleException> outsideLifecycleHandler;
 
-    /**
-     * Prevents changing the plugins from then on.
-     *
-     * This allows container-like environments to prevent client messing with plugins.
-     */
-    public static void lockdown() {
-        lockdown = true;
+  /**
+   * Prevents changing the plugins.
+   */
+  static volatile boolean lockdown;
+
+  /**
+   * Prevents changing the plugins from then on.
+   * <p>
+   * This allows container-like environments to prevent client messing with plugins.
+   */
+  public static void lockdown() {
+    lockdown = true;
+  }
+
+  /**
+   * Returns true if the plugins were locked down.
+   *
+   * @return true if the plugins were locked down
+   */
+  public static boolean isLockdown() {
+    return lockdown;
+  }
+
+  /**
+   * @return the consumer for handling {@link OutsideLifecycleException}.
+   */
+  @Nullable
+  public static Consumer<? super OutsideLifecycleException> getOutsideLifecycleHandler() {
+    return outsideLifecycleHandler;
+  }
+
+  /**
+   * @param handler the consumer for handling {@link OutsideLifecycleException} to set, null allowed
+   */
+  public static void setOutsideLifecycleHandler(
+          @Nullable Consumer<? super OutsideLifecycleException> handler) {
+    if (lockdown) {
+      throw new IllegalStateException("Plugins can't be changed anymore");
     }
+    outsideLifecycleHandler = handler;
+  }
 
-    /**
-     * Returns true if the plugins were locked down.
-     *
-     * @return true if the plugins were locked down
-     */
-    public static boolean isLockdown() {
-        return lockdown;
-    }
-
-    /**
-     * @return the consumer for handling {@link OutsideLifecycleException}.
-     */
-    @Nullable
-    public static Consumer<? super OutsideLifecycleException> getOutsideLifecycleHandler() {
-        return outsideLifecycleHandler;
-    }
-
-    /**
-     * @param handler the consumer for handling {@link OutsideLifecycleException} to set, null allowed
-     */
-    public static void setOutsideLifecycleHandler(@Nullable Consumer<? super OutsideLifecycleException> handler) {
-        if (lockdown) {
-            throw new IllegalStateException("Plugins can't be changed anymore");
-        }
-        outsideLifecycleHandler = handler;
-    }
-
-    /**
-     * Removes all handlers and resets to default behavior.
-     */
-    public static void reset() {
-        setOutsideLifecycleHandler(null);
-    }
+  /**
+   * Removes all handlers and resets to default behavior.
+   */
+  public static void reset() {
+    setOutsideLifecycleHandler(null);
+  }
 }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
@@ -21,6 +21,7 @@ import io.reactivex.Maybe;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
+import io.reactivex.functions.BiConsumer;
 import io.reactivex.functions.Consumer;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -36,9 +37,14 @@ final class AutoDisposingObserverImpl<T> implements AutoDisposingObserver<T> {
     this.delegate = delegate;
   }
 
-  @Override public void onSubscribe(Disposable d) {
+  @Override public void onSubscribe(final Disposable d) {
     if (AutoDisposableHelper.setOnce(lifecycleDisposable,
-        lifecycle.subscribe(new Consumer<Object>() {
+        lifecycle.doOnEvent(new BiConsumer<Object, Throwable>() {
+          @Override
+          public void accept(Object o, Throwable throwable) throws Exception {
+            callMainSubscribeIfNecessary(d);
+          }
+        }).subscribe(new Consumer<Object>() {
           @Override public void accept(Object o) throws Exception {
             dispose();
           }
@@ -60,7 +66,6 @@ final class AutoDisposingObserverImpl<T> implements AutoDisposingObserver<T> {
   @Override public void dispose() {
     synchronized (this) {
       AutoDisposableHelper.dispose(lifecycleDisposable);
-      callMainSubscribeIfNecessary();
       AutoDisposableHelper.dispose(mainDisposable);
     }
   }
@@ -68,16 +73,15 @@ final class AutoDisposingObserverImpl<T> implements AutoDisposingObserver<T> {
   private void lazyDispose() {
     synchronized (this) {
       AutoDisposableHelper.dispose(lifecycleDisposable);
-      callMainSubscribeIfNecessary();
       mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
     }
   }
 
-  private void callMainSubscribeIfNecessary() {
+  private void callMainSubscribeIfNecessary(Disposable d) {
     // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
     // onSubscribe and had a terminal event), we need to still send an empty disposable instance
     // to abide by the Observer contract.
-    if (mainDisposable.get() == null) {
+    if (AutoDisposableHelper.setIfNotSet(mainDisposable, d)) {
       delegate.onSubscribe(Disposables.disposed());
     }
   }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
@@ -21,6 +21,7 @@ import io.reactivex.Maybe;
 import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
+import io.reactivex.functions.BiConsumer;
 import io.reactivex.functions.Consumer;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -36,9 +37,14 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
     this.delegate = delegate;
   }
 
-  @Override public void onSubscribe(Disposable d) {
+  @Override public void onSubscribe(final Disposable d) {
     if (AutoDisposableHelper.setOnce(lifecycleDisposable,
-        lifecycle.subscribe(new Consumer<Object>() {
+        lifecycle.doOnEvent(new BiConsumer<Object, Throwable>() {
+          @Override
+          public void accept(Object o, Throwable throwable) throws Exception {
+            callMainSubscribeIfNecessary(d);
+          }
+        }).subscribe(new Consumer<Object>() {
           @Override public void accept(Object o) throws Exception {
             dispose();
           }
@@ -60,7 +66,6 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
   @Override public void dispose() {
     synchronized (this) {
       AutoDisposableHelper.dispose(lifecycleDisposable);
-      callMainSubscribeIfNecessary();
       AutoDisposableHelper.dispose(mainDisposable);
     }
   }
@@ -68,16 +73,15 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
   private void lazyDispose() {
     synchronized (this) {
       AutoDisposableHelper.dispose(lifecycleDisposable);
-      callMainSubscribeIfNecessary();
       mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
     }
   }
 
-  private void callMainSubscribeIfNecessary() {
+  private void callMainSubscribeIfNecessary(Disposable d) {
     // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
     // onSubscribe and had a terminal event), we need to still send an empty disposable instance
     // to abide by the Observer contract.
-    if (mainDisposable.get() == null) {
+    if (AutoDisposableHelper.setIfNotSet(mainDisposable, d)) {
       delegate.onSubscribe(Disposables.disposed());
     }
   }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoSubscriptionHelper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoSubscriptionHelper.java
@@ -153,6 +153,19 @@ enum AutoSubscriptionHelper implements Subscription {
   }
 
   /**
+   * Atomically sets the field to the given non-null Subscription and returns true
+   * or returns false if the field is non-null.
+   *
+   * @param field the target field
+   * @param s the subscription to set, not null
+   * @return true if the operation succeeded, false
+   */
+  static boolean setIfNotSet(AtomicReference<Subscription> field, Subscription s) {
+    AutoDisposeUtil.checkNotNull(s, "s is null");
+    return field.compareAndSet(null, s);
+  }
+
+  /**
    * Atomically sets the subscription on the field but does not
    * cancel the previous subscription.
    *

--- a/autodispose/src/main/java/com/uber/autodispose/ScopeUtil.java
+++ b/autodispose/src/main/java/com/uber/autodispose/ScopeUtil.java
@@ -76,8 +76,9 @@ public final class ScopeUtil {
         E lastEvent = provider.peekLifecycle();
         if (checkStartBoundary && lastEvent == null) {
           LifecycleNotStartedException exception = new LifecycleNotStartedException();
-          if (AutoDisposePlugins.outsideLifecycleHandler != null) {
-            AutoDisposePlugins.outsideLifecycleHandler.accept(exception);
+          if (AutoDisposePlugins.getOutsideLifecycleHandler() != null) {
+            AutoDisposePlugins.getOutsideLifecycleHandler().accept(exception);
+            return Maybe.just(LifecycleEndNotification.INSTANCE);
           } else {
             throw exception;
           }
@@ -88,9 +89,9 @@ public final class ScopeUtil {
               .apply(lastEvent);
         } catch (Exception e) {
           if (checkEndBoundary && e instanceof LifecycleEndedException) {
-            if (AutoDisposePlugins.outsideLifecycleHandler != null) {
-              AutoDisposePlugins.outsideLifecycleHandler.accept((LifecycleEndedException) e);
-              return Maybe.empty();
+            if (AutoDisposePlugins.getOutsideLifecycleHandler() != null) {
+              AutoDisposePlugins.getOutsideLifecycleHandler().accept((LifecycleEndedException) e);
+              return Maybe.just(LifecycleEndNotification.INSTANCE);
             } else {
               throw e;
             }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -218,7 +218,7 @@ public class AutoDisposeCompletableObserverTest {
     CompletableSubject source = CompletableSubject.create();
     source
             .to(new CompletableScoper(provider))
-            .subscribeWith(o);
+            .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
     assertThat(lifecycle.hasObservers()).isFalse();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -20,10 +20,16 @@ import io.reactivex.Completable;
 import io.reactivex.CompletableEmitter;
 import io.reactivex.CompletableOnSubscribe;
 import io.reactivex.functions.Cancellable;
+import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Predicate;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.CompletableSubject;
 import io.reactivex.subjects.MaybeSubject;
+
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -31,6 +37,10 @@ import static com.uber.autodispose.TestUtil.makeLifecycleProvider;
 import static com.uber.autodispose.TestUtil.makeProvider;
 
 public class AutoDisposeCompletableObserverTest {
+
+  @After public void resetPlugins() {
+    AutoDisposePlugins.reset();
+  }
 
   @Test public void autoDispose_withMaybe_normal() {
     RecordingObserver<Integer> o = new RecordingObserver<>();
@@ -195,6 +205,76 @@ public class AutoDisposeCompletableObserverTest {
 
     o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
+  }
+
+  @Test public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception { }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
+    TestObserver<Integer> o = new TestObserver<>();
+    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
+    CompletableSubject source = CompletableSubject.create();
+    source
+            .to(new CompletableScoper(provider))
+            .subscribeWith(o);
+
+    assertThat(source.hasObservers()).isFalse();
+    assertThat(lifecycle.hasObservers()).isFalse();
+    o.assertNoValues();
+    o.assertNoErrors();
+  }
+
+  @Test public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
+        // Noop
+      }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
+    lifecycle.onNext(1);
+    lifecycle.onNext(2);
+    lifecycle.onNext(3);
+    TestObserver<Integer> o = new TestObserver<>();
+    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
+    CompletableSubject source = CompletableSubject.create();
+    source
+            .to(new CompletableScoper(provider))
+            .subscribe(o);
+
+    assertThat(source.hasObservers()).isFalse();
+    assertThat(lifecycle.hasObservers()).isFalse();
+    o.assertNoValues();
+    o.assertNoErrors();
+  }
+
+  @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithWrappedExp() {
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
+        // Wrap in an IllegalStateException so we can verify this is the exception we see on the
+        // other side
+        throw new IllegalStateException(e);
+      }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
+    TestObserver<Integer> o = new TestObserver<>();
+    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
+    CompletableSubject source = CompletableSubject.create();
+    source
+            .to(new CompletableScoper(provider))
+            .subscribe(o);
+
+    o.assertNoValues();
+    o.assertError(new Predicate<Throwable>() {
+      @Override
+      public boolean test(Throwable throwable) throws Exception {
+        return throwable instanceof IllegalStateException
+                && throwable.getCause() instanceof OutsideLifecycleException;
+      }
+    });
   }
 
   @Test public void verifyCancellation() throws Exception {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -20,10 +20,13 @@ import io.reactivex.Completable;
 import io.reactivex.CompletableEmitter;
 import io.reactivex.CompletableOnSubscribe;
 import io.reactivex.functions.Cancellable;
+import io.reactivex.functions.Consumer;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.CompletableSubject;
 import io.reactivex.subjects.MaybeSubject;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -31,6 +34,10 @@ import static com.uber.autodispose.TestUtil.makeLifecycleProvider;
 import static com.uber.autodispose.TestUtil.makeProvider;
 
 public class AutoDisposeCompletableObserverTest {
+
+  @After public void resetPlugins() {
+    AutoDisposePlugins.reset();
+  }
 
   @Test public void autoDispose_withMaybe_normal() {
     RecordingObserver<Integer> o = new RecordingObserver<>();
@@ -182,6 +189,25 @@ public class AutoDisposeCompletableObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleNotStartedException.class);
   }
 
+  @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailPlugin() {
+    final RecordingObserver<OutsideLifecycleException> errorHandler = new RecordingObserver<>();
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
+        errorHandler.onNext(e);
+      }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
+    RecordingObserver<Integer> o = new RecordingObserver<>();
+    LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
+    Completable.complete()
+            .to(new CompletableScoper(provider))
+            .subscribe(o);
+
+    assertThat(o.takeSubscribe().isDisposed()).isTrue();
+    assertThat(errorHandler.takeNext()).isInstanceOf(LifecycleNotStartedException.class);
+  }
+
   @Test public void autoDispose_withLifecycleProvider_afterLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
@@ -195,6 +221,27 @@ public class AutoDisposeCompletableObserverTest {
 
     o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
+  }
+
+  @Test public void autoDispose_withProviderAndPlugin_afterLifecycle_shouldFailPlugin() {
+    final RecordingObserver<OutsideLifecycleException> errorHandler = new RecordingObserver<>();
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
+        errorHandler.onNext(e);
+      }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
+    lifecycle.onNext(1);
+    lifecycle.onNext(2);
+    lifecycle.onNext(3);
+    RecordingObserver<Integer> o = new RecordingObserver<>();
+    LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
+    Completable.complete()
+            .to(new CompletableScoper(provider))
+            .subscribe(o);
+
+    assertThat(o.takeSubscribe().isDisposed()).isTrue();
   }
 
   @Test public void verifyCancellation() throws Exception {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -20,13 +20,10 @@ import io.reactivex.Completable;
 import io.reactivex.CompletableEmitter;
 import io.reactivex.CompletableOnSubscribe;
 import io.reactivex.functions.Cancellable;
-import io.reactivex.functions.Consumer;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.CompletableSubject;
 import io.reactivex.subjects.MaybeSubject;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.After;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -34,10 +31,6 @@ import static com.uber.autodispose.TestUtil.makeLifecycleProvider;
 import static com.uber.autodispose.TestUtil.makeProvider;
 
 public class AutoDisposeCompletableObserverTest {
-
-  @After public void resetPlugins() {
-    AutoDisposePlugins.reset();
-  }
 
   @Test public void autoDispose_withMaybe_normal() {
     RecordingObserver<Integer> o = new RecordingObserver<>();
@@ -189,25 +182,6 @@ public class AutoDisposeCompletableObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleNotStartedException.class);
   }
 
-  @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailPlugin() {
-    final RecordingObserver<OutsideLifecycleException> errorHandler = new RecordingObserver<>();
-    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override
-      public void accept(OutsideLifecycleException e) throws Exception {
-        errorHandler.onNext(e);
-      }
-    });
-    BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
-    RecordingObserver<Integer> o = new RecordingObserver<>();
-    LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    Completable.complete()
-            .to(new CompletableScoper(provider))
-            .subscribe(o);
-
-    assertThat(o.takeSubscribe().isDisposed()).isTrue();
-    assertThat(errorHandler.takeNext()).isInstanceOf(LifecycleNotStartedException.class);
-  }
-
   @Test public void autoDispose_withLifecycleProvider_afterLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
@@ -221,27 +195,6 @@ public class AutoDisposeCompletableObserverTest {
 
     o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
-  }
-
-  @Test public void autoDispose_withProviderAndPlugin_afterLifecycle_shouldFailPlugin() {
-    final RecordingObserver<OutsideLifecycleException> errorHandler = new RecordingObserver<>();
-    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override
-      public void accept(OutsideLifecycleException e) throws Exception {
-        errorHandler.onNext(e);
-      }
-    });
-    BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
-    lifecycle.onNext(1);
-    lifecycle.onNext(2);
-    lifecycle.onNext(3);
-    RecordingObserver<Integer> o = new RecordingObserver<>();
-    LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    Completable.complete()
-            .to(new CompletableScoper(provider))
-            .subscribe(o);
-
-    assertThat(o.takeSubscribe().isDisposed()).isTrue();
   }
 
   @Test public void verifyCancellation() throws Exception {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -25,8 +25,6 @@ import io.reactivex.functions.Consumer;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.After;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -34,10 +32,6 @@ import static com.uber.autodispose.TestUtil.makeLifecycleProvider;
 import static com.uber.autodispose.TestUtil.makeProvider;
 
 public class AutoDisposeMaybeObserverTest {
-
-  @After public void resetPlugins() {
-    AutoDisposePlugins.reset();
-  }
 
   @Test public void autoDispose_withMaybe_normal() {
     RecordingObserver<Integer> o = new RecordingObserver<>();
@@ -236,25 +230,6 @@ public class AutoDisposeMaybeObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleNotStartedException.class);
   }
 
-  @Test public void autoDispose_withLifecycleAndPlugin_withoutStarting_shouldFailPlugin() {
-    final RecordingObserver<OutsideLifecycleException> errorHandler = new RecordingObserver<>();
-    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override
-      public void accept(OutsideLifecycleException e) throws Exception {
-        errorHandler.onNext(e);
-      }
-    });
-    BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
-    RecordingObserver<Integer> o = new RecordingObserver<>();
-    LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    Maybe.just(1)
-            .to(new MaybeScoper<Integer>(provider))
-            .subscribe(o);
-
-    assertThat(o.takeSubscribe().isDisposed()).isTrue();
-    assertThat(errorHandler.takeNext()).isInstanceOf(LifecycleNotStartedException.class);
-  }
-
   @Test public void autoDispose_withLifecycleProvider_afterLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
@@ -268,28 +243,6 @@ public class AutoDisposeMaybeObserverTest {
 
     o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
-  }
-
-  @Test public void autoDispose_withLifecycleAndPlugin_afterLifecycle_shouldFailPlugin() {
-    final RecordingObserver<OutsideLifecycleException> errorHandler = new RecordingObserver<>();
-    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override
-      public void accept(OutsideLifecycleException e) throws Exception {
-        errorHandler.onNext(e);
-      }
-    });
-    BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
-    lifecycle.onNext(1);
-    lifecycle.onNext(2);
-    lifecycle.onNext(3);
-    RecordingObserver<Integer> o = new RecordingObserver<>();
-    LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    Maybe.just(1)
-            .to(new MaybeScoper<Integer>(provider))
-            .subscribe(o);
-
-    assertThat(o.takeSubscribe().isDisposed()).isTrue();
-    assertThat(errorHandler.takeNext()).isInstanceOf(LifecycleEndedException.class);
   }
 
   @Test public void verifyCancellation() throws Exception {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -265,7 +265,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     source
             .to(new MaybeScoper<Integer>(provider))
-            .subscribeWith(o);
+            .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
     assertThat(lifecycle.hasObservers()).isFalse();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -29,17 +29,11 @@ import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subjects.PublishSubject;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.After;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 
 public class AutoDisposeObserverTest {
-
-  @After public void resetPlugins() {
-    AutoDisposePlugins.reset();
-  }
 
   @Test public void autoDispose_withMaybe_normal() {
     TestObserver<Integer> o = new TestObserver<>();
@@ -172,25 +166,6 @@ public class AutoDisposeObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleNotStartedException.class);
   }
 
-  @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailPlugin() {
-    final RecordingObserver<OutsideLifecycleException> errorHandler = new RecordingObserver<>();
-    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override
-      public void accept(OutsideLifecycleException e) throws Exception {
-        errorHandler.onNext(e);
-      }
-    });
-    BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
-    RecordingObserver<Integer> o = new RecordingObserver<>();
-    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
-    Observable.just(1)
-            .to(new ObservableScoper<Integer>(provider))
-            .subscribe(o);
-
-    assertThat(o.takeSubscribe().isDisposed()).isTrue();
-    assertThat(errorHandler.takeNext()).isInstanceOf(LifecycleNotStartedException.class);
-  }
-
   @Test public void autoDispose_withProvider_afterLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
@@ -204,28 +179,6 @@ public class AutoDisposeObserverTest {
 
     o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
-  }
-
-  @Test public void autoDispose_withProviderAndPlugin_afterLifecycle_shouldFailPlugin() {
-    final RecordingObserver<OutsideLifecycleException> errorHandler = new RecordingObserver<>();
-    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override
-      public void accept(OutsideLifecycleException e) throws Exception {
-        errorHandler.onNext(e);
-      }
-    });
-    BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
-    lifecycle.onNext(1);
-    lifecycle.onNext(2);
-    lifecycle.onNext(3);
-    RecordingObserver<Integer> o = new RecordingObserver<>();
-    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
-    Observable.just(1)
-            .to(new ObservableScoper<Integer>(provider))
-            .subscribe(o);
-
-    assertThat(o.takeSubscribe().isDisposed()).isTrue();
-    assertThat(errorHandler.takeNext()).isInstanceOf(LifecycleEndedException.class);
   }
 
   @Test public void verifyCancellation() throws Exception {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -24,16 +24,23 @@ import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Predicate;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subjects.PublishSubject;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 
 public class AutoDisposeObserverTest {
+
+  @After public void resetPlugins() {
+    AutoDisposePlugins.reset();
+  }
 
   @Test public void autoDispose_withMaybe_normal() {
     TestObserver<Integer> o = new TestObserver<>();
@@ -179,6 +186,76 @@ public class AutoDisposeObserverTest {
 
     o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
+  }
+
+  @Test public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+        public void accept(OutsideLifecycleException e) throws Exception { }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
+    TestObserver<Integer> o = new TestObserver<>();
+    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
+    PublishSubject<Integer> source = PublishSubject.create();
+    source
+      .to(new ObservableScoper<Integer>(provider))
+      .subscribeWith(o);
+
+    assertThat(source.hasObservers()).isFalse();
+    assertThat(lifecycle.hasObservers()).isFalse();
+    o.assertNoValues();
+    o.assertNoErrors();
+  }
+
+  @Test public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
+        // Noop
+      }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
+    lifecycle.onNext(1);
+    lifecycle.onNext(2);
+    lifecycle.onNext(3);
+    TestObserver<Integer> o = new TestObserver<>();
+    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
+    PublishSubject<Integer> source = PublishSubject.create();
+    source
+      .to(new ObservableScoper<Integer>(provider))
+      .subscribe(o);
+
+    assertThat(source.hasObservers()).isFalse();
+    assertThat(lifecycle.hasObservers()).isFalse();
+    o.assertNoValues();
+    o.assertNoErrors();
+  }
+
+  @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithExp() {
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
+        // Wrap in an IllegalStateException so we can verify this is the exception we see on the
+        // other side
+        throw new IllegalStateException(e);
+      }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
+    TestObserver<Integer> o = new TestObserver<>();
+    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
+    PublishSubject<Integer> source = PublishSubject.create();
+    source
+      .to(new ObservableScoper<Integer>(provider))
+      .subscribe(o);
+
+    o.assertNoValues();
+    o.assertError(new Predicate<Throwable>() {
+      @Override
+      public boolean test(Throwable throwable) throws Exception {
+        return throwable instanceof IllegalStateException
+                && throwable.getCause() instanceof OutsideLifecycleException;
+      }
+    });
   }
 
   @Test public void verifyCancellation() throws Exception {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -29,11 +29,17 @@ import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subjects.PublishSubject;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 
 public class AutoDisposeObserverTest {
+
+  @After public void resetPlugins() {
+    AutoDisposePlugins.reset();
+  }
 
   @Test public void autoDispose_withMaybe_normal() {
     TestObserver<Integer> o = new TestObserver<>();
@@ -166,6 +172,25 @@ public class AutoDisposeObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleNotStartedException.class);
   }
 
+  @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailPlugin() {
+    final RecordingObserver<OutsideLifecycleException> errorHandler = new RecordingObserver<>();
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
+        errorHandler.onNext(e);
+      }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
+    RecordingObserver<Integer> o = new RecordingObserver<>();
+    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
+    Observable.just(1)
+            .to(new ObservableScoper<Integer>(provider))
+            .subscribe(o);
+
+    assertThat(o.takeSubscribe().isDisposed()).isTrue();
+    assertThat(errorHandler.takeNext()).isInstanceOf(LifecycleNotStartedException.class);
+  }
+
   @Test public void autoDispose_withProvider_afterLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
@@ -179,6 +204,28 @@ public class AutoDisposeObserverTest {
 
     o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
+  }
+
+  @Test public void autoDispose_withProviderAndPlugin_afterLifecycle_shouldFailPlugin() {
+    final RecordingObserver<OutsideLifecycleException> errorHandler = new RecordingObserver<>();
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
+        errorHandler.onNext(e);
+      }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
+    lifecycle.onNext(1);
+    lifecycle.onNext(2);
+    lifecycle.onNext(3);
+    RecordingObserver<Integer> o = new RecordingObserver<>();
+    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
+    Observable.just(1)
+            .to(new ObservableScoper<Integer>(provider))
+            .subscribe(o);
+
+    assertThat(o.takeSubscribe().isDisposed()).isTrue();
+    assertThat(errorHandler.takeNext()).isInstanceOf(LifecycleEndedException.class);
   }
 
   @Test public void verifyCancellation() throws Exception {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -199,7 +199,7 @@ public class AutoDisposeObserverTest {
     PublishSubject<Integer> source = PublishSubject.create();
     source
       .to(new ObservableScoper<Integer>(provider))
-      .subscribeWith(o);
+      .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
     assertThat(lifecycle.hasObservers()).isFalse();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -23,10 +23,14 @@ import io.reactivex.SingleOnSubscribe;
 import io.reactivex.annotations.NonNull;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Predicate;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subjects.SingleSubject;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -34,6 +38,10 @@ import static com.uber.autodispose.TestUtil.makeLifecycleProvider;
 import static com.uber.autodispose.TestUtil.makeProvider;
 
 public class AutoDisposeSingleObserverTest {
+
+  @After public void resetPlugins() {
+    AutoDisposePlugins.reset();
+  }
 
   @Test public void autoDispose_withMaybe_normal() {
     RecordingObserver<Integer> o = new RecordingObserver<>();
@@ -214,6 +222,76 @@ public class AutoDisposeSingleObserverTest {
 
     o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
+  }
+
+  @Test public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception { }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
+    TestObserver<Integer> o = new TestObserver<>();
+    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
+    SingleSubject<Integer> source = SingleSubject.create();
+    source
+            .to(new SingleScoper<Integer>(provider))
+            .subscribeWith(o);
+
+    assertThat(source.hasObservers()).isFalse();
+    assertThat(lifecycle.hasObservers()).isFalse();
+    o.assertNoValues();
+    o.assertNoErrors();
+  }
+
+  @Test public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
+        // Noop
+      }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
+    lifecycle.onNext(1);
+    lifecycle.onNext(2);
+    lifecycle.onNext(3);
+    TestObserver<Integer> o = new TestObserver<>();
+    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
+    SingleSubject<Integer> source = SingleSubject.create();
+    source
+            .to(new SingleScoper<Integer>(provider))
+            .subscribe(o);
+
+    assertThat(source.hasObservers()).isFalse();
+    assertThat(lifecycle.hasObservers()).isFalse();
+    o.assertNoValues();
+    o.assertNoErrors();
+  }
+
+  @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithExp() {
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
+        // Wrap in an IllegalStateException so we can verify this is the exception we see on the
+        // other side
+        throw new IllegalStateException(e);
+      }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
+    TestObserver<Integer> o = new TestObserver<>();
+    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
+    SingleSubject<Integer> source = SingleSubject.create();
+    source
+            .to(new SingleScoper<Integer>(provider))
+            .subscribe(o);
+
+    o.assertNoValues();
+    o.assertError(new Predicate<Throwable>() {
+      @Override
+      public boolean test(Throwable throwable) throws Exception {
+        return throwable instanceof IllegalStateException
+                && throwable.getCause() instanceof OutsideLifecycleException;
+      }
+    });
   }
 
   @Test public void verifyCancellation() throws Exception {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -235,7 +235,7 @@ public class AutoDisposeSingleObserverTest {
     SingleSubject<Integer> source = SingleSubject.create();
     source
             .to(new SingleScoper<Integer>(provider))
-            .subscribeWith(o);
+            .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
     assertThat(lifecycle.hasObservers()).isFalse();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -27,6 +27,8 @@ import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subjects.SingleSubject;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -34,6 +36,10 @@ import static com.uber.autodispose.TestUtil.makeLifecycleProvider;
 import static com.uber.autodispose.TestUtil.makeProvider;
 
 public class AutoDisposeSingleObserverTest {
+
+  @After public void resetPlugins() {
+    AutoDisposePlugins.reset();
+  }
 
   @Test public void autoDispose_withMaybe_normal() {
     RecordingObserver<Integer> o = new RecordingObserver<>();
@@ -201,6 +207,25 @@ public class AutoDisposeSingleObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleNotStartedException.class);
   }
 
+  @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailPlugin() {
+    final RecordingObserver<OutsideLifecycleException> errorHandler = new RecordingObserver<>();
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
+        errorHandler.onNext(e);
+      }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
+    RecordingObserver<Integer> o = new RecordingObserver<>();
+    LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
+    Single.just(1)
+            .to(new SingleScoper<Integer>(provider))
+            .subscribe(o);
+
+    assertThat(o.takeSubscribe().isDisposed()).isTrue();
+    assertThat(errorHandler.takeNext()).isInstanceOf(LifecycleNotStartedException.class);
+  }
+
   @Test public void autoDispose_withProvider_afterLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
@@ -214,6 +239,28 @@ public class AutoDisposeSingleObserverTest {
 
     o.takeSubscribe();
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
+  }
+
+  @Test public void autoDispose_withProviderAndPlugin_afterLifecycle_shouldFail() {
+    final RecordingObserver<OutsideLifecycleException> errorHandler = new RecordingObserver<>();
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
+        errorHandler.onNext(e);
+      }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
+    lifecycle.onNext(1);
+    lifecycle.onNext(2);
+    lifecycle.onNext(3);
+    RecordingObserver<Integer> o = new RecordingObserver<>();
+    LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
+    Single.just(1)
+            .to(new SingleScoper<Integer>(provider))
+            .subscribe(o);
+
+    assertThat(o.takeSubscribe().isDisposed()).isTrue();
+    assertThat(errorHandler.takeNext()).isInstanceOf(LifecycleEndedException.class);
   }
 
   @Test public void verifyCancellation() throws Exception {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -213,7 +213,7 @@ public class AutoDisposeSubscriberTest {
     PublishProcessor<Integer> source = PublishProcessor.create();
     source
             .to(new FlowableScoper<Integer>(provider))
-            .subscribeWith(o);
+            .subscribe(o);
 
     assertThat(source.hasSubscribers()).isFalse();
     assertThat(lifecycle.hasObservers()).isFalse();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -25,17 +25,24 @@ import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;
+import io.reactivex.functions.Predicate;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 
 public class AutoDisposeSubscriberTest {
+
+  @After public void resetPlugins() {
+    AutoDisposePlugins.reset();
+  }
 
   @Test public void autoDispose_withMaybe_normal() {
     TestSubscriber<Integer> o = new TestSubscriber<>();
@@ -193,6 +200,76 @@ public class AutoDisposeSubscriberTest {
     List<Throwable> errors = o.errors();
     assertThat(errors).hasSize(1);
     assertThat(errors.get(0)).isInstanceOf(LifecycleEndedException.class);
+  }
+
+  @Test public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception { }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
+    TestSubscriber<Integer> o = new TestSubscriber<>();
+    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
+    PublishProcessor<Integer> source = PublishProcessor.create();
+    source
+            .to(new FlowableScoper<Integer>(provider))
+            .subscribeWith(o);
+
+    assertThat(source.hasSubscribers()).isFalse();
+    assertThat(lifecycle.hasObservers()).isFalse();
+    o.assertNoValues();
+    o.assertNoErrors();
+  }
+
+  @Test public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
+        // Noop
+      }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
+    lifecycle.onNext(1);
+    lifecycle.onNext(2);
+    lifecycle.onNext(3);
+    TestSubscriber<Integer> o = new TestSubscriber<>();
+    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
+    PublishProcessor<Integer> source = PublishProcessor.create();
+    source
+            .to(new FlowableScoper<Integer>(provider))
+            .subscribe(o);
+
+    assertThat(source.hasSubscribers()).isFalse();
+    assertThat(lifecycle.hasObservers()).isFalse();
+    o.assertNoValues();
+    o.assertNoErrors();
+  }
+
+  @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithExp() {
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
+        // Wrap in an IllegalStateException so we can verify this is the exception we see on the
+        // other side
+        throw new IllegalStateException(e);
+      }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
+    TestSubscriber<Integer> o = new TestSubscriber<>();
+    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
+    PublishProcessor<Integer> source = PublishProcessor.create();
+    source
+            .to(new FlowableScoper<Integer>(provider))
+            .subscribe(o);
+
+    o.assertNoValues();
+    o.assertError(new Predicate<Throwable>() {
+      @Override
+      public boolean test(Throwable throwable) throws Exception {
+        return throwable instanceof IllegalStateException
+                && throwable.getCause() instanceof OutsideLifecycleException;
+      }
+    });
   }
 
   @Test public void verifyCancellation() throws Exception {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -31,11 +31,17 @@ import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 
 public class AutoDisposeSubscriberTest {
+
+  @After public void resetPlugins() {
+    AutoDisposePlugins.reset();
+  }
 
   @Test public void autoDispose_withMaybe_normal() {
     TestSubscriber<Integer> o = new TestSubscriber<>();
@@ -179,6 +185,25 @@ public class AutoDisposeSubscriberTest {
     assertThat(errors.get(0)).isInstanceOf(LifecycleNotStartedException.class);
   }
 
+  @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailPlugin() {
+    final RecordingObserver<OutsideLifecycleException> errorHandler = new RecordingObserver<>();
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
+        errorHandler.onNext(e);
+      }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
+    TestSubscriber<Integer> o = new TestSubscriber<>();
+    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
+    Flowable.just(1)
+            .to(new FlowableScoper<Integer>(provider))
+            .subscribe(o);
+
+    o.assertNotSubscribed();
+    assertThat(errorHandler.takeNext()).isInstanceOf(LifecycleNotStartedException.class);
+  }
+
   @Test public void autoDispose_withProvider_afterLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
@@ -193,6 +218,28 @@ public class AutoDisposeSubscriberTest {
     List<Throwable> errors = o.errors();
     assertThat(errors).hasSize(1);
     assertThat(errors.get(0)).isInstanceOf(LifecycleEndedException.class);
+  }
+
+  @Test public void autoDispose_withProviderAndPlugin_afterLifecycle_shouldFailPlugin() {
+    final RecordingObserver<OutsideLifecycleException> errorHandler = new RecordingObserver<>();
+    AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
+        errorHandler.onNext(e);
+      }
+    });
+    BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
+    lifecycle.onNext(1);
+    lifecycle.onNext(2);
+    lifecycle.onNext(3);
+    TestSubscriber<Integer> o = new TestSubscriber<>();
+    LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
+    Flowable.just(1)
+            .to(new FlowableScoper<Integer>(provider))
+            .subscribe(o);
+
+    o.assertNotSubscribed();
+    assertThat(errorHandler.takeNext()).isInstanceOf(LifecycleEndedException.class);
   }
 
   @Test public void verifyCancellation() throws Exception {

--- a/autodispose/src/test/java/com/uber/autodispose/RecordingObserver.java
+++ b/autodispose/src/test/java/com/uber/autodispose/RecordingObserver.java
@@ -133,7 +133,7 @@ public final class RecordingObserver<T>
     }
   }
 
-  private final class OnError {
+  private static final class OnError {
     private final Throwable throwable;
 
     private OnError(Throwable throwable) {


### PR DESCRIPTION
(Addresses https://github.com/uber/AutoDispose/issues/52)

The API is very similar to RxJavaPlugins.

One thing I'm a bit concerned about here - if you're providing your own `ScopeProvider` or `LifecycleScopeProvider`, you need to either manually use `ScopeUtil` or manually call the plugin yourself before throwing anything. It would be nicer if AutoDispose does all of this for you.