### PR TITLE
Bring back static factories again, this time with autocomplete!

### DIFF
--- a/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/archcomponents/AndroidLifecycleScopeProviderTest.java
+++ b/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/archcomponents/AndroidLifecycleScopeProviderTest.java
@@ -23,9 +23,9 @@ import android.support.test.annotation.UiThreadTest;
 import android.support.test.rule.UiThreadTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Log;
+import com.uber.autodispose.AutoDispose;
 import com.uber.autodispose.LifecycleEndedException;
 import com.uber.autodispose.LifecycleNotStartedException;
-import com.uber.autodispose.ObservableScoper;
 import com.uber.autodispose.test.RecordingObserver;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.subjects.PublishSubject;
@@ -54,7 +54,8 @@ import static com.google.common.truth.Truth.assertThat;
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
-    subject.to(new ObservableScoper<Integer>(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.to(
+        AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle)).<Integer>observable())
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -83,7 +84,8 @@ import static com.google.common.truth.Truth.assertThat;
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
-    subject.to(new ObservableScoper<Integer>(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.to(
+        AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle)).<Integer>observable())
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -99,7 +101,7 @@ import static com.google.common.truth.Truth.assertThat;
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     UninitializedLifecycleOwner owner = new UninitializedLifecycleOwner();
-    subject.to(new ObservableScoper<Integer>(AndroidLifecycleScopeProvider.from(owner)))
+    subject.to(AutoDispose.with(AndroidLifecycleScopeProvider.from(owner)).<Integer>observable())
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -120,7 +122,8 @@ import static com.google.common.truth.Truth.assertThat;
     lifecycle.emit(Lifecycle.Event.ON_PAUSE);
     lifecycle.emit(Lifecycle.Event.ON_STOP);
     lifecycle.emit(Lifecycle.Event.ON_DESTROY);
-    subject.to(new ObservableScoper<Integer>(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.to(
+        AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle)).<Integer>observable())
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -140,7 +143,8 @@ import static com.google.common.truth.Truth.assertThat;
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
     lifecycle.emit(Lifecycle.Event.ON_PAUSE);
     lifecycle.emit(Lifecycle.Event.ON_STOP);
-    subject.to(new ObservableScoper<Integer>(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.to(
+        AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle)).<Integer>observable())
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();

--- a/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/archcomponents/AndroidLifecycleScopeProviderTest.java
+++ b/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/archcomponents/AndroidLifecycleScopeProviderTest.java
@@ -55,7 +55,7 @@ import static com.google.common.truth.Truth.assertThat;
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
     subject.to(
-        AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle)).<Integer>observable())
+        AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle)).<Integer>forObservable())
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -85,7 +85,7 @@ import static com.google.common.truth.Truth.assertThat;
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
     subject.to(
-        AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle)).<Integer>observable())
+        AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle)).<Integer>forObservable())
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -101,7 +101,7 @@ import static com.google.common.truth.Truth.assertThat;
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     UninitializedLifecycleOwner owner = new UninitializedLifecycleOwner();
-    subject.to(AutoDispose.with(AndroidLifecycleScopeProvider.from(owner)).<Integer>observable())
+    subject.to(AutoDispose.with(AndroidLifecycleScopeProvider.from(owner)).<Integer>forObservable())
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -123,7 +123,7 @@ import static com.google.common.truth.Truth.assertThat;
     lifecycle.emit(Lifecycle.Event.ON_STOP);
     lifecycle.emit(Lifecycle.Event.ON_DESTROY);
     subject.to(
-        AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle)).<Integer>observable())
+        AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle)).<Integer>forObservable())
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -144,7 +144,7 @@ import static com.google.common.truth.Truth.assertThat;
     lifecycle.emit(Lifecycle.Event.ON_PAUSE);
     lifecycle.emit(Lifecycle.Event.ON_STOP);
     subject.to(
-        AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle)).<Integer>observable())
+        AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle)).<Integer>forObservable())
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();

--- a/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/archcomponents/AndroidLifecycleScopeProvider.java
+++ b/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/archcomponents/AndroidLifecycleScopeProvider.java
@@ -28,9 +28,7 @@ import io.reactivex.functions.Function;
  * {@link LifecycleOwner} classes.
  * <p>
  * <pre><code>
- *   myFooObservable
- *      .to(new ObservableScoper<Foo>(AndroidLifecycleScopeProvider.from(lifecycleOwner)))
- *      .subscribe();
+ *   AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycleOwner))
  * </code></pre>
  */
 public final class AndroidLifecycleScopeProvider

--- a/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
+++ b/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
@@ -23,6 +23,7 @@ import android.support.test.runner.AndroidJUnit4;
 import android.util.Log;
 import android.view.View;
 import android.widget.FrameLayout;
+import com.uber.autodispose.AutoDispose;
 import com.uber.autodispose.ObservableScoper;
 import com.uber.autodispose.OutsideLifecycleException;
 import com.uber.autodispose.test.RecordingObserver;
@@ -70,7 +71,7 @@ public final class ViewScopeProviderTest {
     });
     instrumentation.runOnMainSync(new Runnable() {
       @Override public void run() {
-        subject.to(new ObservableScoper<Integer>(ViewScopeProvider.from(child)))
+        subject.to(AutoDispose.with(ViewScopeProvider.from(child)).<Integer>observable())
             .subscribe(o);
       }
     });
@@ -106,7 +107,7 @@ public final class ViewScopeProviderTest {
         parent.addView(child);
       }
     });
-    subject.to(new ObservableScoper<Integer>(ViewScopeProvider.from(child)))
+    subject.to(AutoDispose.with(ViewScopeProvider.from(child)).<Integer>observable())
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -123,7 +124,7 @@ public final class ViewScopeProviderTest {
 
     instrumentation.runOnMainSync(new Runnable() {
       @Override public void run() {
-        subject.to(new ObservableScoper<Integer>(ViewScopeProvider.from(child)))
+        subject.to(AutoDispose.with(ViewScopeProvider.from(child)).<Integer>observable())
             .subscribe(o);
       }
     });
@@ -151,7 +152,7 @@ public final class ViewScopeProviderTest {
     });
     instrumentation.runOnMainSync(new Runnable() {
       @Override public void run() {
-        subject.to(new ObservableScoper<Integer>(ViewScopeProvider.from(child)))
+        subject.to(AutoDispose.with(ViewScopeProvider.from(child)).<Integer>observable())
             .subscribe(o);
       }
     });

--- a/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
+++ b/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
@@ -24,7 +24,6 @@ import android.util.Log;
 import android.view.View;
 import android.widget.FrameLayout;
 import com.uber.autodispose.AutoDispose;
-import com.uber.autodispose.ObservableScoper;
 import com.uber.autodispose.OutsideLifecycleException;
 import com.uber.autodispose.test.RecordingObserver;
 import io.reactivex.disposables.Disposable;
@@ -71,7 +70,7 @@ public final class ViewScopeProviderTest {
     });
     instrumentation.runOnMainSync(new Runnable() {
       @Override public void run() {
-        subject.to(AutoDispose.with(ViewScopeProvider.from(child)).<Integer>observable())
+        subject.to(AutoDispose.with(ViewScopeProvider.from(child)).<Integer>forObservable())
             .subscribe(o);
       }
     });
@@ -107,7 +106,7 @@ public final class ViewScopeProviderTest {
         parent.addView(child);
       }
     });
-    subject.to(AutoDispose.with(ViewScopeProvider.from(child)).<Integer>observable())
+    subject.to(AutoDispose.with(ViewScopeProvider.from(child)).<Integer>forObservable())
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -124,7 +123,7 @@ public final class ViewScopeProviderTest {
 
     instrumentation.runOnMainSync(new Runnable() {
       @Override public void run() {
-        subject.to(AutoDispose.with(ViewScopeProvider.from(child)).<Integer>observable())
+        subject.to(AutoDispose.with(ViewScopeProvider.from(child)).<Integer>forObservable())
             .subscribe(o);
       }
     });
@@ -152,7 +151,7 @@ public final class ViewScopeProviderTest {
     });
     instrumentation.runOnMainSync(new Runnable() {
       @Override public void run() {
-        subject.to(AutoDispose.with(ViewScopeProvider.from(child)).<Integer>observable())
+        subject.to(AutoDispose.with(ViewScopeProvider.from(child)).<Integer>forObservable())
             .subscribe(o);
       }
     });

--- a/autodispose-android/src/main/java/com/uber/autodispose/android/ViewScopeProvider.java
+++ b/autodispose-android/src/main/java/com/uber/autodispose/android/ViewScopeProvider.java
@@ -29,9 +29,7 @@ import static com.uber.autodispose.android.ViewLifecycleEvent.DETACH;
  * A {@link LifecycleScopeProvider} that can provide scoping for Android {@link View} classes.
  * <p>
  * <pre><code>
- *   AutoDispose.observable()
- *      .scopeWith(ViewScopeProvider.from(view))
- *      .empty();
+ *   AutoDispose.with(ViewScopeProvider.from(view));
  * </code></pre>
  */
 public class ViewScopeProvider implements LifecycleScopeProvider<ViewLifecycleEvent> {

--- a/autodispose-kotlin/src/main/kotlin/com/uber/autodispose/kotlin/autodispose.kt
+++ b/autodispose-kotlin/src/main/kotlin/com/uber/autodispose/kotlin/autodispose.kt
@@ -18,17 +18,14 @@
 
 package com.uber.autodispose.kotlin
 
-import com.uber.autodispose.CompletableScoper
+import com.uber.autodispose.AutoDispose
+import com.uber.autodispose.AutoDispose.ScopeHandler
 import com.uber.autodispose.CompletableSubscribeProxy
-import com.uber.autodispose.FlowableScoper
 import com.uber.autodispose.FlowableSubscribeProxy
 import com.uber.autodispose.LifecycleScopeProvider
-import com.uber.autodispose.MaybeScoper
 import com.uber.autodispose.MaybeSubscribeProxy
-import com.uber.autodispose.ObservableScoper
 import com.uber.autodispose.ObservableSubscribeProxy
 import com.uber.autodispose.ScopeProvider
-import com.uber.autodispose.SingleScoper
 import com.uber.autodispose.SingleSubscribeProxy
 import io.reactivex.Completable
 import io.reactivex.Flowable
@@ -38,112 +35,112 @@ import io.reactivex.Single
 import io.reactivex.annotations.CheckReturnValue
 
 /**
- * Extension that proxies to [Flowable.to] + [FlowableScoper]'s [Maybe] constructor.
+ * Extension that proxies to [Flowable.to] + [AutoDispose.with] + [ScopeHandler.flowable]
  */
 @CheckReturnValue
 inline fun <T> Flowable<T>.autoDisposeWith(scope: Maybe<*>): FlowableSubscribeProxy<T>
-    = this.to(FlowableScoper<T>(scope))
+    = this.to(AutoDispose.with(scope).flowable())
 
 /**
- * Extension that proxies to [Observable.to] + [ObservableScoper]'s [Maybe] constructor.
+ * Extension that proxies to [Observable.to] + [AutoDispose.with] + [ScopeHandler.observable]
  */
 @CheckReturnValue
 inline fun <T> Observable<T>.autoDisposeWith(scope: Maybe<*>): ObservableSubscribeProxy<T>
-    = this.to(ObservableScoper<T>(scope))
+    = this.to(AutoDispose.with(scope).observable())
 
 /**
- * Extension that proxies to [Single.to] + [SingleScoper]'s [Maybe] constructor.
+ * Extension that proxies to [Single.to] + [AutoDispose.with] + [ScopeHandler.single]
  */
 @CheckReturnValue
 inline fun <T> Single<T>.autoDisposeWith(scope: Maybe<*>): SingleSubscribeProxy<T>
-    = this.to(SingleScoper<T>(scope))
+    = this.to(AutoDispose.with(scope).single())
 
 /**
- * Extension that proxies to [Maybe.to] + [MaybeScoper]'s [Maybe] constructor.
+ * Extension that proxies to [Maybe.to] + [AutoDispose.with] + [ScopeHandler.maybe]
  */
 @CheckReturnValue
 inline fun <T> Maybe<T>.autoDisposeWith(scope: Maybe<*>): MaybeSubscribeProxy<T>
-    = this.to(MaybeScoper<T>(scope))
+    = this.to(AutoDispose.with(scope).maybe())
 
 /**
- * Extension that proxies to [Completable.to] + [CompletableScoper]'s [Maybe] constructor.
+ * Extension that proxies to [Completable.to] + [AutoDispose.with] + [ScopeHandler.completable]
  */
 @CheckReturnValue
 inline fun Completable.autoDisposeWith(scope: Maybe<*>): CompletableSubscribeProxy
-    = this.to(CompletableScoper(scope))
+    = this.to(AutoDispose.with(scope).completable())
 
 /**
- * Extension that proxies to [Flowable.to] + [FlowableScoper]'s [ScopeProvider] constructor.
+ * Extension that proxies to [Flowable.to] + [AutoDispose.with] + [ScopeHandler.flowable]
  */
 @CheckReturnValue
 inline fun <T> Flowable<T>.autoDisposeWith(provider: ScopeProvider): FlowableSubscribeProxy<T>
-    = this.to(FlowableScoper<T>(provider))
+    = this.to(AutoDispose.with(provider).flowable())
 
 /**
- * Extension that proxies to [Observable.to] + [ObservableScoper]'s [ScopeProvider] constructor.
+ * Extension that proxies to [Observable.to] + [AutoDispose.with] + [ScopeHandler.observable]
  */
 @CheckReturnValue
 inline fun <T> Observable<T>.autoDisposeWith(provider: ScopeProvider): ObservableSubscribeProxy<T>
-    = this.to(ObservableScoper<T>(provider))
+    = this.to(AutoDispose.with(provider).observable())
 
 /**
- * Extension that proxies to [Single.to] + [SingleScoper]'s [ScopeProvider] constructor.
+ * Extension that proxies to [Single.to] + [AutoDispose.with] + [ScopeHandler.single]
  */
 @CheckReturnValue
 inline fun <T> Single<T>.autoDisposeWith(provider: ScopeProvider): SingleSubscribeProxy<T>
-    = this.to(SingleScoper<T>(provider))
+    = this.to(AutoDispose.with(provider).single())
 
 /**
- * Extension that proxies to [Maybe.to] + [MaybeScoper]'s [ScopeProvider] constructor.
+ * Extension that proxies to [Maybe.to] + [AutoDispose.with] + [ScopeHandler.maybe]
  */
 @CheckReturnValue
 inline fun <T> Maybe<T>.autoDisposeWith(provider: ScopeProvider): MaybeSubscribeProxy<T>
-    = this.to(MaybeScoper<T>(provider))
+    = this.to(AutoDispose.with(provider).maybe())
 
 /**
- * Extension that proxies to [Completable.to] + [CompletableScoper]'s [ScopeProvider] constructor.
+ * Extension that proxies to [Completable.to] + [AutoDispose.with] + [ScopeHandler.completable]
  */
 @CheckReturnValue
 inline fun Completable.autoDisposeWith(provider: ScopeProvider): CompletableSubscribeProxy
-    = this.to(CompletableScoper(provider))
+    = this.to(AutoDispose.with(provider).completable())
 
 /**
- * Extension that proxies to [Flowable.to] + [FlowableScoper]'s [LifecycleScopeProvider]
- * constructor.
+ * Extension that proxies to [Flowable.to] + [AutoDispose.with]+ [ScopeHandler.flowable]
+ *
  */
 @CheckReturnValue
 inline fun <T> Flowable<T>.autoDisposeWith(
     provider: LifecycleScopeProvider<*>): FlowableSubscribeProxy<T>
-    = this.to(FlowableScoper<T>(provider))
+    = this.to(AutoDispose.with(provider).flowable())
 
 /**
- * Extension that proxies to [Observable.to] + [ObservableScoper]'s [LifecycleScopeProvider]
- * constructor.
+ * Extension that proxies to [Observable.to] + [AutoDispose.with] + [ScopeHandler.observable]
  */
 @CheckReturnValue
 inline fun <T> Observable<T>.autoDisposeWith(
     provider: LifecycleScopeProvider<*>): ObservableSubscribeProxy<T>
-    = this.to(ObservableScoper<T>(provider))
+    = this.to(AutoDispose.with(provider).observable())
 
 /**
- * Extension that proxies to [Single.to] + [SingleScoper]'s [LifecycleScopeProvider] constructor.
+ * Extension that proxies to [Single.to] + [AutoDispose.with] + [ScopeHandler.single]
  */
 @CheckReturnValue
-inline fun <T> Single<T>.autoDisposeWith(provider: LifecycleScopeProvider<*>): SingleSubscribeProxy<T>
-    = this.to(SingleScoper<T>(provider))
+inline fun <T> Single<T>.autoDisposeWith(
+    provider: LifecycleScopeProvider<*>): SingleSubscribeProxy<T>
+    = this.to(AutoDispose.with(provider).single())
 
 /**
- * Extension that proxies to [Maybe.to] + [MaybeScoper]'s [LifecycleScopeProvider] constructor.
+ * Extension that proxies to [Maybe.to] + [AutoDispose.with] + [ScopeHandler.maybe]
  */
 @CheckReturnValue
 inline fun <T> Maybe<T>.autoDisposeWith(provider: LifecycleScopeProvider<*>): MaybeSubscribeProxy<T>
-    = this.to(MaybeScoper<T>(provider))
+    = this.to(AutoDispose.with(provider).maybe())
 
 /**
- * Extension that proxies to [Completable.to] + [CompletableScoper]'s [LifecycleScopeProvider]
- * constructor.
+ * Extension that proxies to [Completable.to] + [AutoDispose.with]+ [ScopeHandler.completable]
  */
 @CheckReturnValue
-inline fun Completable.autoDisposeWith(provider: LifecycleScopeProvider<*>): CompletableSubscribeProxy
-    = this.to(CompletableScoper(provider))
+inline fun Completable.autoDisposeWith(
+    provider: LifecycleScopeProvider<*>): CompletableSubscribeProxy
+    = this.to(AutoDispose.with(provider).completable())
 

--- a/autodispose-kotlin/src/main/kotlin/com/uber/autodispose/kotlin/autodispose.kt
+++ b/autodispose-kotlin/src/main/kotlin/com/uber/autodispose/kotlin/autodispose.kt
@@ -35,112 +35,112 @@ import io.reactivex.Single
 import io.reactivex.annotations.CheckReturnValue
 
 /**
- * Extension that proxies to [Flowable.to] + [AutoDispose.with] + [ScopeHandler.flowable]
+ * Extension that proxies to [Flowable.to] + [AutoDispose.with] + [ScopeHandler.forFlowable]
  */
 @CheckReturnValue
 inline fun <T> Flowable<T>.autoDisposeWith(scope: Maybe<*>): FlowableSubscribeProxy<T>
-    = this.to(AutoDispose.with(scope).flowable())
+    = this.to(AutoDispose.with(scope).forFlowable())
 
 /**
- * Extension that proxies to [Observable.to] + [AutoDispose.with] + [ScopeHandler.observable]
+ * Extension that proxies to [Observable.to] + [AutoDispose.with] + [ScopeHandler.forObservable]
  */
 @CheckReturnValue
 inline fun <T> Observable<T>.autoDisposeWith(scope: Maybe<*>): ObservableSubscribeProxy<T>
-    = this.to(AutoDispose.with(scope).observable())
+    = this.to(AutoDispose.with(scope).forObservable())
 
 /**
- * Extension that proxies to [Single.to] + [AutoDispose.with] + [ScopeHandler.single]
+ * Extension that proxies to [Single.to] + [AutoDispose.with] + [ScopeHandler.forSingle]
  */
 @CheckReturnValue
 inline fun <T> Single<T>.autoDisposeWith(scope: Maybe<*>): SingleSubscribeProxy<T>
-    = this.to(AutoDispose.with(scope).single())
+    = this.to(AutoDispose.with(scope).forSingle())
 
 /**
- * Extension that proxies to [Maybe.to] + [AutoDispose.with] + [ScopeHandler.maybe]
+ * Extension that proxies to [Maybe.to] + [AutoDispose.with] + [ScopeHandler.forMaybe]
  */
 @CheckReturnValue
 inline fun <T> Maybe<T>.autoDisposeWith(scope: Maybe<*>): MaybeSubscribeProxy<T>
-    = this.to(AutoDispose.with(scope).maybe())
+    = this.to(AutoDispose.with(scope).forMaybe())
 
 /**
- * Extension that proxies to [Completable.to] + [AutoDispose.with] + [ScopeHandler.completable]
+ * Extension that proxies to [Completable.to] + [AutoDispose.with] + [ScopeHandler.forCompletable]
  */
 @CheckReturnValue
 inline fun Completable.autoDisposeWith(scope: Maybe<*>): CompletableSubscribeProxy
-    = this.to(AutoDispose.with(scope).completable())
+    = this.to(AutoDispose.with(scope).forCompletable())
 
 /**
- * Extension that proxies to [Flowable.to] + [AutoDispose.with] + [ScopeHandler.flowable]
+ * Extension that proxies to [Flowable.to] + [AutoDispose.with] + [ScopeHandler.forFlowable]
  */
 @CheckReturnValue
 inline fun <T> Flowable<T>.autoDisposeWith(provider: ScopeProvider): FlowableSubscribeProxy<T>
-    = this.to(AutoDispose.with(provider).flowable())
+    = this.to(AutoDispose.with(provider).forFlowable())
 
 /**
- * Extension that proxies to [Observable.to] + [AutoDispose.with] + [ScopeHandler.observable]
+ * Extension that proxies to [Observable.to] + [AutoDispose.with] + [ScopeHandler.forObservable]
  */
 @CheckReturnValue
 inline fun <T> Observable<T>.autoDisposeWith(provider: ScopeProvider): ObservableSubscribeProxy<T>
-    = this.to(AutoDispose.with(provider).observable())
+    = this.to(AutoDispose.with(provider).forObservable())
 
 /**
- * Extension that proxies to [Single.to] + [AutoDispose.with] + [ScopeHandler.single]
+ * Extension that proxies to [Single.to] + [AutoDispose.with] + [ScopeHandler.forSingle]
  */
 @CheckReturnValue
 inline fun <T> Single<T>.autoDisposeWith(provider: ScopeProvider): SingleSubscribeProxy<T>
-    = this.to(AutoDispose.with(provider).single())
+    = this.to(AutoDispose.with(provider).forSingle())
 
 /**
- * Extension that proxies to [Maybe.to] + [AutoDispose.with] + [ScopeHandler.maybe]
+ * Extension that proxies to [Maybe.to] + [AutoDispose.with] + [ScopeHandler.forMaybe]
  */
 @CheckReturnValue
 inline fun <T> Maybe<T>.autoDisposeWith(provider: ScopeProvider): MaybeSubscribeProxy<T>
-    = this.to(AutoDispose.with(provider).maybe())
+    = this.to(AutoDispose.with(provider).forMaybe())
 
 /**
- * Extension that proxies to [Completable.to] + [AutoDispose.with] + [ScopeHandler.completable]
+ * Extension that proxies to [Completable.to] + [AutoDispose.with] + [ScopeHandler.forCompletable]
  */
 @CheckReturnValue
 inline fun Completable.autoDisposeWith(provider: ScopeProvider): CompletableSubscribeProxy
-    = this.to(AutoDispose.with(provider).completable())
+    = this.to(AutoDispose.with(provider).forCompletable())
 
 /**
- * Extension that proxies to [Flowable.to] + [AutoDispose.with]+ [ScopeHandler.flowable]
+ * Extension that proxies to [Flowable.to] + [AutoDispose.with]+ [ScopeHandler.forFlowable]
  *
  */
 @CheckReturnValue
 inline fun <T> Flowable<T>.autoDisposeWith(
     provider: LifecycleScopeProvider<*>): FlowableSubscribeProxy<T>
-    = this.to(AutoDispose.with(provider).flowable())
+    = this.to(AutoDispose.with(provider).forFlowable())
 
 /**
- * Extension that proxies to [Observable.to] + [AutoDispose.with] + [ScopeHandler.observable]
+ * Extension that proxies to [Observable.to] + [AutoDispose.with] + [ScopeHandler.forObservable]
  */
 @CheckReturnValue
 inline fun <T> Observable<T>.autoDisposeWith(
     provider: LifecycleScopeProvider<*>): ObservableSubscribeProxy<T>
-    = this.to(AutoDispose.with(provider).observable())
+    = this.to(AutoDispose.with(provider).forObservable())
 
 /**
- * Extension that proxies to [Single.to] + [AutoDispose.with] + [ScopeHandler.single]
+ * Extension that proxies to [Single.to] + [AutoDispose.with] + [ScopeHandler.forSingle]
  */
 @CheckReturnValue
 inline fun <T> Single<T>.autoDisposeWith(
     provider: LifecycleScopeProvider<*>): SingleSubscribeProxy<T>
-    = this.to(AutoDispose.with(provider).single())
+    = this.to(AutoDispose.with(provider).forSingle())
 
 /**
- * Extension that proxies to [Maybe.to] + [AutoDispose.with] + [ScopeHandler.maybe]
+ * Extension that proxies to [Maybe.to] + [AutoDispose.with] + [ScopeHandler.forMaybe]
  */
 @CheckReturnValue
 inline fun <T> Maybe<T>.autoDisposeWith(provider: LifecycleScopeProvider<*>): MaybeSubscribeProxy<T>
-    = this.to(AutoDispose.with(provider).maybe())
+    = this.to(AutoDispose.with(provider).forMaybe())
 
 /**
- * Extension that proxies to [Completable.to] + [AutoDispose.with]+ [ScopeHandler.completable]
+ * Extension that proxies to [Completable.to] + [AutoDispose.with]+ [ScopeHandler.forCompletable]
  */
 @CheckReturnValue
 inline fun Completable.autoDisposeWith(
     provider: LifecycleScopeProvider<*>): CompletableSubscribeProxy
-    = this.to(AutoDispose.with(provider).completable())
+    = this.to(AutoDispose.with(provider).forCompletable())
 

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -23,28 +23,143 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.functions.Function;
 
+/**
+ * Factories for autodispose transformation {@link Function}s that can be used with RxJava types'
+ * corresponding {@code to(...)} methods to transform them into auto-disposing streams.
+ * <p>
+ * There are several static {@code with(...)} entry points, with the most basic being a simple
+ * {@link #with(Maybe)}. The provided {@link Maybe} is ultimately what every scope resolves to
+ * under the hood, and AutoDispose has some built-in understanding for predefined types. The scope
+ * is considered ended upon onSuccess emission of this {@link Maybe}. The most common use case would
+ * probably be {@link #with(ScopeProvider)}.
+ * <p>
+ * Every factory method returns an instance of a {@link ScopeHandler} that serves as an indirection
+ * to route to the corresponding RxJava types. This is structured in such a way to be friendly to
+ * autocompletion in IDEs, where the no-parameter generic method will autocomplete with the
+ * appropriate generic parameters in Java <7, or implicitly in >=8.
+ *
+ * @see Flowable#to(Function)
+ * @see Observable#to(Function)
+ * @see Maybe#to(Function)
+ * @see Single#to(Function)
+ * @see Completable#to(Function)
+ * @see ScopeHandler#flowable()
+ * @see ScopeHandler#observable()
+ * @see ScopeHandler#maybe()
+ * @see ScopeHandler#single()
+ * @see ScopeHandler#completable()
+ */
 public final class AutoDispose {
 
+  /**
+   * The intermediary return type of the {@code with(...)} factories in {@link AutoDispose}. See the
+   * documentation on {@link AutoDispose} for more information on why this interface exists.
+   */
   public interface ScopeHandler {
+    /**
+     * Entry point for auto-disposing {@link Flowable}s.
+     * <p>
+     * The basic flow stencil might look like this:
+     * <pre><code>
+     *   myFlowable
+     *        .to(AutoDispose.with(scope).<T>flowable())
+     *        .subscribe(...)
+     * </code></pre>
+     *
+     * @param <T> the stream type.
+     * @return a {@link Function} to transform with {@link Flowable#to(Function)}
+     */
     <T> Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> flowable();
 
+    /**
+     * Entry point for auto-disposing {@link Observable}s.
+     * <p>
+     * The basic flow stencil might look like this:
+     * <pre><code>
+     *   myObservable
+     *        .to(AutoDispose.with(scope).<T>observable())
+     *        .subscribe(...)
+     * </code></pre>
+     *
+     * @param <T> the stream type.
+     * @return a {@link Function} to transform with {@link Observable#to(Function)}
+     */
     <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> observable();
 
+    /**
+     * Entry point for auto-disposing {@link Maybe}s.
+     * <p>
+     * The basic flow stencil might look like this:
+     * <pre><code>
+     *   myMaybe
+     *        .to(AutoDispose.with(scope).<T>maybe())
+     *        .subscribe(...)
+     * </code></pre>
+     *
+     * @param <T> the stream type.
+     * @return a {@link Function} to transform with {@link Maybe#to(Function)}
+     */
     <T> Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> maybe();
 
+    /**
+     * Entry point for auto-disposing {@link Single}s.
+     * <p>
+     * The basic flow stencil might look like this:
+     * <pre><code>
+     *   mySingle
+     *        .to(AutoDispose.with(scope).<T>single())
+     *        .subscribe(...)
+     * </code></pre>
+     *
+     * @param <T> the stream type.
+     * @return a {@link Function} to transform with {@link Single#to(Function)}
+     */
     <T> Function<Single<? extends T>, SingleSubscribeProxy<T>> single();
 
+    /**
+     * Entry point for auto-disposing {@link Completable}s.
+     * <p>
+     * The basic flow stencil might look like this:
+     * <pre><code>
+     *   myCompletable
+     *        .to(AutoDispose.with(scope).completable())
+     *        .subscribe(...)
+     * </code></pre>
+     *
+     * @return a {@link Function} to transform with {@link Completable#to(Function)}
+     */
     Function<Completable, CompletableSubscribeProxy> completable();
   }
 
+  /**
+   * The factory for {@link Maybe} scopes.
+   *
+   * @param scope the target scope
+   * @return a {@link ScopeHandler} for this scope to create AutoDisposing transformation
+   * {@link Function}s
+   */
   public static ScopeHandler with(Maybe<?> scope) {
     return new MaybeScopeHandlerImpl(scope);
   }
 
+  /**
+   * The factory for {@link ScopeProvider} scopes.
+   *
+   * @param scope the target scope
+   * @return a {@link ScopeHandler} for this scope to create AutoDisposing transformation
+   * {@link Function}s
+   */
   public static ScopeHandler with(ScopeProvider scope) {
     return new ScopeProviderHandlerImpl(scope);
   }
 
+  /**
+   * The factory for {@link LifecycleScopeProvider} scopes.
+   *
+   * @param scope the target scope
+   * @return a {@link ScopeHandler} for this scope to create AutoDisposing transformation
+   * {@link Function}s
+   */
   public static ScopeHandler with(LifecycleScopeProvider<?> scope) {
     return new LifecycleScopeProviderHandlerImpl(scope);
   }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -17,6 +17,7 @@
 package com.uber.autodispose;
 
 import io.reactivex.Completable;
+import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
@@ -25,6 +26,8 @@ import io.reactivex.functions.Function;
 public final class AutoDispose {
 
   public interface ScopeHandler {
+    <T> Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> flowable();
+
     <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> observable();
 
     <T> Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> maybe();
@@ -54,6 +57,10 @@ public final class AutoDispose {
       this.scope = scope;
     }
 
+    @Override public <T> Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> flowable() {
+      return new FlowableScoper<>(scope);
+    }
+
     @Override
     public <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> observable() {
       return new ObservableScoper<>(scope);
@@ -80,6 +87,10 @@ public final class AutoDispose {
       this.scope = scope;
     }
 
+    @Override public <T> Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> flowable() {
+      return new FlowableScoper<>(scope);
+    }
+
     @Override
     public <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> observable() {
       return new ObservableScoper<>(scope);
@@ -104,6 +115,10 @@ public final class AutoDispose {
 
     LifecycleScopeProviderHandlerImpl(LifecycleScopeProvider<?> scope) {
       this.scope = scope;
+    }
+
+    @Override public <T> Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> flowable() {
+      return new FlowableScoper<>(scope);
     }
 
     @Override

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -138,4 +138,8 @@ public final class AutoDispose {
       return new CompletableScoper(scope);
     }
   }
+
+  private AutoDispose() {
+    throw new AssertionError("No instances");
+  }
 }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -49,6 +49,7 @@ import io.reactivex.functions.Function;
  * @see ScopeHandler#single()
  * @see ScopeHandler#completable()
  */
+@SuppressWarnings("deprecation") // Temporary until we remove and inline the Scoper classes
 public final class AutoDispose {
 
   /**

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -31,8 +31,7 @@ import io.reactivex.functions.Function;
  * There are several static {@code with(...)} entry points, with the most basic being a simple
  * {@link #with(Maybe)}. The provided {@link Maybe} is ultimately what every scope resolves to
  * under the hood, and AutoDispose has some built-in understanding for predefined types. The scope
- * is considered ended upon onSuccess emission of this {@link Maybe}. The most common use case would
- * probably be {@link #with(ScopeProvider)}.
+ * is considered ended upon onSuccess emission of this {@link Maybe}.
  * <p>
  * Every factory method returns an instance of a {@link ScopeHandler} that serves as an indirection
  * to route to the corresponding RxJava types. This is structured in such a way to be friendly to
@@ -61,10 +60,10 @@ public final class AutoDispose {
     /**
      * Entry point for auto-disposing {@link Flowable}s.
      * <p>
-     * The basic flow stencil might look like this:
+     * Example usage:
      * <pre><code>
-     *   myFlowable
-     *        .to(AutoDispose.with(scope).<T>flowable())
+     *   Flowable.just(1)
+     *        .to(AutoDispose.with(scope).<Integer>flowable())
      *        .subscribe(...)
      * </code></pre>
      *
@@ -76,10 +75,10 @@ public final class AutoDispose {
     /**
      * Entry point for auto-disposing {@link Observable}s.
      * <p>
-     * The basic flow stencil might look like this:
+     * Example usage:
      * <pre><code>
-     *   myObservable
-     *        .to(AutoDispose.with(scope).<T>observable())
+     *   Observable.just(1)
+     *        .to(AutoDispose.with(scope).<Integer>observable())
      *        .subscribe(...)
      * </code></pre>
      *
@@ -92,10 +91,10 @@ public final class AutoDispose {
     /**
      * Entry point for auto-disposing {@link Maybe}s.
      * <p>
-     * The basic flow stencil might look like this:
+     * Example usage:
      * <pre><code>
-     *   myMaybe
-     *        .to(AutoDispose.with(scope).<T>maybe())
+     *   Maybe.just(1)
+     *        .to(AutoDispose.with(scope).<Integer>maybe())
      *        .subscribe(...)
      * </code></pre>
      *
@@ -107,10 +106,10 @@ public final class AutoDispose {
     /**
      * Entry point for auto-disposing {@link Single}s.
      * <p>
-     * The basic flow stencil might look like this:
+     * Example usage:
      * <pre><code>
-     *   mySingle
-     *        .to(AutoDispose.with(scope).<T>single())
+     *   Single.just(1)
+     *        .to(AutoDispose.with(scope).<Integer>single())
      *        .subscribe(...)
      * </code></pre>
      *
@@ -122,9 +121,9 @@ public final class AutoDispose {
     /**
      * Entry point for auto-disposing {@link Completable}s.
      * <p>
-     * The basic flow stencil might look like this:
+     * Example usage:
      * <pre><code>
-     *   myCompletable
+     *   Completable.complete()
      *        .to(AutoDispose.with(scope).completable())
      *        .subscribe(...)
      * </code></pre>

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -21,6 +21,7 @@ import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
+import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.functions.Function;
 
 /**
@@ -70,7 +71,7 @@ public final class AutoDispose {
      * @param <T> the stream type.
      * @return a {@link Function} to transform with {@link Flowable#to(Function)}
      */
-    <T> Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> flowable();
+    @CheckReturnValue <T> Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> flowable();
 
     /**
      * Entry point for auto-disposing {@link Observable}s.
@@ -85,6 +86,7 @@ public final class AutoDispose {
      * @param <T> the stream type.
      * @return a {@link Function} to transform with {@link Observable#to(Function)}
      */
+    @CheckReturnValue
     <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> observable();
 
     /**
@@ -100,7 +102,7 @@ public final class AutoDispose {
      * @param <T> the stream type.
      * @return a {@link Function} to transform with {@link Maybe#to(Function)}
      */
-    <T> Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> maybe();
+    @CheckReturnValue <T> Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> maybe();
 
     /**
      * Entry point for auto-disposing {@link Single}s.
@@ -115,7 +117,7 @@ public final class AutoDispose {
      * @param <T> the stream type.
      * @return a {@link Function} to transform with {@link Single#to(Function)}
      */
-    <T> Function<Single<? extends T>, SingleSubscribeProxy<T>> single();
+    @CheckReturnValue <T> Function<Single<? extends T>, SingleSubscribeProxy<T>> single();
 
     /**
      * Entry point for auto-disposing {@link Completable}s.
@@ -129,7 +131,7 @@ public final class AutoDispose {
      *
      * @return a {@link Function} to transform with {@link Completable#to(Function)}
      */
-    Function<Completable, CompletableSubscribeProxy> completable();
+    @CheckReturnValue Function<Completable, CompletableSubscribeProxy> completable();
   }
 
   /**
@@ -139,7 +141,7 @@ public final class AutoDispose {
    * @return a {@link ScopeHandler} for this scope to create AutoDisposing transformation
    * {@link Function}s
    */
-  public static ScopeHandler with(Maybe<?> scope) {
+  @CheckReturnValue public static ScopeHandler with(Maybe<?> scope) {
     return new MaybeScopeHandlerImpl(scope);
   }
 
@@ -150,7 +152,7 @@ public final class AutoDispose {
    * @return a {@link ScopeHandler} for this scope to create AutoDisposing transformation
    * {@link Function}s
    */
-  public static ScopeHandler with(ScopeProvider scope) {
+  @CheckReturnValue public static ScopeHandler with(ScopeProvider scope) {
     return new ScopeProviderHandlerImpl(scope);
   }
 
@@ -161,7 +163,7 @@ public final class AutoDispose {
    * @return a {@link ScopeHandler} for this scope to create AutoDisposing transformation
    * {@link Function}s
    */
-  public static ScopeHandler with(LifecycleScopeProvider<?> scope) {
+  @CheckReturnValue public static ScopeHandler with(LifecycleScopeProvider<?> scope) {
     return new LifecycleScopeProviderHandlerImpl(scope);
   }
 

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -43,11 +43,11 @@ import io.reactivex.functions.Function;
  * @see Maybe#to(Function)
  * @see Single#to(Function)
  * @see Completable#to(Function)
- * @see ScopeHandler#flowable()
- * @see ScopeHandler#observable()
- * @see ScopeHandler#maybe()
- * @see ScopeHandler#single()
- * @see ScopeHandler#completable()
+ * @see ScopeHandler#forFlowable()
+ * @see ScopeHandler#forObservable()
+ * @see ScopeHandler#forMaybe()
+ * @see ScopeHandler#forSingle()
+ * @see ScopeHandler#forCompletable()
  */
 @SuppressWarnings("deprecation") // Temporary until we remove and inline the Scoper classes
 public final class AutoDispose {
@@ -63,14 +63,14 @@ public final class AutoDispose {
      * Example usage:
      * <pre><code>
      *   Flowable.just(1)
-     *        .to(AutoDispose.with(scope).<Integer>flowable())
+     *        .to(AutoDispose.with(scope).<Integer>forFlowable())
      *        .subscribe(...)
      * </code></pre>
      *
      * @param <T> the stream type.
      * @return a {@link Function} to transform with {@link Flowable#to(Function)}
      */
-    @CheckReturnValue <T> Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> flowable();
+    @CheckReturnValue <T> Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> forFlowable();
 
     /**
      * Entry point for auto-disposing {@link Observable}s.
@@ -78,7 +78,7 @@ public final class AutoDispose {
      * Example usage:
      * <pre><code>
      *   Observable.just(1)
-     *        .to(AutoDispose.with(scope).<Integer>observable())
+     *        .to(AutoDispose.with(scope).<Integer>forObservable())
      *        .subscribe(...)
      * </code></pre>
      *
@@ -86,7 +86,7 @@ public final class AutoDispose {
      * @return a {@link Function} to transform with {@link Observable#to(Function)}
      */
     @CheckReturnValue
-    <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> observable();
+    <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> forObservable();
 
     /**
      * Entry point for auto-disposing {@link Maybe}s.
@@ -94,14 +94,14 @@ public final class AutoDispose {
      * Example usage:
      * <pre><code>
      *   Maybe.just(1)
-     *        .to(AutoDispose.with(scope).<Integer>maybe())
+     *        .to(AutoDispose.with(scope).<Integer>forMaybe())
      *        .subscribe(...)
      * </code></pre>
      *
      * @param <T> the stream type.
      * @return a {@link Function} to transform with {@link Maybe#to(Function)}
      */
-    @CheckReturnValue <T> Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> maybe();
+    @CheckReturnValue <T> Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> forMaybe();
 
     /**
      * Entry point for auto-disposing {@link Single}s.
@@ -109,14 +109,14 @@ public final class AutoDispose {
      * Example usage:
      * <pre><code>
      *   Single.just(1)
-     *        .to(AutoDispose.with(scope).<Integer>single())
+     *        .to(AutoDispose.with(scope).<Integer>forSingle())
      *        .subscribe(...)
      * </code></pre>
      *
      * @param <T> the stream type.
      * @return a {@link Function} to transform with {@link Single#to(Function)}
      */
-    @CheckReturnValue <T> Function<Single<? extends T>, SingleSubscribeProxy<T>> single();
+    @CheckReturnValue <T> Function<Single<? extends T>, SingleSubscribeProxy<T>> forSingle();
 
     /**
      * Entry point for auto-disposing {@link Completable}s.
@@ -124,13 +124,13 @@ public final class AutoDispose {
      * Example usage:
      * <pre><code>
      *   Completable.complete()
-     *        .to(AutoDispose.with(scope).completable())
+     *        .to(AutoDispose.with(scope).forCompletable())
      *        .subscribe(...)
      * </code></pre>
      *
      * @return a {@link Function} to transform with {@link Completable#to(Function)}
      */
-    @CheckReturnValue Function<Completable, CompletableSubscribeProxy> completable();
+    @CheckReturnValue Function<Completable, CompletableSubscribeProxy> forCompletable();
   }
 
   /**
@@ -174,24 +174,24 @@ public final class AutoDispose {
       this.scope = scope;
     }
 
-    @Override public <T> Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> flowable() {
+    @Override public <T> Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> forFlowable() {
       return new FlowableScoper<>(scope);
     }
 
     @Override
-    public <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> observable() {
+    public <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> forObservable() {
       return new ObservableScoper<>(scope);
     }
 
-    @Override public <T> Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> maybe() {
+    @Override public <T> Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> forMaybe() {
       return new MaybeScoper<>(scope);
     }
 
-    @Override public <T> Function<Single<? extends T>, SingleSubscribeProxy<T>> single() {
+    @Override public <T> Function<Single<? extends T>, SingleSubscribeProxy<T>> forSingle() {
       return new SingleScoper<>(scope);
     }
 
-    @Override public Function<Completable, CompletableSubscribeProxy> completable() {
+    @Override public Function<Completable, CompletableSubscribeProxy> forCompletable() {
       return new CompletableScoper(scope);
     }
   }
@@ -204,24 +204,24 @@ public final class AutoDispose {
       this.scope = scope;
     }
 
-    @Override public <T> Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> flowable() {
+    @Override public <T> Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> forFlowable() {
       return new FlowableScoper<>(scope);
     }
 
     @Override
-    public <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> observable() {
+    public <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> forObservable() {
       return new ObservableScoper<>(scope);
     }
 
-    @Override public <T> Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> maybe() {
+    @Override public <T> Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> forMaybe() {
       return new MaybeScoper<>(scope);
     }
 
-    @Override public <T> Function<Single<? extends T>, SingleSubscribeProxy<T>> single() {
+    @Override public <T> Function<Single<? extends T>, SingleSubscribeProxy<T>> forSingle() {
       return new SingleScoper<>(scope);
     }
 
-    @Override public Function<Completable, CompletableSubscribeProxy> completable() {
+    @Override public Function<Completable, CompletableSubscribeProxy> forCompletable() {
       return new CompletableScoper(scope);
     }
   }
@@ -234,24 +234,24 @@ public final class AutoDispose {
       this.scope = scope;
     }
 
-    @Override public <T> Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> flowable() {
+    @Override public <T> Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> forFlowable() {
       return new FlowableScoper<>(scope);
     }
 
     @Override
-    public <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> observable() {
+    public <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> forObservable() {
       return new ObservableScoper<>(scope);
     }
 
-    @Override public <T> Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> maybe() {
+    @Override public <T> Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> forMaybe() {
       return new MaybeScoper<>(scope);
     }
 
-    @Override public <T> Function<Single<? extends T>, SingleSubscribeProxy<T>> single() {
+    @Override public <T> Function<Single<? extends T>, SingleSubscribeProxy<T>> forSingle() {
       return new SingleScoper<>(scope);
     }
 
-    @Override public Function<Completable, CompletableSubscribeProxy> completable() {
+    @Override public Function<Completable, CompletableSubscribeProxy> forCompletable() {
       return new CompletableScoper(scope);
     }
   }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose;
+
+import io.reactivex.Completable;
+import io.reactivex.Maybe;
+import io.reactivex.Observable;
+import io.reactivex.Single;
+import io.reactivex.functions.Function;
+
+public final class AutoDispose {
+
+  public interface ScopeHandler {
+    <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> observable();
+
+    <T> Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> maybe();
+
+    <T> Function<Single<? extends T>, SingleSubscribeProxy<T>> single();
+
+    Function<Completable, CompletableSubscribeProxy> completable();
+  }
+
+  public static ScopeHandler with(Maybe<?> scope) {
+    return new MaybeScopeHandlerImpl(scope);
+  }
+
+  public static ScopeHandler with(ScopeProvider scope) {
+    return new ScopeProviderHandlerImpl(scope);
+  }
+
+  public static ScopeHandler with(LifecycleScopeProvider<?> scope) {
+    return new LifecycleScopeProviderHandlerImpl(scope);
+  }
+
+  private static class MaybeScopeHandlerImpl implements ScopeHandler {
+
+    private final Maybe<?> scope;
+
+    MaybeScopeHandlerImpl(Maybe<?> scope) {
+      this.scope = scope;
+    }
+
+    @Override
+    public <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> observable() {
+      return new ObservableScoper<>(scope);
+    }
+
+    @Override public <T> Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> maybe() {
+      return new MaybeScoper<>(scope);
+    }
+
+    @Override public <T> Function<Single<? extends T>, SingleSubscribeProxy<T>> single() {
+      return new SingleScoper<>(scope);
+    }
+
+    @Override public Function<Completable, CompletableSubscribeProxy> completable() {
+      return new CompletableScoper(scope);
+    }
+  }
+
+  private static class ScopeProviderHandlerImpl implements ScopeHandler {
+
+    private final ScopeProvider scope;
+
+    ScopeProviderHandlerImpl(ScopeProvider scope) {
+      this.scope = scope;
+    }
+
+    @Override
+    public <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> observable() {
+      return new ObservableScoper<>(scope);
+    }
+
+    @Override public <T> Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> maybe() {
+      return new MaybeScoper<>(scope);
+    }
+
+    @Override public <T> Function<Single<? extends T>, SingleSubscribeProxy<T>> single() {
+      return new SingleScoper<>(scope);
+    }
+
+    @Override public Function<Completable, CompletableSubscribeProxy> completable() {
+      return new CompletableScoper(scope);
+    }
+  }
+
+  private static class LifecycleScopeProviderHandlerImpl implements ScopeHandler {
+
+    private final LifecycleScopeProvider<?> scope;
+
+    LifecycleScopeProviderHandlerImpl(LifecycleScopeProvider<?> scope) {
+      this.scope = scope;
+    }
+
+    @Override
+    public <T> Function<Observable<? extends T>, ObservableSubscribeProxy<T>> observable() {
+      return new ObservableScoper<>(scope);
+    }
+
+    @Override public <T> Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> maybe() {
+      return new MaybeScoper<>(scope);
+    }
+
+    @Override public <T> Function<Single<? extends T>, SingleSubscribeProxy<T>> single() {
+      return new SingleScoper<>(scope);
+    }
+
+    @Override public Function<Completable, CompletableSubscribeProxy> completable() {
+      return new CompletableScoper(scope);
+    }
+  }
+}

--- a/autodispose/src/main/java/com/uber/autodispose/CompletableScoper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/CompletableScoper.java
@@ -40,7 +40,10 @@ import io.reactivex.functions.Function;
  * under the hood, and AutoDispose has some built-in understanding for predefined types. The scope
  * is considered ended upon onSuccess emission of this {@link Maybe}. The most common use case would
  * probably be {@link #CompletableScoper(ScopeProvider)}.
+ *
+ * @deprecated Use the static factories in {@link AutoDispose}. This will be removed in 1.0.
  */
+@Deprecated
 public class CompletableScoper extends Scoper
     implements Function<Completable, CompletableSubscribeProxy> {
 

--- a/autodispose/src/main/java/com/uber/autodispose/FlowableScoper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/FlowableScoper.java
@@ -43,7 +43,9 @@ import org.reactivestreams.Subscription;
  * probably be {@link #FlowableScoper(ScopeProvider)}.
  *
  * @param <T> the stream type.
+ * @deprecated Use the static factories in {@link AutoDispose}. This will be removed in 1.0.
  */
+@Deprecated
 public class FlowableScoper<T> extends Scoper
     implements Function<Flowable<? extends T>, FlowableSubscribeProxy<T>> {
 

--- a/autodispose/src/main/java/com/uber/autodispose/MaybeScoper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/MaybeScoper.java
@@ -41,7 +41,9 @@ import io.reactivex.functions.Function;
  * probably be {@link #MaybeScoper(ScopeProvider)}.
  *
  * @param <T> the stream type.
+ * @deprecated Use the static factories in {@link AutoDispose}. This will be removed in 1.0.
  */
+@Deprecated
 public class MaybeScoper<T> extends Scoper
     implements Function<Maybe<? extends T>, MaybeSubscribeProxy<T>> {
 

--- a/autodispose/src/main/java/com/uber/autodispose/ObservableScoper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/ObservableScoper.java
@@ -42,7 +42,9 @@ import io.reactivex.functions.Function;
  * probably be {@link #ObservableScoper(ScopeProvider)}.
  *
  * @param <T> the stream type.
+ * @deprecated Use the static factories in {@link AutoDispose}. This will be removed in 1.0.
  */
+@Deprecated
 public class ObservableScoper<T> extends Scoper
     implements Function<Observable<? extends T>, ObservableSubscribeProxy<T>> {
 

--- a/autodispose/src/main/java/com/uber/autodispose/SingleScoper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/SingleScoper.java
@@ -42,7 +42,9 @@ import io.reactivex.functions.Function;
  * probably be {@link #SingleScoper(ScopeProvider)}.
  *
  * @param <T> the stream type.
+ * @deprecated Use the static factories in {@link AutoDispose}. This will be removed in 1.0.
  */
+@Deprecated
 public class SingleScoper<T> extends Scoper
     implements Function<Single<? extends T>, SingleSubscribeProxy<T>> {
 

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -318,11 +318,12 @@ public class AutoDisposeCompletableObserverTest {
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(
           AutoDisposingCompletableObserver.class);
-      assertThat(
-          ((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
-      assertThat(
-          ((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isSameAs(
-          atomicObserver.get());
+      assertThat(((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get())
+              .delegateObserver())
+          .isNotNull();
+      assertThat(((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get())
+              .delegateObserver())
+          .isSameAs(atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -58,7 +58,7 @@ public class AutoDisposeCompletableObserverTest {
     CompletableSubject source = CompletableSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
     source.to(AutoDispose.with(lifecycle)
-        .completable())
+        .forCompletable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -80,7 +80,7 @@ public class AutoDisposeCompletableObserverTest {
     CompletableSubject source = CompletableSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
     source.to(AutoDispose.with(lifecycle)
-        .completable())
+        .forCompletable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -103,7 +103,7 @@ public class AutoDisposeCompletableObserverTest {
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = makeProvider(scope);
     source.to(AutoDispose.with(provider)
-        .completable())
+        .forCompletable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -124,7 +124,7 @@ public class AutoDisposeCompletableObserverTest {
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = makeProvider(scope);
     source.to(AutoDispose.with(provider)
-        .completable())
+        .forCompletable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -148,7 +148,7 @@ public class AutoDisposeCompletableObserverTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     source.to(AutoDispose.with(provider)
-        .completable())
+        .forCompletable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -174,7 +174,7 @@ public class AutoDisposeCompletableObserverTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     source.to(AutoDispose.with(provider)
-        .completable())
+        .forCompletable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -203,7 +203,7 @@ public class AutoDisposeCompletableObserverTest {
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Completable.complete()
         .to(AutoDispose.with(provider)
-            .completable())
+            .forCompletable())
         .subscribe(o);
 
     o.takeSubscribe();
@@ -219,7 +219,7 @@ public class AutoDisposeCompletableObserverTest {
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Completable.complete()
         .to(AutoDispose.with(provider)
-            .completable())
+            .forCompletable())
         .subscribe(o);
 
     o.takeSubscribe();
@@ -235,7 +235,7 @@ public class AutoDisposeCompletableObserverTest {
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     CompletableSubject source = CompletableSubject.create();
     source.to(AutoDispose.with(provider)
-        .completable())
+        .forCompletable())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -258,7 +258,7 @@ public class AutoDisposeCompletableObserverTest {
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     CompletableSubject source = CompletableSubject.create();
     source.to(AutoDispose.with(provider)
-        .completable())
+        .forCompletable())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -280,7 +280,7 @@ public class AutoDisposeCompletableObserverTest {
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     CompletableSubject source = CompletableSubject.create();
     source.to(AutoDispose.with(provider)
-        .completable())
+        .forCompletable())
         .subscribe(o);
 
     o.assertNoValues();
@@ -312,7 +312,7 @@ public class AutoDisposeCompletableObserverTest {
           });
       Completable.complete()
           .to(AutoDispose.with(Maybe.never())
-              .completable())
+              .forCompletable())
           .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
@@ -343,7 +343,7 @@ public class AutoDisposeCompletableObserverTest {
     });
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
     source.to(AutoDispose.with(lifecycle)
-        .completable())
+        .forCompletable())
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -63,7 +63,7 @@ public class AutoDisposeCompletableObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     CompletableSubject source = CompletableSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(new CompletableScoper(lifecycle))
+    source.to(AutoDispose.with(lifecycle).completable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -85,7 +85,7 @@ public class AutoDisposeCompletableObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     CompletableSubject source = CompletableSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(new CompletableScoper(lifecycle))
+    source.to(AutoDispose.with(lifecycle).completable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -108,7 +108,7 @@ public class AutoDisposeCompletableObserverTest {
     CompletableSubject source = CompletableSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.to(new CompletableScoper(provider))
+    source.to(AutoDispose.with(provider).completable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -129,7 +129,7 @@ public class AutoDisposeCompletableObserverTest {
     CompletableSubject source = CompletableSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.to(new CompletableScoper(provider))
+    source.to(AutoDispose.with(provider).completable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -153,7 +153,7 @@ public class AutoDisposeCompletableObserverTest {
     CompletableSubject source = CompletableSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.to(new CompletableScoper(provider))
+    source.to(AutoDispose.with(provider).completable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -179,7 +179,7 @@ public class AutoDisposeCompletableObserverTest {
     CompletableSubject source = CompletableSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.to(new CompletableScoper(provider))
+    source.to(AutoDispose.with(provider).completable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -208,7 +208,8 @@ public class AutoDisposeCompletableObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Completable.complete()
-        .to(new CompletableScoper(provider))
+        .to(AutoDispose.with(provider)
+            .completable())
         .subscribe(o);
 
     o.takeSubscribe();
@@ -224,7 +225,8 @@ public class AutoDisposeCompletableObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Completable.complete()
-        .to(new CompletableScoper(provider))
+        .to(AutoDispose.with(provider)
+            .completable())
         .subscribe(o);
 
     o.takeSubscribe();
@@ -241,7 +243,7 @@ public class AutoDisposeCompletableObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     CompletableSubject source = CompletableSubject.create();
-    source.to(new CompletableScoper(provider))
+    source.to(AutoDispose.with(provider).completable())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -265,7 +267,7 @@ public class AutoDisposeCompletableObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     CompletableSubject source = CompletableSubject.create();
-    source.to(new CompletableScoper(provider))
+    source.to(AutoDispose.with(provider).completable())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -288,7 +290,7 @@ public class AutoDisposeCompletableObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     CompletableSubject source = CompletableSubject.create();
-    source.to(new CompletableScoper(provider))
+    source.to(AutoDispose.with(provider).completable())
         .subscribe(o);
 
     o.assertNoValues();
@@ -352,7 +354,7 @@ public class AutoDisposeCompletableObserverTest {
       }
     });
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(new CompletableScoper(lifecycle))
+    source.to(AutoDispose.with(lifecycle).completable())
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -16,9 +16,8 @@
 
 package com.uber.autodispose;
 
-import com.uber.autodispose.test.RecordingObserver;
 import com.uber.autodispose.observers.AutoDisposingCompletableObserver;
-
+import com.uber.autodispose.test.RecordingObserver;
 import io.reactivex.Completable;
 import io.reactivex.CompletableEmitter;
 import io.reactivex.CompletableObserver;
@@ -33,10 +32,8 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.CompletableSubject;
 import io.reactivex.subjects.MaybeSubject;
-
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.junit.After;
 import org.junit.Test;
 
@@ -47,23 +44,21 @@ import static com.uber.autodispose.TestUtil.makeProvider;
 public class AutoDisposeCompletableObserverTest {
 
   private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
-    @Override
-    public void log(String message) {
+    @Override public void log(String message) {
       System.out.println(AutoDisposeCompletableObserverTest.class.getSimpleName() + ": " + message);
     }
   };
 
-  @After
-  public void resetPlugins() {
+  @After public void resetPlugins() {
     AutoDisposePlugins.reset();
   }
 
-  @Test
-  public void autoDispose_withMaybe_normal() {
+  @Test public void autoDispose_withMaybe_normal() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     CompletableSubject source = CompletableSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(AutoDispose.with(lifecycle).completable())
+    source.to(AutoDispose.with(lifecycle)
+        .completable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -80,12 +75,12 @@ public class AutoDisposeCompletableObserverTest {
     assertThat(lifecycle.hasObservers()).isFalse();
   }
 
-  @Test
-  public void autoDispose_withMaybe_interrupted() {
+  @Test public void autoDispose_withMaybe_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     CompletableSubject source = CompletableSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(AutoDispose.with(lifecycle).completable())
+    source.to(AutoDispose.with(lifecycle)
+        .completable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -102,13 +97,13 @@ public class AutoDisposeCompletableObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test
-  public void autoDispose_withProvider_completion() {
+  @Test public void autoDispose_withProvider_completion() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     CompletableSubject source = CompletableSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.to(AutoDispose.with(provider).completable())
+    source.to(AutoDispose.with(provider)
+        .completable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -123,13 +118,13 @@ public class AutoDisposeCompletableObserverTest {
     assertThat(scope.hasObservers()).isFalse();
   }
 
-  @Test
-  public void autoDispose_withProvider_interrupted() {
+  @Test public void autoDispose_withProvider_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     CompletableSubject source = CompletableSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.to(AutoDispose.with(provider).completable())
+    source.to(AutoDispose.with(provider)
+        .completable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -147,13 +142,13 @@ public class AutoDisposeCompletableObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test
-  public void autoDispose_withLifecycleProvider_completion() {
+  @Test public void autoDispose_withLifecycleProvider_completion() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     CompletableSubject source = CompletableSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.to(AutoDispose.with(provider).completable())
+    source.to(AutoDispose.with(provider)
+        .completable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -173,13 +168,13 @@ public class AutoDisposeCompletableObserverTest {
     assertThat(lifecycle.hasObservers()).isFalse();
   }
 
-  @Test
-  public void autoDispose_withLifecycleProvider_interrupted() {
+  @Test public void autoDispose_withLifecycleProvider_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     CompletableSubject source = CompletableSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.to(AutoDispose.with(provider).completable())
+    source.to(AutoDispose.with(provider)
+        .completable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -202,8 +197,7 @@ public class AutoDisposeCompletableObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test
-  public void autoDispose_withLifecycleProvider_withoutStartingLifecycle_shouldFail() {
+  @Test public void autoDispose_withLifecycleProvider_withoutStartingLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
@@ -216,8 +210,7 @@ public class AutoDisposeCompletableObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleNotStartedException.class);
   }
 
-  @Test
-  public void autoDispose_withLifecycleProvider_afterLifecycle_shouldFail() {
+  @Test public void autoDispose_withLifecycleProvider_afterLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
     lifecycle.onNext(2);
@@ -233,17 +226,16 @@ public class AutoDisposeCompletableObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
   }
 
-  @Test
-  public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
+  @Test public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override
-      public void accept(OutsideLifecycleException e) throws Exception { }
+      @Override public void accept(OutsideLifecycleException e) throws Exception { }
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     CompletableSubject source = CompletableSubject.create();
-    source.to(AutoDispose.with(provider).completable())
+    source.to(AutoDispose.with(provider)
+        .completable())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -252,11 +244,9 @@ public class AutoDisposeCompletableObserverTest {
     o.assertNoErrors();
   }
 
-  @Test
-  public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
+  @Test public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override
-      public void accept(OutsideLifecycleException e) throws Exception {
+      @Override public void accept(OutsideLifecycleException e) throws Exception {
         // Noop
       }
     });
@@ -267,7 +257,8 @@ public class AutoDisposeCompletableObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     CompletableSubject source = CompletableSubject.create();
-    source.to(AutoDispose.with(provider).completable())
+    source.to(AutoDispose.with(provider)
+        .completable())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -276,11 +267,9 @@ public class AutoDisposeCompletableObserverTest {
     o.assertNoErrors();
   }
 
-  @Test
-  public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithWrappedExp() {
+  @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithWrappedExp() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override
-      public void accept(OutsideLifecycleException e) throws Exception {
+      @Override public void accept(OutsideLifecycleException e) throws Exception {
         // Wrap in an IllegalStateException so we can verify this is the exception we see on the
         // other side
         throw new IllegalStateException(e);
@@ -290,71 +279,70 @@ public class AutoDisposeCompletableObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     CompletableSubject source = CompletableSubject.create();
-    source.to(AutoDispose.with(provider).completable())
+    source.to(AutoDispose.with(provider)
+        .completable())
         .subscribe(o);
 
     o.assertNoValues();
     o.assertError(new Predicate<Throwable>() {
-      @Override
-      public boolean test(Throwable throwable) throws Exception {
+      @Override public boolean test(Throwable throwable) throws Exception {
         return throwable instanceof IllegalStateException
             && throwable.getCause() instanceof OutsideLifecycleException;
       }
     });
   }
 
-  @Test
-  public void verifyObserverDelegate() {
+  @Test public void verifyObserverDelegate() {
     final AtomicReference<CompletableObserver> atomicObserver = new AtomicReference<>();
-    final AtomicReference<CompletableObserver> atomicAutoDisposingObserver
-        = new AtomicReference<>();
+    final AtomicReference<CompletableObserver> atomicAutoDisposingObserver =
+        new AtomicReference<>();
     try {
-      RxJavaPlugins.setOnCompletableSubscribe(new BiFunction<Completable,
-          CompletableObserver,
-          CompletableObserver>() {
-        @Override public CompletableObserver apply(
-            Completable source,
-            CompletableObserver observer) {
-          if (atomicObserver.get() == null) {
-            atomicObserver.set(observer);
-          } else if (atomicAutoDisposingObserver.get() == null) {
-            atomicAutoDisposingObserver.set(observer);
-            RxJavaPlugins.setOnObservableSubscribe(null);
-          }
-          return observer;
-        }
-      });
-      Completable.complete().to(new CompletableScoper(Maybe.never())).subscribe();
+      RxJavaPlugins.setOnCompletableSubscribe(
+          new BiFunction<Completable, CompletableObserver, CompletableObserver>() {
+            @Override
+            public CompletableObserver apply(Completable source, CompletableObserver observer) {
+              if (atomicObserver.get() == null) {
+                atomicObserver.set(observer);
+              } else if (atomicAutoDisposingObserver.get() == null) {
+                atomicAutoDisposingObserver.set(observer);
+                RxJavaPlugins.setOnObservableSubscribe(null);
+              }
+              return observer;
+            }
+          });
+      Completable.complete()
+          .to(AutoDispose.with(Maybe.never())
+              .completable())
+          .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
-      assertThat(atomicAutoDisposingObserver.get())
-          .isInstanceOf(AutoDisposingCompletableObserver.class);
-      assertThat(((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get())
-          .delegateObserver()).isNotNull();
-      assertThat(((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get())
-          .delegateObserver()).isSameAs(atomicObserver.get());
+      assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(
+          AutoDisposingCompletableObserver.class);
+      assertThat(
+          ((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
+      assertThat(
+          ((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isSameAs(
+          atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }
   }
 
-  @Test
-  public void verifyCancellation() throws Exception {
+  @Test public void verifyCancellation() throws Exception {
     final AtomicInteger i = new AtomicInteger();
     //noinspection unchecked because Java
     Completable source = Completable.create(new CompletableOnSubscribe() {
-      @Override
-      public void subscribe(CompletableEmitter e) throws Exception {
+      @Override public void subscribe(CompletableEmitter e) throws Exception {
         e.setCancellable(new Cancellable() {
-          @Override
-          public void cancel() throws Exception {
+          @Override public void cancel() throws Exception {
             i.incrementAndGet();
           }
         });
       }
     });
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(AutoDispose.with(lifecycle).completable())
+    source.to(AutoDispose.with(lifecycle)
+        .completable())
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -61,7 +61,7 @@ public class AutoDisposeMaybeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(new MaybeScoper<Integer>(lifecycle))
+    source.to(AutoDispose.with(lifecycle).<Integer>maybe())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -81,7 +81,7 @@ public class AutoDisposeMaybeObserverTest {
   @Test
   public void autoDispose_withSuperClassGenerics_compilesFine() {
     Maybe.just(new BClass())
-        .to(new MaybeScoper<AClass>(Maybe.never()))
+        .to(AutoDispose.with(Maybe.never()).<AClass>maybe())
         .subscribe(new Consumer<AClass>() {
           @Override
           public void accept(AClass aClass) throws Exception {
@@ -93,7 +93,8 @@ public class AutoDisposeMaybeObserverTest {
   @Test
   public void autoDispose_noGenericsOnEmpty_isFine() {
     Maybe.just(new BClass())
-        .to(new MaybeScoper<>(Maybe.never()))
+        .to(AutoDispose.with(Maybe.never())
+            .maybe())
         .subscribe();
   }
 
@@ -102,9 +103,9 @@ public class AutoDisposeMaybeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(new MaybeScoper<Integer>(lifecycle))
+    source.to(AutoDispose.with(lifecycle).<Integer>maybe())
         .subscribe(o);
-    source.to(new MaybeScoper<Integer>(lifecycle))
+    source.to(AutoDispose.with(lifecycle).<Integer>maybe())
         .subscribe(new Consumer<Integer>() {
           @Override
           public void accept(Integer integer) throws Exception {
@@ -132,7 +133,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.to(new MaybeScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>maybe())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -158,7 +159,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.to(new MaybeScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>maybe())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -179,7 +180,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.to(new MaybeScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>maybe())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -203,7 +204,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.to(new MaybeScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>maybe())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -229,7 +230,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.to(new MaybeScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>maybe())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -258,7 +259,7 @@ public class AutoDisposeMaybeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Maybe.just(1)
-        .to(new MaybeScoper<Integer>(provider))
+        .to(AutoDispose.with(provider).<Integer>maybe())
         .subscribe(o);
 
     o.takeSubscribe();
@@ -274,7 +275,7 @@ public class AutoDisposeMaybeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Maybe.just(1)
-        .to(new MaybeScoper<Integer>(provider))
+        .to(AutoDispose.with(provider).<Integer>maybe())
         .subscribe(o);
 
     o.takeSubscribe();
@@ -291,7 +292,7 @@ public class AutoDisposeMaybeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     MaybeSubject<Integer> source = MaybeSubject.create();
-    source.to(new MaybeScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>maybe())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -315,7 +316,7 @@ public class AutoDisposeMaybeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     MaybeSubject<Integer> source = MaybeSubject.create();
-    source.to(new MaybeScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>maybe())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -338,7 +339,7 @@ public class AutoDisposeMaybeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     MaybeSubject<Integer> source = MaybeSubject.create();
-    source.to(new MaybeScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>maybe())
         .subscribe(o);
 
     o.assertNoValues();
@@ -396,7 +397,7 @@ public class AutoDisposeMaybeObserverTest {
       }
     });
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(new MaybeScoper<Integer>(lifecycle))
+    source.to(AutoDispose.with(lifecycle).<Integer>maybe())
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -348,11 +348,12 @@ public class AutoDisposeMaybeObserverTest {
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingMaybeObserver.class);
-      assertThat(
-          ((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
-      assertThat(
-          ((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isSameAs(
-          atomicObserver.get());
+      assertThat(((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get())
+              .delegateObserver())
+          .isNotNull();
+      assertThat(((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get())
+              .delegateObserver())
+          .isSameAs(atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -55,7 +55,7 @@ public class AutoDisposeMaybeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(AutoDispose.with(lifecycle).<Integer>maybe())
+    source.to(AutoDispose.with(lifecycle).<Integer>forMaybe())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -74,7 +74,7 @@ public class AutoDisposeMaybeObserverTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Maybe.just(new BClass())
-        .to(AutoDispose.with(Maybe.never()).<AClass>maybe())
+        .to(AutoDispose.with(Maybe.never()).<AClass>forMaybe())
         .subscribe(new Consumer<AClass>() {
           @Override public void accept(AClass aClass) throws Exception {
 
@@ -85,7 +85,7 @@ public class AutoDisposeMaybeObserverTest {
   @Test public void autoDispose_noGenericsOnEmpty_isFine() {
     Maybe.just(new BClass())
         .to(AutoDispose.with(Maybe.never())
-            .maybe())
+            .forMaybe())
         .subscribe();
   }
 
@@ -93,9 +93,9 @@ public class AutoDisposeMaybeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(AutoDispose.with(lifecycle).<Integer>maybe())
+    source.to(AutoDispose.with(lifecycle).<Integer>forMaybe())
         .subscribe(o);
-    source.to(AutoDispose.with(lifecycle).<Integer>maybe())
+    source.to(AutoDispose.with(lifecycle).<Integer>forMaybe())
         .subscribe(new Consumer<Integer>() {
           @Override public void accept(Integer integer) throws Exception {
 
@@ -121,7 +121,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.to(AutoDispose.with(provider).<Integer>maybe())
+    source.to(AutoDispose.with(provider).<Integer>forMaybe())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -146,7 +146,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.to(AutoDispose.with(provider).<Integer>maybe())
+    source.to(AutoDispose.with(provider).<Integer>forMaybe())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -166,7 +166,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.to(AutoDispose.with(provider).<Integer>maybe())
+    source.to(AutoDispose.with(provider).<Integer>forMaybe())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -189,7 +189,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.to(AutoDispose.with(provider).<Integer>maybe())
+    source.to(AutoDispose.with(provider).<Integer>forMaybe())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -214,7 +214,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.to(AutoDispose.with(provider).<Integer>maybe())
+    source.to(AutoDispose.with(provider).<Integer>forMaybe())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -242,7 +242,7 @@ public class AutoDisposeMaybeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Maybe.just(1)
-        .to(AutoDispose.with(provider).<Integer>maybe())
+        .to(AutoDispose.with(provider).<Integer>forMaybe())
         .subscribe(o);
 
     o.takeSubscribe();
@@ -257,7 +257,7 @@ public class AutoDisposeMaybeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Maybe.just(1)
-        .to(AutoDispose.with(provider).<Integer>maybe())
+        .to(AutoDispose.with(provider).<Integer>forMaybe())
         .subscribe(o);
 
     o.takeSubscribe();
@@ -272,7 +272,7 @@ public class AutoDisposeMaybeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     MaybeSubject<Integer> source = MaybeSubject.create();
-    source.to(AutoDispose.with(provider).<Integer>maybe())
+    source.to(AutoDispose.with(provider).<Integer>forMaybe())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -294,7 +294,7 @@ public class AutoDisposeMaybeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     MaybeSubject<Integer> source = MaybeSubject.create();
-    source.to(AutoDispose.with(provider).<Integer>maybe())
+    source.to(AutoDispose.with(provider).<Integer>forMaybe())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -315,7 +315,7 @@ public class AutoDisposeMaybeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     MaybeSubject<Integer> source = MaybeSubject.create();
-    source.to(AutoDispose.with(provider).<Integer>maybe())
+    source.to(AutoDispose.with(provider).<Integer>forMaybe())
         .subscribe(o);
 
     o.assertNoValues();
@@ -343,7 +343,7 @@ public class AutoDisposeMaybeObserverTest {
         }
       });
       Maybe.just(1)
-          .to(AutoDispose.with(Maybe.never()).<Integer>maybe())
+          .to(AutoDispose.with(Maybe.never()).<Integer>forMaybe())
           .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
@@ -372,7 +372,7 @@ public class AutoDisposeMaybeObserverTest {
       }
     });
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(AutoDispose.with(lifecycle).<Integer>maybe())
+    source.to(AutoDispose.with(lifecycle).<Integer>forMaybe())
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -16,9 +16,8 @@
 
 package com.uber.autodispose;
 
-import com.uber.autodispose.test.RecordingObserver;
 import com.uber.autodispose.observers.AutoDisposingMaybeObserver;
-
+import com.uber.autodispose.test.RecordingObserver;
 import io.reactivex.Maybe;
 import io.reactivex.MaybeEmitter;
 import io.reactivex.MaybeObserver;
@@ -31,10 +30,8 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
-
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.junit.After;
 import org.junit.Test;
 
@@ -45,19 +42,16 @@ import static com.uber.autodispose.TestUtil.makeProvider;
 public class AutoDisposeMaybeObserverTest {
 
   private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
-    @Override
-    public void log(String message) {
+    @Override public void log(String message) {
       System.out.println(AutoDisposeMaybeObserverTest.class.getSimpleName() + ": " + message);
     }
   };
 
-  @After
-  public void resetPlugins() {
+  @After public void resetPlugins() {
     AutoDisposePlugins.reset();
   }
 
-  @Test
-  public void autoDispose_withMaybe_normal() {
+  @Test public void autoDispose_withMaybe_normal() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
@@ -78,28 +72,24 @@ public class AutoDisposeMaybeObserverTest {
     assertThat(lifecycle.hasObservers()).isFalse();
   }
 
-  @Test
-  public void autoDispose_withSuperClassGenerics_compilesFine() {
+  @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Maybe.just(new BClass())
         .to(AutoDispose.with(Maybe.never()).<AClass>maybe())
         .subscribe(new Consumer<AClass>() {
-          @Override
-          public void accept(AClass aClass) throws Exception {
+          @Override public void accept(AClass aClass) throws Exception {
 
           }
         });
   }
 
-  @Test
-  public void autoDispose_noGenericsOnEmpty_isFine() {
+  @Test public void autoDispose_noGenericsOnEmpty_isFine() {
     Maybe.just(new BClass())
         .to(AutoDispose.with(Maybe.never())
             .maybe())
         .subscribe();
   }
 
-  @Test
-  public void autoDispose_withMaybe_interrupted() {
+  @Test public void autoDispose_withMaybe_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
@@ -107,8 +97,7 @@ public class AutoDisposeMaybeObserverTest {
         .subscribe(o);
     source.to(AutoDispose.with(lifecycle).<Integer>maybe())
         .subscribe(new Consumer<Integer>() {
-          @Override
-          public void accept(Integer integer) throws Exception {
+          @Override public void accept(Integer integer) throws Exception {
 
           }
         });
@@ -127,8 +116,7 @@ public class AutoDisposeMaybeObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test
-  public void autoDispose_withProvider_success() {
+  @Test public void autoDispose_withProvider_success() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
@@ -153,8 +141,7 @@ public class AutoDisposeMaybeObserverTest {
     assertThat(lifecycle.hasObservers()).isFalse();
   }
 
-  @Test
-  public void autoDispose_withProvider_completion() {
+  @Test public void autoDispose_withProvider_completion() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
@@ -174,8 +161,7 @@ public class AutoDisposeMaybeObserverTest {
     assertThat(scope.hasObservers()).isFalse();
   }
 
-  @Test
-  public void autoDispose_withProvider_interrupted() {
+  @Test public void autoDispose_withProvider_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
@@ -198,8 +184,7 @@ public class AutoDisposeMaybeObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test
-  public void autoDispose_withLifecycleProvider_completion() {
+  @Test public void autoDispose_withLifecycleProvider_completion() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
@@ -224,8 +209,7 @@ public class AutoDisposeMaybeObserverTest {
     assertThat(lifecycle.hasObservers()).isFalse();
   }
 
-  @Test
-  public void autoDispose_withLifecycleProvider_interrupted() {
+  @Test public void autoDispose_withLifecycleProvider_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
@@ -253,8 +237,7 @@ public class AutoDisposeMaybeObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test
-  public void autoDispose_withLifecycleProvider_withoutStartingLifecycle_shouldFail() {
+  @Test public void autoDispose_withLifecycleProvider_withoutStartingLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
@@ -266,8 +249,7 @@ public class AutoDisposeMaybeObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleNotStartedException.class);
   }
 
-  @Test
-  public void autoDispose_withLifecycleProvider_afterLifecycle_shouldFail() {
+  @Test public void autoDispose_withLifecycleProvider_afterLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
     lifecycle.onNext(2);
@@ -282,11 +264,9 @@ public class AutoDisposeMaybeObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
   }
 
-  @Test
-  public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
+  @Test public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override
-      public void accept(OutsideLifecycleException e) throws Exception { }
+      @Override public void accept(OutsideLifecycleException e) throws Exception { }
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     TestObserver<Integer> o = new TestObserver<>();
@@ -301,11 +281,9 @@ public class AutoDisposeMaybeObserverTest {
     o.assertNoErrors();
   }
 
-  @Test
-  public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
+  @Test public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override
-      public void accept(OutsideLifecycleException e) throws Exception {
+      @Override public void accept(OutsideLifecycleException e) throws Exception {
         // Noop
       }
     });
@@ -325,11 +303,9 @@ public class AutoDisposeMaybeObserverTest {
     o.assertNoErrors();
   }
 
-  @Test
-  public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithWrappedExp() {
+  @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithWrappedExp() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override
-      public void accept(OutsideLifecycleException e) throws Exception {
+      @Override public void accept(OutsideLifecycleException e) throws Exception {
         // Wrap in an IllegalStateException so we can verify this is the exception we see on the
         // other side
         throw new IllegalStateException(e);
@@ -344,16 +320,14 @@ public class AutoDisposeMaybeObserverTest {
 
     o.assertNoValues();
     o.assertError(new Predicate<Throwable>() {
-      @Override
-      public boolean test(Throwable throwable) throws Exception {
+      @Override public boolean test(Throwable throwable) throws Exception {
         return throwable instanceof IllegalStateException
             && throwable.getCause() instanceof OutsideLifecycleException;
       }
     });
   }
 
-  @Test
-  public void verifyObserverDelegate() {
+  @Test public void verifyObserverDelegate() {
     final AtomicReference<MaybeObserver> atomicObserver = new AtomicReference<>();
     final AtomicReference<MaybeObserver> atomicAutoDisposingObserver = new AtomicReference<>();
     try {
@@ -368,29 +342,29 @@ public class AutoDisposeMaybeObserverTest {
           return observer;
         }
       });
-      Maybe.just(1).to(new MaybeScoper<Integer>(Maybe.never())).subscribe();
+      Maybe.just(1)
+          .to(AutoDispose.with(Maybe.never()).<Integer>maybe())
+          .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingMaybeObserver.class);
-      assertThat(((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get())
-          .delegateObserver()).isNotNull();
-      assertThat(((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get())
-          .delegateObserver()).isSameAs(atomicObserver.get());
+      assertThat(
+          ((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
+      assertThat(
+          ((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isSameAs(
+          atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }
   }
 
-  @Test
-  public void verifyCancellation() throws Exception {
+  @Test public void verifyCancellation() throws Exception {
     final AtomicInteger i = new AtomicInteger();
     //noinspection unchecked because Java
     Maybe<Integer> source = Maybe.create(new MaybeOnSubscribe<Integer>() {
-      @Override
-      public void subscribe(MaybeEmitter<Integer> e) throws Exception {
+      @Override public void subscribe(MaybeEmitter<Integer> e) throws Exception {
         e.setCancellable(new Cancellable() {
-          @Override
-          public void cancel() throws Exception {
+          @Override public void cancel() throws Exception {
             i.incrementAndGet();
           }
         });

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -56,7 +56,7 @@ public class AutoDisposeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     PublishSubject<Integer> source = PublishSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    Disposable d = source.to(AutoDispose.with(lifecycle).<Integer>observable())
+    Disposable d = source.to(AutoDispose.with(lifecycle).<Integer>forObservable())
         .subscribeWith(o);
     o.assertSubscribed();
 
@@ -77,7 +77,7 @@ public class AutoDisposeObserverTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Observable.just(new BClass())
-        .to(AutoDispose.with(Maybe.never()).<AClass>observable())
+        .to(AutoDispose.with(Maybe.never()).<AClass>forObservable())
         .subscribe(new Consumer<AClass>() {
           @Override public void accept(AClass aClass) throws Exception {
 
@@ -88,7 +88,7 @@ public class AutoDisposeObserverTest {
   @Test public void autoDispose_noGenericsOnEmpty_isFine() {
     Observable.just(new BClass())
         .to(AutoDispose.with(Maybe.never())
-            .observable())
+            .forObservable())
         .subscribe();
   }
 
@@ -96,7 +96,7 @@ public class AutoDisposeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     PublishSubject<Integer> source = PublishSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(AutoDispose.with(lifecycle).<Integer>observable())
+    source.to(AutoDispose.with(lifecycle).<Integer>forObservable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -118,7 +118,7 @@ public class AutoDisposeObserverTest {
     PublishSubject<Integer> source = PublishSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = TestUtil.makeProvider(scope);
-    source.to(AutoDispose.with(provider).<Integer>observable())
+    source.to(AutoDispose.with(provider).<Integer>forObservable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -147,7 +147,7 @@ public class AutoDisposeObserverTest {
     PublishSubject<Integer> source = PublishSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
-    source.to(AutoDispose.with(provider).<Integer>observable())
+    source.to(AutoDispose.with(provider).<Integer>forObservable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -177,7 +177,7 @@ public class AutoDisposeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     Observable.just(1)
-        .to(AutoDispose.with(provider).<Integer>observable())
+        .to(AutoDispose.with(provider).<Integer>forObservable())
         .subscribe(o);
 
     o.takeSubscribe();
@@ -192,7 +192,7 @@ public class AutoDisposeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     Observable.just(1)
-        .to(AutoDispose.with(provider).<Integer>observable())
+        .to(AutoDispose.with(provider).<Integer>forObservable())
         .subscribe(o);
 
     o.takeSubscribe();
@@ -207,7 +207,7 @@ public class AutoDisposeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     PublishSubject<Integer> source = PublishSubject.create();
-    source.to(AutoDispose.with(provider).<Integer>observable())
+    source.to(AutoDispose.with(provider).<Integer>forObservable())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -229,7 +229,7 @@ public class AutoDisposeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     PublishSubject<Integer> source = PublishSubject.create();
-    source.to(AutoDispose.with(provider).<Integer>observable())
+    source.to(AutoDispose.with(provider).<Integer>forObservable())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -250,7 +250,7 @@ public class AutoDisposeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     PublishSubject<Integer> source = PublishSubject.create();
-    source.to(AutoDispose.with(provider).<Integer>observable())
+    source.to(AutoDispose.with(provider).<Integer>forObservable())
         .subscribe(o);
 
     o.assertNoValues();
@@ -278,7 +278,7 @@ public class AutoDisposeObserverTest {
         }
       });
       Observable.just(1)
-          .to(AutoDispose.with(Maybe.never()).<Integer>observable())
+          .to(AutoDispose.with(Maybe.never()).<Integer>forObservable())
           .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
@@ -309,7 +309,7 @@ public class AutoDisposeObserverTest {
       }
     });
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(AutoDispose.with(lifecycle).<Integer>observable())
+    source.to(AutoDispose.with(lifecycle).<Integer>forObservable())
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -16,8 +16,8 @@
 
 package com.uber.autodispose;
 
-import com.uber.autodispose.test.RecordingObserver;
 import com.uber.autodispose.observers.AutoDisposingObserver;
+import com.uber.autodispose.test.RecordingObserver;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.ObservableEmitter;
@@ -87,7 +87,8 @@ public class AutoDisposeObserverTest {
 
   @Test public void autoDispose_noGenericsOnEmpty_isFine() {
     Observable.just(new BClass())
-        .to(AutoDispose.with(Maybe.never()).observable())
+        .to(AutoDispose.with(Maybe.never())
+            .observable())
         .subscribe();
   }
 
@@ -262,8 +263,8 @@ public class AutoDisposeObserverTest {
   }
 
   @Test public void verifyObserverDelegate() {
-    final AtomicReference<Observer> atomicObserver = new AtomicReference();
-    final AtomicReference<Observer> atomicAutoDisposingObserver = new AtomicReference();
+    final AtomicReference<Observer> atomicObserver = new AtomicReference<>();
+    final AtomicReference<Observer> atomicAutoDisposingObserver = new AtomicReference<>();
     try {
       RxJavaPlugins.setOnObservableSubscribe(new BiFunction<Observable, Observer, Observer>() {
         @Override public Observer apply(Observable source, Observer observer) {
@@ -276,14 +277,17 @@ public class AutoDisposeObserverTest {
           return observer;
         }
       });
-      Observable.just(1).to(new ObservableScoper<Integer>(Maybe.never())).subscribe();
+      Observable.just(1)
+          .to(AutoDispose.with(Maybe.never()).<Integer>observable())
+          .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingObserver.class);
-      assertThat(((AutoDisposingObserver) atomicAutoDisposingObserver.get()).delegateObserver())
-              .isNotNull();
-      assertThat(((AutoDisposingObserver) atomicAutoDisposingObserver.get()).delegateObserver())
-              .isSameAs(atomicObserver.get());
+      assertThat(
+          ((AutoDisposingObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
+      assertThat(
+          ((AutoDisposingObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isSameAs(
+          atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -56,7 +56,7 @@ public class AutoDisposeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     PublishSubject<Integer> source = PublishSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    Disposable d = source.to(new ObservableScoper<Integer>(lifecycle))
+    Disposable d = source.to(AutoDispose.with(lifecycle).<Integer>observable())
         .subscribeWith(o);
     o.assertSubscribed();
 
@@ -77,7 +77,7 @@ public class AutoDisposeObserverTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Observable.just(new BClass())
-        .to(new ObservableScoper<AClass>(Maybe.never()))
+        .to(AutoDispose.with(Maybe.never()).<AClass>observable())
         .subscribe(new Consumer<AClass>() {
           @Override public void accept(AClass aClass) throws Exception {
 
@@ -87,7 +87,7 @@ public class AutoDisposeObserverTest {
 
   @Test public void autoDispose_noGenericsOnEmpty_isFine() {
     Observable.just(new BClass())
-        .to(new ObservableScoper<>(Maybe.never()))
+        .to(AutoDispose.with(Maybe.never()).observable())
         .subscribe();
   }
 
@@ -95,7 +95,7 @@ public class AutoDisposeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     PublishSubject<Integer> source = PublishSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(new ObservableScoper<Integer>(lifecycle))
+    source.to(AutoDispose.with(lifecycle).<Integer>observable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -117,7 +117,7 @@ public class AutoDisposeObserverTest {
     PublishSubject<Integer> source = PublishSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = TestUtil.makeProvider(scope);
-    source.to(new ObservableScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>observable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -146,7 +146,7 @@ public class AutoDisposeObserverTest {
     PublishSubject<Integer> source = PublishSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
-    source.to(new ObservableScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>observable())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -176,7 +176,7 @@ public class AutoDisposeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     Observable.just(1)
-        .to(new ObservableScoper<Integer>(provider))
+        .to(AutoDispose.with(provider).<Integer>observable())
         .subscribe(o);
 
     o.takeSubscribe();
@@ -191,7 +191,7 @@ public class AutoDisposeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     Observable.just(1)
-        .to(new ObservableScoper<Integer>(provider))
+        .to(AutoDispose.with(provider).<Integer>observable())
         .subscribe(o);
 
     o.takeSubscribe();
@@ -206,7 +206,7 @@ public class AutoDisposeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     PublishSubject<Integer> source = PublishSubject.create();
-    source.to(new ObservableScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>observable())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -228,7 +228,7 @@ public class AutoDisposeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     PublishSubject<Integer> source = PublishSubject.create();
-    source.to(new ObservableScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>observable())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -249,7 +249,7 @@ public class AutoDisposeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     PublishSubject<Integer> source = PublishSubject.create();
-    source.to(new ObservableScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>observable())
         .subscribe(o);
 
     o.assertNoValues();
@@ -304,7 +304,7 @@ public class AutoDisposeObserverTest {
       }
     });
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(new ObservableScoper<Integer>(lifecycle))
+    source.to(AutoDispose.with(lifecycle).<Integer>observable())
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -283,11 +283,12 @@ public class AutoDisposeObserverTest {
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingObserver.class);
-      assertThat(
-          ((AutoDisposingObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
-      assertThat(
-          ((AutoDisposingObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isSameAs(
-          atomicObserver.get());
+      assertThat(((AutoDisposingObserver) atomicAutoDisposingObserver.get())
+              .delegateObserver())
+          .isNotNull();
+      assertThat(((AutoDisposingObserver) atomicAutoDisposingObserver.get())
+              .delegateObserver())
+          .isSameAs(atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -16,9 +16,8 @@
 
 package com.uber.autodispose;
 
-import com.uber.autodispose.test.RecordingObserver;
 import com.uber.autodispose.observers.AutoDisposingSingleObserver;
-
+import com.uber.autodispose.test.RecordingObserver;
 import io.reactivex.Maybe;
 import io.reactivex.Single;
 import io.reactivex.SingleEmitter;
@@ -33,10 +32,8 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subjects.SingleSubject;
-
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.junit.After;
 import org.junit.Test;
 
@@ -47,19 +44,16 @@ import static com.uber.autodispose.TestUtil.makeProvider;
 public class AutoDisposeSingleObserverTest {
 
   private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
-    @Override
-    public void log(String message) {
+    @Override public void log(String message) {
       System.out.println(AutoDisposeSingleObserverTest.class.getSimpleName() + ": " + message);
     }
   };
 
-  @After
-  public void resetPlugins() {
+  @After public void resetPlugins() {
     AutoDisposePlugins.reset();
   }
 
-  @Test
-  public void autoDispose_withMaybe_normal() {
+  @Test public void autoDispose_withMaybe_normal() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
@@ -80,28 +74,24 @@ public class AutoDisposeSingleObserverTest {
     assertThat(lifecycle.hasObservers()).isFalse();
   }
 
-  @Test
-  public void autoDispose_withSuperClassGenerics_compilesFine() {
+  @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Single.just(new BClass())
         .to(AutoDispose.with(Maybe.never()).<AClass>single())
         .subscribe(new Consumer<AClass>() {
-          @Override
-          public void accept(AClass aClass) throws Exception {
+          @Override public void accept(AClass aClass) throws Exception {
 
           }
         });
   }
 
-  @Test
-  public void autoDispose_noGenericsOnEmpty_isFine() {
+  @Test public void autoDispose_noGenericsOnEmpty_isFine() {
     Single.just(new BClass())
         .to(AutoDispose.with(Maybe.never())
             .single())
         .subscribe();
   }
 
-  @Test
-  public void autoDispose_withMaybe_interrupted() {
+  @Test public void autoDispose_withMaybe_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
@@ -122,8 +112,7 @@ public class AutoDisposeSingleObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test
-  public void autoDispose_withProvider() {
+  @Test public void autoDispose_withProvider() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
@@ -144,8 +133,7 @@ public class AutoDisposeSingleObserverTest {
     assertThat(scope.hasObservers()).isFalse();
   }
 
-  @Test
-  public void autoDispose_withProvider_interrupted() {
+  @Test public void autoDispose_withProvider_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
@@ -167,8 +155,7 @@ public class AutoDisposeSingleObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test
-  public void autoDispose_withLifecycleProvider() {
+  @Test public void autoDispose_withLifecycleProvider() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
@@ -194,8 +181,7 @@ public class AutoDisposeSingleObserverTest {
     assertThat(lifecycle.hasObservers()).isFalse();
   }
 
-  @Test
-  public void autoDispose_withLifecycleProvider_interrupted() {
+  @Test public void autoDispose_withLifecycleProvider_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
@@ -222,8 +208,7 @@ public class AutoDisposeSingleObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test
-  public void autoDispose_withProvider_withoutStartingLifecycle_shouldFail() {
+  @Test public void autoDispose_withProvider_withoutStartingLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
@@ -235,8 +220,7 @@ public class AutoDisposeSingleObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleNotStartedException.class);
   }
 
-  @Test
-  public void autoDispose_withProvider_afterLifecycle_shouldFail() {
+  @Test public void autoDispose_withProvider_afterLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
     lifecycle.onNext(2);
@@ -251,11 +235,9 @@ public class AutoDisposeSingleObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
   }
 
-  @Test
-  public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
+  @Test public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override
-      public void accept(OutsideLifecycleException e) throws Exception { }
+      @Override public void accept(OutsideLifecycleException e) throws Exception { }
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     TestObserver<Integer> o = new TestObserver<>();
@@ -270,11 +252,9 @@ public class AutoDisposeSingleObserverTest {
     o.assertNoErrors();
   }
 
-  @Test
-  public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
+  @Test public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override
-      public void accept(OutsideLifecycleException e) throws Exception {
+      @Override public void accept(OutsideLifecycleException e) throws Exception {
         // Noop
       }
     });
@@ -294,11 +274,9 @@ public class AutoDisposeSingleObserverTest {
     o.assertNoErrors();
   }
 
-  @Test
-  public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithExp() {
+  @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithExp() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override
-      public void accept(OutsideLifecycleException e) throws Exception {
+      @Override public void accept(OutsideLifecycleException e) throws Exception {
         // Wrap in an IllegalStateException so we can verify this is the exception we see on the
         // other side
         throw new IllegalStateException(e);
@@ -313,16 +291,14 @@ public class AutoDisposeSingleObserverTest {
 
     o.assertNoValues();
     o.assertError(new Predicate<Throwable>() {
-      @Override
-      public boolean test(Throwable throwable) throws Exception {
+      @Override public boolean test(Throwable throwable) throws Exception {
         return throwable instanceof IllegalStateException
             && throwable.getCause() instanceof OutsideLifecycleException;
       }
     });
   }
 
-  @Test
-  public void verifyObserverDelegate() {
+  @Test public void verifyObserverDelegate() {
     final AtomicReference<SingleObserver> atomicObserver = new AtomicReference<>();
     final AtomicReference<SingleObserver> atomicAutoDisposingObserver = new AtomicReference<>();
     try {
@@ -337,29 +313,29 @@ public class AutoDisposeSingleObserverTest {
           return observer;
         }
       });
-      Single.just(1).to(new SingleScoper<Integer>(Maybe.never())).subscribe();
+      Single.just(1)
+          .to(AutoDispose.with(Maybe.never()).<Integer>single())
+          .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingSingleObserver.class);
-      assertThat(((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get())
-          .delegateObserver()).isNotNull();
-      assertThat(((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get())
-          .delegateObserver()).isSameAs(atomicObserver.get());
+      assertThat(
+          ((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
+      assertThat(
+          ((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isSameAs(
+          atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }
   }
 
-  @Test
-  public void verifyCancellation() throws Exception {
+  @Test public void verifyCancellation() throws Exception {
     final AtomicInteger i = new AtomicInteger();
     //noinspection unchecked because Java
     Single<Integer> source = Single.create(new SingleOnSubscribe<Integer>() {
-      @Override
-      public void subscribe(SingleEmitter<Integer> e) throws Exception {
+      @Override public void subscribe(SingleEmitter<Integer> e) throws Exception {
         e.setCancellable(new Cancellable() {
-          @Override
-          public void cancel() throws Exception {
+          @Override public void cancel() throws Exception {
             i.incrementAndGet();
           }
         });

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -63,7 +63,7 @@ public class AutoDisposeSingleObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(new SingleScoper<Integer>(lifecycle))
+    source.to(AutoDispose.with(lifecycle).<Integer>single())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -83,7 +83,7 @@ public class AutoDisposeSingleObserverTest {
   @Test
   public void autoDispose_withSuperClassGenerics_compilesFine() {
     Single.just(new BClass())
-        .to(new SingleScoper<AClass>(Maybe.never()))
+        .to(AutoDispose.with(Maybe.never()).<AClass>single())
         .subscribe(new Consumer<AClass>() {
           @Override
           public void accept(AClass aClass) throws Exception {
@@ -95,7 +95,8 @@ public class AutoDisposeSingleObserverTest {
   @Test
   public void autoDispose_noGenericsOnEmpty_isFine() {
     Single.just(new BClass())
-        .to(new SingleScoper<>(Maybe.never()))
+        .to(AutoDispose.with(Maybe.never())
+            .single())
         .subscribe();
   }
 
@@ -104,7 +105,7 @@ public class AutoDisposeSingleObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(new SingleScoper<Integer>(lifecycle))
+    source.to(AutoDispose.with(lifecycle).<Integer>single())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -127,7 +128,7 @@ public class AutoDisposeSingleObserverTest {
     SingleSubject<Integer> source = SingleSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.to(new SingleScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>single())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -149,7 +150,7 @@ public class AutoDisposeSingleObserverTest {
     SingleSubject<Integer> source = SingleSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.to(new SingleScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>single())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -172,7 +173,7 @@ public class AutoDisposeSingleObserverTest {
     SingleSubject<Integer> source = SingleSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.to(new SingleScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>single())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -199,7 +200,7 @@ public class AutoDisposeSingleObserverTest {
     SingleSubject<Integer> source = SingleSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.to(new SingleScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>single())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -227,7 +228,7 @@ public class AutoDisposeSingleObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Single.just(1)
-        .to(new SingleScoper<Integer>(provider))
+        .to(AutoDispose.with(provider).<Integer>single())
         .subscribe(o);
 
     o.takeSubscribe();
@@ -243,7 +244,7 @@ public class AutoDisposeSingleObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Single.just(1)
-        .to(new SingleScoper<Integer>(provider))
+        .to(AutoDispose.with(provider).<Integer>single())
         .subscribe(o);
 
     o.takeSubscribe();
@@ -260,7 +261,7 @@ public class AutoDisposeSingleObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     SingleSubject<Integer> source = SingleSubject.create();
-    source.to(new SingleScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>single())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -284,7 +285,7 @@ public class AutoDisposeSingleObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     SingleSubject<Integer> source = SingleSubject.create();
-    source.to(new SingleScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>single())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -307,7 +308,7 @@ public class AutoDisposeSingleObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     SingleSubject<Integer> source = SingleSubject.create();
-    source.to(new SingleScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>single())
         .subscribe(o);
 
     o.assertNoValues();
@@ -365,7 +366,7 @@ public class AutoDisposeSingleObserverTest {
       }
     });
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(new SingleScoper<Integer>(lifecycle))
+    source.to(AutoDispose.with(lifecycle).<Integer>single())
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -319,11 +319,12 @@ public class AutoDisposeSingleObserverTest {
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingSingleObserver.class);
-      assertThat(
-          ((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
-      assertThat(
-          ((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isSameAs(
-          atomicObserver.get());
+      assertThat(((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get())
+              .delegateObserver())
+          .isNotNull();
+      assertThat(((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get())
+              .delegateObserver())
+          .isSameAs(atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -57,7 +57,7 @@ public class AutoDisposeSingleObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(AutoDispose.with(lifecycle).<Integer>single())
+    source.to(AutoDispose.with(lifecycle).<Integer>forSingle())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -76,7 +76,7 @@ public class AutoDisposeSingleObserverTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Single.just(new BClass())
-        .to(AutoDispose.with(Maybe.never()).<AClass>single())
+        .to(AutoDispose.with(Maybe.never()).<AClass>forSingle())
         .subscribe(new Consumer<AClass>() {
           @Override public void accept(AClass aClass) throws Exception {
 
@@ -87,7 +87,7 @@ public class AutoDisposeSingleObserverTest {
   @Test public void autoDispose_noGenericsOnEmpty_isFine() {
     Single.just(new BClass())
         .to(AutoDispose.with(Maybe.never())
-            .single())
+            .forSingle())
         .subscribe();
   }
 
@@ -95,7 +95,7 @@ public class AutoDisposeSingleObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(AutoDispose.with(lifecycle).<Integer>single())
+    source.to(AutoDispose.with(lifecycle).<Integer>forSingle())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -117,7 +117,7 @@ public class AutoDisposeSingleObserverTest {
     SingleSubject<Integer> source = SingleSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.to(AutoDispose.with(provider).<Integer>single())
+    source.to(AutoDispose.with(provider).<Integer>forSingle())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -138,7 +138,7 @@ public class AutoDisposeSingleObserverTest {
     SingleSubject<Integer> source = SingleSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.to(AutoDispose.with(provider).<Integer>single())
+    source.to(AutoDispose.with(provider).<Integer>forSingle())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -160,7 +160,7 @@ public class AutoDisposeSingleObserverTest {
     SingleSubject<Integer> source = SingleSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.to(AutoDispose.with(provider).<Integer>single())
+    source.to(AutoDispose.with(provider).<Integer>forSingle())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -186,7 +186,7 @@ public class AutoDisposeSingleObserverTest {
     SingleSubject<Integer> source = SingleSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.to(AutoDispose.with(provider).<Integer>single())
+    source.to(AutoDispose.with(provider).<Integer>forSingle())
         .subscribe(o);
     o.takeSubscribe();
 
@@ -213,7 +213,7 @@ public class AutoDisposeSingleObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Single.just(1)
-        .to(AutoDispose.with(provider).<Integer>single())
+        .to(AutoDispose.with(provider).<Integer>forSingle())
         .subscribe(o);
 
     o.takeSubscribe();
@@ -228,7 +228,7 @@ public class AutoDisposeSingleObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Single.just(1)
-        .to(AutoDispose.with(provider).<Integer>single())
+        .to(AutoDispose.with(provider).<Integer>forSingle())
         .subscribe(o);
 
     o.takeSubscribe();
@@ -243,7 +243,7 @@ public class AutoDisposeSingleObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     SingleSubject<Integer> source = SingleSubject.create();
-    source.to(AutoDispose.with(provider).<Integer>single())
+    source.to(AutoDispose.with(provider).<Integer>forSingle())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -265,7 +265,7 @@ public class AutoDisposeSingleObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     SingleSubject<Integer> source = SingleSubject.create();
-    source.to(AutoDispose.with(provider).<Integer>single())
+    source.to(AutoDispose.with(provider).<Integer>forSingle())
         .subscribe(o);
 
     assertThat(source.hasObservers()).isFalse();
@@ -286,7 +286,7 @@ public class AutoDisposeSingleObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     SingleSubject<Integer> source = SingleSubject.create();
-    source.to(AutoDispose.with(provider).<Integer>single())
+    source.to(AutoDispose.with(provider).<Integer>forSingle())
         .subscribe(o);
 
     o.assertNoValues();
@@ -314,7 +314,7 @@ public class AutoDisposeSingleObserverTest {
         }
       });
       Single.just(1)
-          .to(AutoDispose.with(Maybe.never()).<Integer>single())
+          .to(AutoDispose.with(Maybe.never()).<Integer>forSingle())
           .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
@@ -343,7 +343,7 @@ public class AutoDisposeSingleObserverTest {
       }
     });
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(AutoDispose.with(lifecycle).<Integer>single())
+    source.to(AutoDispose.with(lifecycle).<Integer>forSingle())
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -17,7 +17,6 @@
 package com.uber.autodispose;
 
 import com.uber.autodispose.observers.AutoDisposingSubscriber;
-
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
 import io.reactivex.FlowableEmitter;
@@ -36,10 +35,9 @@ import io.reactivex.subscribers.TestSubscriber;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import org.reactivestreams.Subscriber;
-
 import org.junit.After;
 import org.junit.Test;
+import org.reactivestreams.Subscriber;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -278,24 +276,29 @@ public class AutoDisposeSubscriberTest {
       RxJavaPlugins.setOnFlowableSubscribe(new BiFunction<Flowable, Subscriber, Subscriber>() {
         @Override public Subscriber apply(Flowable source, Subscriber subscriber) {
           if (atomicSubscriber.get() == null) {
-            System.out.println(subscriber.getClass().toString());
+            System.out.println(subscriber.getClass()
+                .toString());
             atomicSubscriber.set(subscriber);
           } else if (atomicAutoDisposingSubscriber.get() == null) {
-            System.out.println(subscriber.getClass().toString());
+            System.out.println(subscriber.getClass()
+                .toString());
             atomicAutoDisposingSubscriber.set(subscriber);
             RxJavaPlugins.setOnFlowableSubscribe(null);
           }
           return subscriber;
         }
       });
-      Flowable.just(1).to(new FlowableScoper<Integer>(Maybe.never())).subscribe();
+      Flowable.just(1)
+          .to(AutoDispose.with(Maybe.never()).<Integer>flowable())
+          .subscribe();
 
       assertThat(atomicAutoDisposingSubscriber.get()).isNotNull();
       assertThat(atomicAutoDisposingSubscriber.get()).isInstanceOf(AutoDisposingSubscriber.class);
-      assertThat(((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get())
-          .delegateSubscriber()).isNotNull();
-      assertThat(((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get())
-          .delegateSubscriber()).isSameAs(atomicSubscriber.get());
+      assertThat(
+          ((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get()).delegateSubscriber()).isNotNull();
+      assertThat(
+          ((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get()).delegateSubscriber()).isSameAs(
+          atomicSubscriber.get());
     } finally {
       RxJavaPlugins.reset();
     }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -51,7 +51,7 @@ public class AutoDisposeSubscriberTest {
     TestSubscriber<Integer> o = new TestSubscriber<>();
     PublishProcessor<Integer> source = PublishProcessor.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    Disposable d = source.to(AutoDispose.with(lifecycle).<Integer>flowable())
+    Disposable d = source.to(AutoDispose.with(lifecycle).<Integer>forFlowable())
         .subscribeWith(o);
     o.assertSubscribed();
 
@@ -72,7 +72,7 @@ public class AutoDisposeSubscriberTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Flowable.just(new BClass())
-        .to(AutoDispose.with(Maybe.never()).<AClass>flowable())
+        .to(AutoDispose.with(Maybe.never()).<AClass>forFlowable())
         .subscribe(new Consumer<AClass>() {
           @Override public void accept(AClass aClass) throws Exception {
 
@@ -83,7 +83,7 @@ public class AutoDisposeSubscriberTest {
   @Test public void autoDispose_noGenericsOnEmpty_isFine() {
     Flowable.just(new BClass())
         .to(AutoDispose.with(Maybe.never())
-            .flowable())
+            .forFlowable())
         .subscribe();
   }
 
@@ -91,7 +91,7 @@ public class AutoDisposeSubscriberTest {
     TestSubscriber<Integer> o = new TestSubscriber<>();
     PublishProcessor<Integer> source = PublishProcessor.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(AutoDispose.with(lifecycle).<Integer>flowable())
+    source.to(AutoDispose.with(lifecycle).<Integer>forFlowable())
         .subscribe(o);
     o.assertSubscribed();
 
@@ -117,7 +117,7 @@ public class AutoDisposeSubscriberTest {
     PublishProcessor<Integer> source = PublishProcessor.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = TestUtil.makeProvider(scope);
-    source.to(AutoDispose.with(provider).<Integer>flowable())
+    source.to(AutoDispose.with(provider).<Integer>forFlowable())
         .subscribe(o);
     o.assertSubscribed();
 
@@ -149,7 +149,7 @@ public class AutoDisposeSubscriberTest {
     PublishProcessor<Integer> source = PublishProcessor.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
-    source.to(AutoDispose.with(provider).<Integer>flowable())
+    source.to(AutoDispose.with(provider).<Integer>forFlowable())
         .subscribe(o);
     o.assertSubscribed();
 
@@ -182,7 +182,7 @@ public class AutoDisposeSubscriberTest {
     TestSubscriber<Integer> o = new TestSubscriber<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     Flowable.just(1)
-        .to(AutoDispose.with(provider).<Integer>flowable())
+        .to(AutoDispose.with(provider).<Integer>forFlowable())
         .subscribe(o);
 
     List<Throwable> errors = o.errors();
@@ -198,7 +198,7 @@ public class AutoDisposeSubscriberTest {
     TestSubscriber<Integer> o = new TestSubscriber<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     Flowable.just(1)
-        .to(AutoDispose.with(provider).<Integer>flowable())
+        .to(AutoDispose.with(provider).<Integer>forFlowable())
         .subscribe(o);
 
     List<Throwable> errors = o.errors();
@@ -214,7 +214,7 @@ public class AutoDisposeSubscriberTest {
     TestSubscriber<Integer> o = new TestSubscriber<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     PublishProcessor<Integer> source = PublishProcessor.create();
-    source.to(AutoDispose.with(provider).<Integer>flowable())
+    source.to(AutoDispose.with(provider).<Integer>forFlowable())
         .subscribe(o);
 
     assertThat(source.hasSubscribers()).isFalse();
@@ -236,7 +236,7 @@ public class AutoDisposeSubscriberTest {
     TestSubscriber<Integer> o = new TestSubscriber<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     PublishProcessor<Integer> source = PublishProcessor.create();
-    source.to(AutoDispose.with(provider).<Integer>flowable())
+    source.to(AutoDispose.with(provider).<Integer>forFlowable())
         .subscribe(o);
 
     assertThat(source.hasSubscribers()).isFalse();
@@ -257,7 +257,7 @@ public class AutoDisposeSubscriberTest {
     TestSubscriber<Integer> o = new TestSubscriber<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     PublishProcessor<Integer> source = PublishProcessor.create();
-    source.to(AutoDispose.with(provider).<Integer>flowable())
+    source.to(AutoDispose.with(provider).<Integer>forFlowable())
         .subscribe(o);
 
     o.assertNoValues();
@@ -289,7 +289,7 @@ public class AutoDisposeSubscriberTest {
         }
       });
       Flowable.just(1)
-          .to(AutoDispose.with(Maybe.never()).<Integer>flowable())
+          .to(AutoDispose.with(Maybe.never()).<Integer>forFlowable())
           .subscribe();
 
       assertThat(atomicAutoDisposingSubscriber.get()).isNotNull();
@@ -320,7 +320,7 @@ public class AutoDisposeSubscriberTest {
       }
     }, BackpressureStrategy.LATEST);
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(AutoDispose.with(lifecycle).<Integer>flowable())
+    source.to(AutoDispose.with(lifecycle).<Integer>forFlowable())
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -294,11 +294,12 @@ public class AutoDisposeSubscriberTest {
 
       assertThat(atomicAutoDisposingSubscriber.get()).isNotNull();
       assertThat(atomicAutoDisposingSubscriber.get()).isInstanceOf(AutoDisposingSubscriber.class);
-      assertThat(
-          ((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get()).delegateSubscriber()).isNotNull();
-      assertThat(
-          ((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get()).delegateSubscriber()).isSameAs(
-          atomicSubscriber.get());
+      assertThat(((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get())
+              .delegateSubscriber())
+          .isNotNull();
+      assertThat(((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get())
+              .delegateSubscriber())
+          .isSameAs(atomicSubscriber.get());
     } finally {
       RxJavaPlugins.reset();
     }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -53,7 +53,7 @@ public class AutoDisposeSubscriberTest {
     TestSubscriber<Integer> o = new TestSubscriber<>();
     PublishProcessor<Integer> source = PublishProcessor.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    Disposable d = source.to(new FlowableScoper<Integer>(lifecycle))
+    Disposable d = source.to(AutoDispose.with(lifecycle).<Integer>flowable())
         .subscribeWith(o);
     o.assertSubscribed();
 
@@ -74,7 +74,7 @@ public class AutoDisposeSubscriberTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Flowable.just(new BClass())
-        .to(new FlowableScoper<AClass>(Maybe.never()))
+        .to(AutoDispose.with(Maybe.never()).<AClass>flowable())
         .subscribe(new Consumer<AClass>() {
           @Override public void accept(AClass aClass) throws Exception {
 
@@ -84,7 +84,8 @@ public class AutoDisposeSubscriberTest {
 
   @Test public void autoDispose_noGenericsOnEmpty_isFine() {
     Flowable.just(new BClass())
-        .to(new FlowableScoper<>(Maybe.never()))
+        .to(AutoDispose.with(Maybe.never())
+            .flowable())
         .subscribe();
   }
 
@@ -92,7 +93,7 @@ public class AutoDisposeSubscriberTest {
     TestSubscriber<Integer> o = new TestSubscriber<>();
     PublishProcessor<Integer> source = PublishProcessor.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(new FlowableScoper<Integer>(lifecycle))
+    source.to(AutoDispose.with(lifecycle).<Integer>flowable())
         .subscribe(o);
     o.assertSubscribed();
 
@@ -118,7 +119,7 @@ public class AutoDisposeSubscriberTest {
     PublishProcessor<Integer> source = PublishProcessor.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
     ScopeProvider provider = TestUtil.makeProvider(scope);
-    source.to(new FlowableScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>flowable())
         .subscribe(o);
     o.assertSubscribed();
 
@@ -150,7 +151,7 @@ public class AutoDisposeSubscriberTest {
     PublishProcessor<Integer> source = PublishProcessor.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
-    source.to(new FlowableScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>flowable())
         .subscribe(o);
     o.assertSubscribed();
 
@@ -183,7 +184,7 @@ public class AutoDisposeSubscriberTest {
     TestSubscriber<Integer> o = new TestSubscriber<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     Flowable.just(1)
-        .to(new FlowableScoper<Integer>(provider))
+        .to(AutoDispose.with(provider).<Integer>flowable())
         .subscribe(o);
 
     List<Throwable> errors = o.errors();
@@ -199,7 +200,7 @@ public class AutoDisposeSubscriberTest {
     TestSubscriber<Integer> o = new TestSubscriber<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     Flowable.just(1)
-        .to(new FlowableScoper<Integer>(provider))
+        .to(AutoDispose.with(provider).<Integer>flowable())
         .subscribe(o);
 
     List<Throwable> errors = o.errors();
@@ -215,7 +216,7 @@ public class AutoDisposeSubscriberTest {
     TestSubscriber<Integer> o = new TestSubscriber<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     PublishProcessor<Integer> source = PublishProcessor.create();
-    source.to(new FlowableScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>flowable())
         .subscribe(o);
 
     assertThat(source.hasSubscribers()).isFalse();
@@ -237,7 +238,7 @@ public class AutoDisposeSubscriberTest {
     TestSubscriber<Integer> o = new TestSubscriber<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     PublishProcessor<Integer> source = PublishProcessor.create();
-    source.to(new FlowableScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>flowable())
         .subscribe(o);
 
     assertThat(source.hasSubscribers()).isFalse();
@@ -258,7 +259,7 @@ public class AutoDisposeSubscriberTest {
     TestSubscriber<Integer> o = new TestSubscriber<>();
     LifecycleScopeProvider<Integer> provider = TestUtil.makeLifecycleProvider(lifecycle);
     PublishProcessor<Integer> source = PublishProcessor.create();
-    source.to(new FlowableScoper<Integer>(provider))
+    source.to(AutoDispose.with(provider).<Integer>flowable())
         .subscribe(o);
 
     o.assertNoValues();
@@ -315,7 +316,7 @@ public class AutoDisposeSubscriberTest {
       }
     }, BackpressureStrategy.LATEST);
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
-    source.to(new FlowableScoper<Integer>(lifecycle))
+    source.to(AutoDispose.with(lifecycle).<Integer>flowable())
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);


### PR DESCRIPTION
This is yet another attempt at static factories, but I feel pretty good about this.

Prior art: #61 #17 #42 #43

Basically - the static API wasn't possible before because of java generics issues. I could never find a sweet spot of conciseness/readability and tooling support (basically - IDE autocomplete). After playing with this more though, I think I've found the sweet spot.

The IDE will happily autocomplete generics IFF there are no parameters. I don't know why, but yeah that's how it is. Doesn't matter if the parameters are generic themselves either, just presence alone. This kind of works ok though, as we can leverage this as a plus to separate scope capture separately to make a single point of entry, then fan out to types.

The gist of how this works is that there's a single `AutoDispose` class with three public static overloads of `with()`, each taking one of the supported scope types. These return an implementation of a `ScopeHandler`, which is just an interface that has 5 methods (one for each rxjava type, aka `observable()`, `single()`, etc). Because these methods don't have parameters and the generics are still on the method signature, the IDE autocompletes! This feels a little more readable too, similar to Picasso's API. One extra key stroke, but more obvious to read than "ObservableScoper" IMO.

It's effectively a sort of rehash of #5, but only scope and type since we can leverage the `to()` operator now.

If this looks good from an API perspective here, I'll update the PR with tests/docs and deprecate the scoper API (with the intention of removing/making it not public it by 1.0). This should be pretty easy to migrate via structural replace as well

Now code looks like this:
```java
Flowable.just(3)
    .to(AutoDispose.with(this).<Integer>flowable())
    .subscribe();

Observable.just(3)
    .to(AutoDispose.with(this).<Integer>observable())
    .subscribe();

Single.just(3)
    .to(AutoDispose.with(this).<Integer>single())
    .subscribe();

Maybe.just(3)
    .to(AutoDispose.with(this).<Integer>maybe())
    .subscribe();

Completable.complete()
    .to(AutoDispose.with(this).completable())
    .subscribe();
```

And an added bonus - generic isn't necessary in Java 8!

```java
Observable.just(1)
    .to(AutoDispose.with(this).observable())
    .subscribe(integer -> {
      // Yay it's an integer!
    });
```