### PR TITLE
Integrate NullAway into errorProne checks

### DIFF
--- a/autodispose-android-archcomponents/build.gradle
+++ b/autodispose-android-archcomponents/build.gradle
@@ -65,7 +65,10 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-  options.compilerArgs += ["-Xep:NullAway:ERROR", "-XepOpt:NullAway:AnnotatedPackages=com.uber"]
+  options.compilerArgs += ["-Xep:NullAway:ERROR",
+                           "-XepOpt:NullAway:AnnotatedPackages=com.uber",
+                           // Because arch components doesn't generate @Override
+                           "-Xep:MissingOverride:OFF"]
 }
 
 // Disable for now until we're ready to release this

--- a/autodispose-android-archcomponents/build.gradle
+++ b/autodispose-android-archcomponents/build.gradle
@@ -45,6 +45,7 @@ android {
 }
 
 dependencies {
+  annotationProcessor deps.build.nullAway
   annotationProcessor deps.support.arch.lifecycle.compiler
 
   compile project(':autodispose-android')
@@ -53,11 +54,17 @@ dependencies {
 
   provided deps.misc.errorProneAnnotations
   provided deps.misc.javaxExtras
+
+  errorprone deps.build.checkerFramework
   errorprone deps.build.errorProne
 
   androidTestCompile project(':test-utils')
   androidTestCompile deps.test.androidRunner
   androidTestCompile deps.test.androidRules
+}
+
+tasks.withType(JavaCompile) {
+  options.compilerArgs += ["-Xep:NullAway:ERROR", "-XepOpt:NullAway:AnnotatedPackages=com.uber"]
 }
 
 // Disable for now until we're ready to release this

--- a/autodispose-android-archcomponents/build.gradle
+++ b/autodispose-android-archcomponents/build.gradle
@@ -46,6 +46,7 @@ android {
 
 dependencies {
   annotationProcessor deps.build.nullAway
+  testAnnotationProcessor deps.build.nullAway
   annotationProcessor deps.support.arch.lifecycle.compiler
 
   compile project(':autodispose-android')

--- a/autodispose-android/build.gradle
+++ b/autodispose-android/build.gradle
@@ -45,17 +45,27 @@ android {
 }
 
 dependencies {
+  annotationProcessor deps.build.nullAway
+
   compile project(':autodispose')
   compile deps.rx.java
   compile deps.rx.android
   compile deps.support.annotations
+
   provided deps.misc.errorProneAnnotations
   provided deps.misc.javaxExtras
+
+  errorprone deps.build.checkerFramework
   errorprone deps.build.errorProne
+
   androidTestCompile project(':test-utils')
   androidTestCompile deps.support.annotations
   androidTestCompile deps.test.androidRunner
   androidTestCompile deps.test.androidRules
+}
+
+tasks.withType(JavaCompile) {
+  options.compilerArgs += ["-Xep:NullAway:ERROR", "-XepOpt:NullAway:AnnotatedPackages=com.uber"]
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/autodispose-android/build.gradle
+++ b/autodispose-android/build.gradle
@@ -46,6 +46,7 @@ android {
 
 dependencies {
   annotationProcessor deps.build.nullAway
+  testAnnotationProcessor deps.build.nullAway
 
   compile project(':autodispose')
   compile deps.rx.java

--- a/autodispose/build.gradle
+++ b/autodispose/build.gradle
@@ -37,6 +37,7 @@ test {
 
 dependencies {
   apt deps.build.nullAway
+  testApt deps.build.nullAway
 
   api deps.rx.java
   compileOnly deps.misc.errorProneAnnotations

--- a/autodispose/build.gradle
+++ b/autodispose/build.gradle
@@ -19,11 +19,13 @@ buildscript {
     maven { url deps.build.repositories.plugins }
   }
   dependencies {
+    classpath deps.build.gradlePlugins.apt
     classpath deps.build.gradlePlugins.errorProne
   }
 }
 
 apply plugin: 'java-library'
+apply plugin: 'net.ltgt.apt'
 apply plugin: 'net.ltgt.errorprone'
 
 sourceCompatibility = "1.7"
@@ -34,13 +36,20 @@ test {
 }
 
 dependencies {
+  apt deps.build.nullAway
+
   api deps.rx.java
   compileOnly deps.misc.errorProneAnnotations
   compileOnly deps.misc.javaxExtras
 
+  errorprone deps.build.checkerFramework
   errorprone deps.build.errorProne
 
   testCompile project(':test-utils')
+}
+
+tasks.withType(JavaCompile) {
+  options.compilerArgs += ["-Xep:NullAway:ERROR", "-XepOpt:NullAway:AnnotatedPackages=com.uber"]
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
@@ -70,8 +70,10 @@ final class AutoDisposingSubscriberImpl<T> implements AutoDisposingSubscriber<T>
    * @param n the request amount, positive
    */
   @Override public void request(long n) {
-    mainSubscription.get()
-        .request(n);
+    Subscription s = mainSubscription.get();
+    if (s != null) {
+      s.request(n);
+    }
   }
 
   /**

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,7 +17,7 @@
 def versions = [
     androidTest: '0.5',
     archComponents: '1.0.0-alpha8',
-    errorProne: '2.0.21',
+    errorProne: '2.1.1',
     kotlin: '1.1.4-2',
     support: '25.1.0'
 ]
@@ -28,7 +28,10 @@ def build = [
     ci: 'true' == System.getenv('CI'),
     minSdkVersion: 14,
     targetSdkVersion: 26,
+
+    checkerFramework: 'org.checkerframework:dataflow:2.1.14',
     errorProne: "com.google.errorprone:error_prone_core:${versions.errorProne}",
+    nullAway: 'com.uber.nullaway:nullaway:0.1.2',
 
     repositories: [
         plugins: 'https://plugins.gradle.org/m2/'
@@ -36,7 +39,8 @@ def build = [
 
     gradlePlugins: [
         android: 'com.android.tools.build:gradle:2.3.0',
-        errorProne: 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.10',
+        apt: 'net.ltgt.gradle:gradle-apt-plugin:0.11',
+        errorProne: 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.11',
         kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
     ]
 ]


### PR DESCRIPTION
I would have liked to have done this all from the root module and applied automatically to relevant subprojects, but I can't seem to make gradle understand buildscript classpaths as it always fails to find the plugin on it.

Only one-ish issue found in 08b9467, effectively `AtomicReference` types are sort of lazily initialized in `onSubscribe`, but I don't know of a good way to indicate that to NullAway