### PR TITLE
Proposal - reintroduce static scoper factories

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -1,0 +1,74 @@
+package com.uber.autodispose;
+
+import io.reactivex.Maybe;
+import io.reactivex.annotations.Experimental;
+
+/**
+ * Static factories for creating new scopers.
+ */
+@Experimental public final class AutoDispose {
+
+  private AutoDispose() {
+    // No instances.
+  }
+
+  public static <T> ObservableScoper<T> observableScoper(Maybe<?> scope) {
+    return new ObservableScoper<>(scope);
+  }
+
+  public static <T> ObservableScoper<T> observableScoper(LifecycleScopeProvider<?> provider) {
+    return new ObservableScoper<>(provider);
+  }
+
+  public static <T> ObservableScoper<T> observableScoper(ScopeProvider provider) {
+    return new ObservableScoper<>(provider);
+  }
+
+  public static <T> FlowableScoper<T> flowableScoper(Maybe<?> scope) {
+    return new FlowableScoper<>(scope);
+  }
+
+  public static <T> FlowableScoper<T> flowableScoper(LifecycleScopeProvider<?> provider) {
+    return new FlowableScoper<>(provider);
+  }
+
+  public static <T> FlowableScoper<T> flowableScoper(ScopeProvider provider) {
+    return new FlowableScoper<>(provider);
+  }
+
+  public static <T> MaybeScoper<T> maybeScoper(Maybe<?> scope) {
+    return new MaybeScoper<>(scope);
+  }
+
+  public static <T> MaybeScoper<T> maybeScoper(LifecycleScopeProvider<?> provider) {
+    return new MaybeScoper<>(provider);
+  }
+
+  public static <T> MaybeScoper<T> maybeScoper(ScopeProvider provider) {
+    return new MaybeScoper<>(provider);
+  }
+
+  public static <T> SingleScoper<T> singleScoper(Maybe<?> scope) {
+    return new SingleScoper<>(scope);
+  }
+
+  public static <T> SingleScoper<T> singleScoper(LifecycleScopeProvider<?> provider) {
+    return new SingleScoper<>(provider);
+  }
+
+  public static <T> SingleScoper<T> singleScoper(ScopeProvider provider) {
+    return new SingleScoper<>(provider);
+  }
+
+  public static CompletableScoper completableScoper(Maybe<?> scope) {
+    return new CompletableScoper(scope);
+  }
+
+  public static CompletableScoper completableScoper(LifecycleScopeProvider<?> provider) {
+    return new CompletableScoper(provider);
+  }
+
+  public static CompletableScoper completableScoper(ScopeProvider provider) {
+    return new CompletableScoper(provider);
+  }
+}

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -39,7 +39,7 @@ public class AutoDisposeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     PublishSubject<Integer> source = PublishSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    Disposable d = source.to(new ObservableScoper<Integer>(lifecycle))
+    Disposable d = source.to(AutoDispose.<Integer>observableScoper(lifecycle))
         .subscribeWith(o);
     o.assertSubscribed();
 
@@ -60,7 +60,7 @@ public class AutoDisposeObserverTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Observable.just(new BClass())
-        .to(new ObservableScoper<AClass>(Maybe.never()))
+        .to(AutoDispose.<AClass>observableScoper(Maybe.never()))
         .subscribe(new Consumer<AClass>() {
           @Override public void accept(@NonNull AClass aClass) throws Exception {
 
@@ -70,7 +70,7 @@ public class AutoDisposeObserverTest {
 
   @Test public void autoDispose_noGenericsOnEmpty_isFine() {
     Observable.just(new BClass())
-        .to(new ObservableScoper<>(Maybe.never()))
+        .to(AutoDispose.observableScoper(Maybe.never()))
         .subscribe();
   }
 
@@ -78,7 +78,7 @@ public class AutoDisposeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>();
     PublishSubject<Integer> source = PublishSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(new ObservableScoper<Integer>(lifecycle))
+    source.to(AutoDispose.<Integer>observableScoper(lifecycle))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -100,7 +100,7 @@ public class AutoDisposeObserverTest {
     PublishSubject<Integer> source = PublishSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = TestUtil.makeProvider(scope);
-    source.to(new ObservableScoper<Integer>(provider))
+    source.to(AutoDispose.<Integer>observableScoper(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -129,7 +129,7 @@ public class AutoDisposeObserverTest {
     PublishSubject<Integer> source = PublishSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
-    source.to(new ObservableScoper<Integer>(provider))
+    source.to(AutoDispose.<Integer>observableScoper(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -159,7 +159,7 @@ public class AutoDisposeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     Observable.just(1)
-        .to(new ObservableScoper<Integer>(provider))
+        .to(AutoDispose.<Integer>observableScoper(provider))
         .subscribe(o);
 
     o.takeSubscribe();
@@ -174,7 +174,7 @@ public class AutoDisposeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     Observable.just(1)
-        .to(new ObservableScoper<Integer>(provider))
+        .to(AutoDispose.<Integer>observableScoper(provider))
         .subscribe(o);
 
     o.takeSubscribe();
@@ -196,7 +196,7 @@ public class AutoDisposeObserverTest {
       }
     });
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(new ObservableScoper<Integer>(lifecycle))
+    source.to(AutoDispose.<Integer>observableScoper(lifecycle))
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);


### PR DESCRIPTION
These don't autocomplete nicely, but they're sort of nicer to read in code. Want to put this up for discussion to see if there's interest in having them as an option (albeit `@Experimental`).

Now you'd do

```java
myObservable
    .to(AutoDipose.<Stuff>observableScoper(this)
    .subscribe()
```