### PR TITLE
Lower support annotations

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,7 +18,7 @@ def versions = [
     androidTest: '0.5',
     errorProne: '2.0.19',
     kotlin: '1.1.2',
-    support: '25.3.1'
+    support: '22.1.0'
 ]
 
 def build = [


### PR DESCRIPTION
This is the earliest official version I could find in the changelog. It's useful for a library to only maintain the minimum supported support library/sdk version since otherwise consumers have to do a bunch of suppression hackery.