### PR TITLE
Switch to provided jsr305 and nullability improvements

### DIFF
--- a/autodispose/build.gradle
+++ b/autodispose/build.gradle
@@ -36,6 +36,8 @@ test {
 dependencies {
   api deps.rx.java
   compileOnly deps.misc.errorProneAnnotations
+  compileOnly deps.misc.jsr305
+
   errorprone deps.build.errorProne
 
   testCompile deps.test.junit

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposableHelper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposableHelper.java
@@ -19,6 +19,7 @@ package com.uber.autodispose;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.plugins.RxJavaPlugins;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 
 /**
  * Utility methods for working with Disposables atomically. Copied from the RxJava implementation.
@@ -33,7 +34,7 @@ enum AutoDisposableHelper implements Disposable {
     return d == DISPOSED;
   }
 
-  static boolean set(AtomicReference<Disposable> field, Disposable d) {
+  static boolean set(AtomicReference<Disposable> field, @Nullable Disposable d) {
     for (; ; ) {
       Disposable current = field.get();
       if (current == DISPOSED) {
@@ -96,7 +97,7 @@ enum AutoDisposableHelper implements Disposable {
    * @return true if the operation succeeded, false if the target field contained
    * the common DISPOSED instance and the given disposable (if not null) is disposed.
    */
-  static boolean replace(AtomicReference<Disposable> field, Disposable d) {
+  static boolean replace(AtomicReference<Disposable> field, @Nullable Disposable d) {
     for (; ; ) {
       Disposable current = field.get();
       if (current == DISPOSED) {
@@ -140,7 +141,8 @@ enum AutoDisposableHelper implements Disposable {
    * @param next the next Disposable, expected to be non-null
    * @return true if the validation succeeded
    */
-  static boolean validate(Disposable current, Disposable next) {
+  static boolean validate(@Nullable Disposable current, Disposable next) {
+    //noinspection ConstantConditions leftover from original RxJava implementation
     if (next == null) {
       RxJavaPlugins.onError(new NullPointerException("next is null"));
       return false;

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
@@ -16,8 +16,8 @@
 
 package com.uber.autodispose;
 
-import io.reactivex.annotations.Nullable;
 import io.reactivex.functions.Consumer;
+import javax.annotation.Nullable;
 
 /**
  * Utility class to inject handlers to certain standard AutoDispose operations.

--- a/autodispose/src/main/java/com/uber/autodispose/AutoSubscriptionHelper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoSubscriptionHelper.java
@@ -19,6 +19,7 @@ package com.uber.autodispose;
 import io.reactivex.plugins.RxJavaPlugins;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 import org.reactivestreams.Subscription;
 
 /**
@@ -48,7 +49,8 @@ enum AutoSubscriptionHelper implements Subscription {
    * @param next the next Subscription, expected to be non-null
    * @return true if the validation succeeded
    */
-  static boolean validate(Subscription current, Subscription next) {
+  static boolean validate(@Nullable Subscription current, Subscription next) {
+    //noinspection ConstantConditions left as is from original RxJava implementation
     if (next == null) {
       RxJavaPlugins.onError(new NullPointerException("next is null"));
       return false;
@@ -113,7 +115,7 @@ enum AutoSubscriptionHelper implements Subscription {
    * holds the {@link #CANCELLED} instance.
    * @see #replace(AtomicReference, Subscription)
    */
-  static boolean set(AtomicReference<Subscription> field, Subscription s) {
+  static boolean set(AtomicReference<Subscription> field, @Nullable Subscription s) {
     for (; ; ) {
       Subscription current = field.get();
       if (current == CANCELLED) {
@@ -175,7 +177,7 @@ enum AutoSubscriptionHelper implements Subscription {
    * holds the {@link #CANCELLED} instance.
    * @see #set(AtomicReference, Subscription)
    */
-  static boolean replace(AtomicReference<Subscription> field, Subscription s) {
+  static boolean replace(AtomicReference<Subscription> field, @Nullable Subscription s) {
     for (; ; ) {
       Subscription current = field.get();
       if (current == CANCELLED) {

--- a/autodispose/src/main/java/com/uber/autodispose/LifecycleScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/LifecycleScopeProvider.java
@@ -18,8 +18,8 @@ package com.uber.autodispose;
 
 import io.reactivex.Observable;
 import io.reactivex.annotations.CheckReturnValue;
-import io.reactivex.annotations.Nullable;
 import io.reactivex.functions.Function;
+import javax.annotation.Nullable;
 
 /**
  * An interface that, when implemented, provides information to AutoDispose to allow it to resolve

--- a/autodispose/src/main/java/com/uber/autodispose/ScopeUtil.java
+++ b/autodispose/src/main/java/com/uber/autodispose/ScopeUtil.java
@@ -16,13 +16,13 @@
 
 package com.uber.autodispose;
 
-import java.util.concurrent.Callable;
-
 import io.reactivex.Maybe;
 import io.reactivex.MaybeSource;
 import io.reactivex.Observable;
+import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
 import io.reactivex.functions.Predicate;
+import java.util.concurrent.Callable;
 
 /**
  * Utilities for dealing with scopes, usually for providers. This includes factories for resolving
@@ -76,8 +76,10 @@ public final class ScopeUtil {
         E lastEvent = provider.peekLifecycle();
         if (checkStartBoundary && lastEvent == null) {
           LifecycleNotStartedException exception = new LifecycleNotStartedException();
-          if (AutoDisposePlugins.getOutsideLifecycleHandler() != null) {
-            AutoDisposePlugins.getOutsideLifecycleHandler().accept(exception);
+          Consumer<? super OutsideLifecycleException> handler
+              = AutoDisposePlugins.getOutsideLifecycleHandler();
+          if (handler != null) {
+            handler.accept(exception);
             return Maybe.just(LifecycleEndNotification.INSTANCE);
           } else {
             throw exception;
@@ -89,8 +91,10 @@ public final class ScopeUtil {
               .apply(lastEvent);
         } catch (Exception e) {
           if (checkEndBoundary && e instanceof LifecycleEndedException) {
-            if (AutoDisposePlugins.getOutsideLifecycleHandler() != null) {
-              AutoDisposePlugins.getOutsideLifecycleHandler().accept((LifecycleEndedException) e);
+            Consumer<? super OutsideLifecycleException> handler
+                = AutoDisposePlugins.getOutsideLifecycleHandler();
+            if (handler != null) {
+              handler.accept((LifecycleEndedException) e);
               return Maybe.just(LifecycleEndNotification.INSTANCE);
             } else {
               throw e;

--- a/autodispose/src/main/java/com/uber/autodispose/TestLifecycleScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/TestLifecycleScopeProvider.java
@@ -17,10 +17,9 @@
 package com.uber.autodispose;
 
 import io.reactivex.Observable;
-import io.reactivex.annotations.NonNull;
-import io.reactivex.annotations.Nullable;
 import io.reactivex.functions.Function;
 import io.reactivex.subjects.BehaviorSubject;
+import javax.annotation.Nullable;
 
 /**
  * Test utility to create {@link LifecycleScopeProvider} instances for tests.
@@ -66,7 +65,7 @@ public final class TestLifecycleScopeProvider
 
   @Override public Function<TestLifecycle, TestLifecycle> correspondingEvents() {
     return new Function<TestLifecycle, TestLifecycle>() {
-      @Override public TestLifecycle apply(@NonNull TestLifecycle testLifecycle) {
+      @Override public TestLifecycle apply(TestLifecycle testLifecycle) {
         switch (testLifecycle) {
           case STARTED:
             return TestLifecycle.STOPPED;

--- a/autodispose/src/main/java/com/uber/autodispose/package-info.java
+++ b/autodispose/src/main/java/com/uber/autodispose/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017. Uber Technologies
+ * Copyright (c) 2017. Uber Technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,9 @@
  * limitations under the License.
  */
 
+/**
+ * AutoDispose is an RxJava 2 tool for automatically binding the execution of RxJava 2 streams to a
+ * provided scope via disposal/cancellation.
+ */
+@javax.annotation.ParametersAreNonnullByDefault
 package com.uber.autodispose;
-
-import javax.annotation.Nullable;
-
-final class AutoDisposeUtil {
-
-  private AutoDisposeUtil() {
-    throw new InstantiationError();
-  }
-
-  static <T> T checkNotNull(@Nullable T value, String message) {
-    if (value == null) {
-      throw new NullPointerException(message);
-    } else {
-      return value;
-    }
-  }
-}

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -19,16 +19,13 @@ package com.uber.autodispose;
 import io.reactivex.Maybe;
 import io.reactivex.MaybeEmitter;
 import io.reactivex.MaybeOnSubscribe;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Predicate;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
-
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.junit.After;
 import org.junit.Test;
 
@@ -67,7 +64,7 @@ public class AutoDisposeMaybeObserverTest {
     Maybe.just(new BClass())
         .to(new MaybeScoper<AClass>(Maybe.never()))
         .subscribe(new Consumer<AClass>() {
-          @Override public void accept(@NonNull AClass aClass) throws Exception {
+          @Override public void accept(AClass aClass) throws Exception {
 
           }
         });
@@ -87,7 +84,7 @@ public class AutoDisposeMaybeObserverTest {
         .subscribe(o);
     source.to(new MaybeScoper<Integer>(lifecycle))
         .subscribe(new Consumer<Integer>() {
-          @Override public void accept(@NonNull Integer integer) throws Exception {
+          @Override public void accept(Integer integer) throws Exception {
 
           }
         });

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -20,7 +20,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.ObservableEmitter;
 import io.reactivex.ObservableOnSubscribe;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;
@@ -30,7 +29,6 @@ import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subjects.PublishSubject;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.junit.After;
 import org.junit.Test;
 
@@ -69,7 +67,7 @@ public class AutoDisposeObserverTest {
     Observable.just(new BClass())
         .to(new ObservableScoper<AClass>(Maybe.never()))
         .subscribe(new Consumer<AClass>() {
-          @Override public void accept(@NonNull AClass aClass) throws Exception {
+          @Override public void accept(AClass aClass) throws Exception {
 
           }
         });

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -20,7 +20,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Single;
 import io.reactivex.SingleEmitter;
 import io.reactivex.SingleOnSubscribe;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Predicate;
@@ -29,7 +28,6 @@ import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subjects.SingleSubject;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.junit.After;
 import org.junit.Test;
 
@@ -68,7 +66,7 @@ public class AutoDisposeSingleObserverTest {
     Single.just(new BClass())
         .to(new SingleScoper<AClass>(Maybe.never()))
         .subscribe(new Consumer<AClass>() {
-          @Override public void accept(@NonNull AClass aClass) throws Exception {
+          @Override public void accept(AClass aClass) throws Exception {
 
           }
         });

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -21,7 +21,6 @@ import io.reactivex.Flowable;
 import io.reactivex.FlowableEmitter;
 import io.reactivex.FlowableOnSubscribe;
 import io.reactivex.Maybe;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;
@@ -32,7 +31,6 @@ import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.junit.After;
 import org.junit.Test;
 
@@ -71,7 +69,7 @@ public class AutoDisposeSubscriberTest {
     Flowable.just(new BClass())
         .to(new FlowableScoper<AClass>(Maybe.never()))
         .subscribe(new Consumer<AClass>() {
-          @Override public void accept(@NonNull AClass aClass) throws Exception {
+          @Override public void accept(AClass aClass) throws Exception {
 
           }
         });

--- a/autodispose/src/test/java/com/uber/autodispose/TestUtil.java
+++ b/autodispose/src/test/java/com/uber/autodispose/TestUtil.java
@@ -18,7 +18,6 @@ package com.uber.autodispose;
 
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
-import io.reactivex.annotations.NonNull;
 import io.reactivex.functions.Function;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
@@ -53,11 +52,11 @@ final class TestUtil {
   static LifecycleScopeProvider<Integer> makeLifecycleProvider(
       final BehaviorSubject<Integer> lifecycle) {
     return new LifecycleScopeProvider<Integer>() {
-      @NonNull @Override public Observable<Integer> lifecycle() {
+      @Override public Observable<Integer> lifecycle() {
         return lifecycle;
       }
 
-      @NonNull @Override public Function<Integer, Integer> correspondingEvents() {
+      @Override public Function<Integer, Integer> correspondingEvents() {
         return CORRESPONDING_EVENTS;
       }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -45,7 +45,8 @@ def kotlin = [
 ]
 
 def misc = [
-    errorProneAnnotations: "com.google.errorprone:error_prone_annotations:${versions.errorProne}"
+    errorProneAnnotations: "com.google.errorprone:error_prone_annotations:${versions.errorProne}",
+    jsr305: 'com.google.code.findbugs:jsr305:3.0.2'
 ]
 
 def rx = [


### PR DESCRIPTION
This takes inspiration from Square's recent blog post and brings back the jsr305 dependency as a provided dependency. Benefits are static analysis and kotlin code still can leverage this.

Main functional differences are annotating a `package-info` with `@ParametersAreNonnullByDefault` annotation and switching to javax' `@Nullable` annotation instead of RxJava's.

Thank you for contributing to AutoDispose. Before pressing the "Create Pull Request" button, please consider the following points: 

Prior reading:
  - https://github.com/square/okio/pull/307
  - https://medium.com/square-corner-blog/rolling-out-nullable-42dd823fbd89