### PR TITLE
More nullability annotation work

### DIFF
--- a/autodispose-android/build.gradle
+++ b/autodispose-android/build.gradle
@@ -50,6 +50,7 @@ dependencies {
   compile deps.rx.android
   compile deps.support.annotations
   provided deps.misc.errorProneAnnotations
+  provided project(':autodispose-provided')
   errorprone deps.build.errorProne
   androidTestCompile deps.support.annotations
   androidTestCompile deps.test.junit

--- a/autodispose-android/src/main/java/com/uber/autodispose/android/package-info.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/package-info.java
@@ -15,8 +15,8 @@
  */
 
 /**
- * AutoDispose is an RxJava 2 tool for automatically binding the execution of RxJava 2 streams to a
- * provided scope via disposal/cancellation.
+ * Android components for AutoDispose.
  */
 @com.uber.autodispose.internal.PackageNonNull
-package com.uber.autodispose;
+package com.uber.autodispose.android;
+

--- a/autodispose-android/src/main/java/com/uber/autodispose/android/package-info.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/package-info.java
@@ -17,6 +17,6 @@
 /**
  * Android components for AutoDispose.
  */
-@com.uber.autodispose.internal.PackageNonNull
+@com.uber.autodispose.internal.EverythingNonNullByDefault
 package com.uber.autodispose.android;
 

--- a/autodispose-provided/README.md
+++ b/autodispose-provided/README.md
@@ -1,0 +1,6 @@
+AutoDispose-provided
+====================
+
+This module solely exists to separate out `@PackageNonnull` to allow for it to be a `compileOnly` 
+dependency of the other projects. This allows it to be useful still for static analysis, while not 
+imposing the jsr305 artifact as a full compile dependency on the consumer.

--- a/autodispose-provided/build.gradle
+++ b/autodispose-provided/build.gradle
@@ -39,5 +39,3 @@ dependencies {
 
   errorprone deps.build.errorProne
 }
-
-apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/autodispose-provided/build.gradle
+++ b/autodispose-provided/build.gradle
@@ -13,9 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+buildscript {
+  repositories {
+    jcenter()
+    maven { url deps.build.repositories.plugins }
+  }
+  dependencies {
+    classpath deps.build.gradlePlugins.errorProne
+  }
+}
 
-rootProject.name = 'autodispose-root'
-include ':autodispose'
-include ':autodispose-android'
-include ':autodispose-kotlin'
-include ':autodispose-provided'
+apply plugin: 'java-library'
+apply plugin: 'net.ltgt.errorprone'
+
+sourceCompatibility = "1.7"
+targetCompatibility = "1.7"
+
+test {
+  testLogging.showStandardStreams = true
+}
+
+dependencies {
+  compileOnly deps.misc.errorProneAnnotations
+  compile deps.misc.jsr305
+
+  errorprone deps.build.errorProne
+}
+
+apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/autodispose-provided/gradle.properties
+++ b/autodispose-provided/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=AutoDispose (Provided)
+POM_ARTIFACT_ID=autodispose-provided
+POM_PACKAGING=jar

--- a/autodispose-provided/gradle.properties
+++ b/autodispose-provided/gradle.properties
@@ -1,3 +1,0 @@
-POM_NAME=AutoDispose (Provided)
-POM_ARTIFACT_ID=autodispose-provided
-POM_PACKAGING=jar

--- a/autodispose-provided/src/main/java/com/uber/autodispose/internal/EverythingNonNullByDefault.java
+++ b/autodispose-provided/src/main/java/com/uber/autodispose/internal/EverythingNonNullByDefault.java
@@ -21,5 +21,5 @@ import javax.annotation.meta.TypeQualifierDefault;
     ElementType.METHOD,
     ElementType.PARAMETER
 })
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.CLASS)
 public @interface EverythingNonNullByDefault { }

--- a/autodispose-provided/src/main/java/com/uber/autodispose/internal/EverythingNonNullByDefault.java
+++ b/autodispose-provided/src/main/java/com/uber/autodispose/internal/EverythingNonNullByDefault.java
@@ -22,4 +22,4 @@ import javax.annotation.meta.TypeQualifierDefault;
     ElementType.PARAMETER
 })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface PackageNonNull { }
+public @interface EverythingNonNullByDefault { }

--- a/autodispose-provided/src/main/java/com/uber/autodispose/internal/PackageNonNull.java
+++ b/autodispose-provided/src/main/java/com/uber/autodispose/internal/PackageNonNull.java
@@ -1,0 +1,30 @@
+package com.uber.autodispose.internal;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierDefault;
+
+/**
+ * This annotation can be applied to a package, class or method to indicate that the class fields,
+ * method return types and parameters in that element are not null by default unless:
+ * - The method overrides a method in a superclass (in which case the annotation of the
+ * corresponding parameter in the superclass applies).
+ * - There is a default parameter annotation applied to a more tightly nested element.
+ */
+@Documented
+@Nonnull
+@TypeQualifierDefault({
+    ElementType.ANNOTATION_TYPE,
+    ElementType.CONSTRUCTOR,
+    ElementType.FIELD,
+    ElementType.LOCAL_VARIABLE,
+    ElementType.METHOD,
+    ElementType.PACKAGE,
+    ElementType.PARAMETER,
+    ElementType.TYPE
+})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PackageNonNull { }

--- a/autodispose-provided/src/main/java/com/uber/autodispose/internal/PackageNonNull.java
+++ b/autodispose-provided/src/main/java/com/uber/autodispose/internal/PackageNonNull.java
@@ -17,14 +17,9 @@ import javax.annotation.meta.TypeQualifierDefault;
 @Documented
 @Nonnull
 @TypeQualifierDefault({
-    ElementType.ANNOTATION_TYPE,
-    ElementType.CONSTRUCTOR,
     ElementType.FIELD,
-    ElementType.LOCAL_VARIABLE,
     ElementType.METHOD,
-    ElementType.PACKAGE,
-    ElementType.PARAMETER,
-    ElementType.TYPE
+    ElementType.PARAMETER
 })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PackageNonNull { }

--- a/autodispose/build.gradle
+++ b/autodispose/build.gradle
@@ -36,7 +36,7 @@ test {
 dependencies {
   api deps.rx.java
   compileOnly deps.misc.errorProneAnnotations
-  compileOnly deps.misc.jsr305
+  compileOnly project(':autodispose-provided')
 
   errorprone deps.build.errorProne
 

--- a/autodispose/src/main/java/com/uber/autodispose/observers/package-info.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/package-info.java
@@ -18,6 +18,6 @@
  * These are Observers AutoDispose uses when scoping an observable. They are exposed as a public API
  *  to allow for consumers to watch for them if they want, such as in RxJava plugins.
  */
-@com.uber.autodispose.internal.PackageNonNull
+@com.uber.autodispose.internal.EverythingNonNullByDefault
 package com.uber.autodispose.observers;
 

--- a/autodispose/src/main/java/com/uber/autodispose/observers/package-info.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/package-info.java
@@ -15,8 +15,9 @@
  */
 
 /**
- * AutoDispose is an RxJava 2 tool for automatically binding the execution of RxJava 2 streams to a
- * provided scope via disposal/cancellation.
+ * These are Observers AutoDispose uses when scoping an observable. They are exposed as a public API
+ *  to allow for consumers to watch for them if they want, such as in RxJava plugins.
  */
 @com.uber.autodispose.internal.PackageNonNull
-package com.uber.autodispose;
+package com.uber.autodispose.observers;
+

--- a/autodispose/src/main/java/com/uber/autodispose/package-info.java
+++ b/autodispose/src/main/java/com/uber/autodispose/package-info.java
@@ -18,5 +18,6 @@
  * AutoDispose is an RxJava 2 tool for automatically binding the execution of RxJava 2 streams to a
  * provided scope via disposal/cancellation.
  */
-@com.uber.autodispose.internal.PackageNonNull
+@com.uber.autodispose.internal.EverythingNonNullByDefault
 package com.uber.autodispose;
+


### PR DESCRIPTION
This is a followup to #69, and improves it in two main ways:
- This adds it to subpackages as well, which I missed in the first pass.
- Switches to a custom `PackageNonNull` annotation instead, which expands the checks to also include return types, fields, local vars, etc. It's pretty broad right now but we could reduce scope if need be. This is pulled into a separate artifact for re-use, but still only applied as compileOnly. `@ParametersAreNonnullByDefault` actually only covers method parameters it seems.