### PR TITLE
Add support for exposing delegate observers.

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
@@ -19,6 +19,7 @@ package com.uber.autodispose;
 import com.uber.autodispose.observers.AutoDisposingCompletableObserver;
 import io.reactivex.CompletableObserver;
 import io.reactivex.Maybe;
+import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.functions.BiConsumer;
@@ -35,6 +36,10 @@ final class AutoDisposingCompletableObserverImpl implements AutoDisposingComplet
   AutoDisposingCompletableObserverImpl(Maybe<?> lifecycle, CompletableObserver delegate) {
     this.lifecycle = lifecycle;
     this.delegate = delegate;
+  }
+
+  @Override public CompletableObserver delegateObserver() {
+    return delegate;
   }
 
   @Override public void onSubscribe(final Disposable d) {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
@@ -19,7 +19,6 @@ package com.uber.autodispose;
 import com.uber.autodispose.observers.AutoDisposingCompletableObserver;
 import io.reactivex.CompletableObserver;
 import io.reactivex.Maybe;
-import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.functions.BiConsumer;

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
@@ -19,6 +19,7 @@ package com.uber.autodispose;
 import com.uber.autodispose.observers.AutoDisposingMaybeObserver;
 import io.reactivex.Maybe;
 import io.reactivex.MaybeObserver;
+import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.functions.BiConsumer;
@@ -35,6 +36,10 @@ final class AutoDisposingMaybeObserverImpl<T> implements AutoDisposingMaybeObser
   AutoDisposingMaybeObserverImpl(Maybe<?> lifecycle, MaybeObserver<? super T> delegate) {
     this.lifecycle = lifecycle;
     this.delegate = delegate;
+  }
+
+  @Override public MaybeObserver<? super T> delegateObserver() {
+    return delegate;
   }
 
   @Override public void onSubscribe(final Disposable d) {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
@@ -19,7 +19,6 @@ package com.uber.autodispose;
 import com.uber.autodispose.observers.AutoDisposingMaybeObserver;
 import io.reactivex.Maybe;
 import io.reactivex.MaybeObserver;
-import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.functions.BiConsumer;

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
@@ -37,6 +37,10 @@ final class AutoDisposingObserverImpl<T> implements AutoDisposingObserver<T> {
     this.delegate = delegate;
   }
 
+  @Override public Observer<? super T> delegateObserver() {
+    return delegate;
+  }
+
   @Override public void onSubscribe(final Disposable d) {
     if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable,
         lifecycle.doOnEvent(new BiConsumer<Object, Throwable>() {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
@@ -18,7 +18,6 @@ package com.uber.autodispose;
 
 import com.uber.autodispose.observers.AutoDisposingSingleObserver;
 import io.reactivex.Maybe;
-import io.reactivex.Observer;
 import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
@@ -18,6 +18,7 @@ package com.uber.autodispose;
 
 import com.uber.autodispose.observers.AutoDisposingSingleObserver;
 import io.reactivex.Maybe;
+import io.reactivex.Observer;
 import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
@@ -35,6 +36,10 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
   AutoDisposingSingleObserverImpl(Maybe<?> lifecycle, SingleObserver<? super T> delegate) {
     this.lifecycle = lifecycle;
     this.delegate = delegate;
+  }
+
+  @Override public SingleObserver<? super T> delegateObserver() {
+    return delegate;
   }
 
   @Override public void onSubscribe(final Disposable d) {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
@@ -18,7 +18,6 @@ package com.uber.autodispose;
 
 import com.uber.autodispose.observers.AutoDisposingSubscriber;
 import io.reactivex.Maybe;
-import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.BiConsumer;
 import io.reactivex.functions.Consumer;

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
@@ -18,6 +18,7 @@ package com.uber.autodispose;
 
 import com.uber.autodispose.observers.AutoDisposingSubscriber;
 import io.reactivex.Maybe;
+import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.BiConsumer;
 import io.reactivex.functions.Consumer;
@@ -36,6 +37,10 @@ final class AutoDisposingSubscriberImpl<T> implements AutoDisposingSubscriber<T>
   AutoDisposingSubscriberImpl(Maybe<?> lifecycle, Subscriber<? super T> delegate) {
     this.lifecycle = lifecycle;
     this.delegate = delegate;
+  }
+
+  @Override public Subscriber<? super T> delegateSubscriber() {
+    return delegate;
   }
 
   @Override public void onSubscribe(final Subscription s) {

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingCompletableObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingCompletableObserver.java
@@ -17,6 +17,7 @@
 package com.uber.autodispose.observers;
 
 import io.reactivex.CompletableObserver;
+import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 
 /**
@@ -27,7 +28,8 @@ public interface AutoDisposingCompletableObserver extends CompletableObserver, D
 
   /**
    * @return The delegate {@link CompletableObserver} that is used under the hood forintrospection
-   * purposes.
+   * purposes. This will be updated once LambdaIntrospection is out of @Experimental in RxJava.
    */
+  @Experimental
   CompletableObserver delegateObserver();
 }

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingCompletableObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingCompletableObserver.java
@@ -17,7 +17,6 @@
 package com.uber.autodispose.observers;
 
 import io.reactivex.CompletableObserver;
-import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 
 /**
@@ -26,8 +25,9 @@ import io.reactivex.disposables.Disposable;
  */
 public interface AutoDisposingCompletableObserver extends CompletableObserver, Disposable {
 
-    /**
-     * @return The delegate {@link CompletableObserver} that is used under the hood for introspection purposes.
-     */
-    CompletableObserver delegateObserver();
+  /**
+   * @return The delegate {@link CompletableObserver} that is used under the hood forintrospection
+   * purposes.
+   */
+  CompletableObserver delegateObserver();
 }

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingCompletableObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingCompletableObserver.java
@@ -27,7 +27,7 @@ import io.reactivex.disposables.Disposable;
 public interface AutoDisposingCompletableObserver extends CompletableObserver, Disposable {
 
     /**
-     * @return {@link Observer} The delegate Observer that is used under the hood for introspection purposes.
+     * @return The delegate {@link CompletableObserver} that is used under the hood for introspection purposes.
      */
     CompletableObserver delegateObserver();
 }

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingCompletableObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingCompletableObserver.java
@@ -17,10 +17,17 @@
 package com.uber.autodispose.observers;
 
 import io.reactivex.CompletableObserver;
+import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 
 /**
  * A {@link Disposable} {@link CompletableObserver} that can automatically dispose itself.
  * Interface here for type safety but enforcement is left to the implementation.
  */
-public interface AutoDisposingCompletableObserver extends CompletableObserver, Disposable {}
+public interface AutoDisposingCompletableObserver extends CompletableObserver, Disposable {
+
+    /**
+     * @return {@link Observer} The delegate Observer that is used under the hood for introspection purposes.
+     */
+    CompletableObserver delegateObserver();
+}

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingMaybeObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingMaybeObserver.java
@@ -27,7 +27,7 @@ import io.reactivex.disposables.Disposable;
 public interface AutoDisposingMaybeObserver<T> extends MaybeObserver<T>, Disposable {
 
     /**
-     * @return {@Link Observer} The delegate Observer that is used under the hood for introspection purposes.
+     * @return The delegate {@link MayberObserver} that is used under the hood for introspection purposes.
      */
     MaybeObserver<? super T> delegateObserver();
 }

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingMaybeObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingMaybeObserver.java
@@ -17,7 +17,6 @@
 package com.uber.autodispose.observers;
 
 import io.reactivex.MaybeObserver;
-import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 
 /**
@@ -26,8 +25,9 @@ import io.reactivex.disposables.Disposable;
  */
 public interface AutoDisposingMaybeObserver<T> extends MaybeObserver<T>, Disposable {
 
-    /**
-     * @return The delegate {@link MayberObserver} that is used under the hood for introspection purposes.
-     */
-    MaybeObserver<? super T> delegateObserver();
+  /**
+   * @return The delegate {@link MayberObserver} that is used under the hood for introspection
+   * purposes.
+   */
+  MaybeObserver<? super T> delegateObserver();
 }

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingMaybeObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingMaybeObserver.java
@@ -17,6 +17,7 @@
 package com.uber.autodispose.observers;
 
 import io.reactivex.MaybeObserver;
+import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 
 /**
@@ -27,7 +28,8 @@ public interface AutoDisposingMaybeObserver<T> extends MaybeObserver<T>, Disposa
 
   /**
    * @return The delegate {@link MayberObserver} that is used under the hood for introspection
-   * purposes.
+   * purposes. This will be updated once LambdaIntrospection is out of @Experimental in RxJava.
    */
+  @Experimental
   MaybeObserver<? super T> delegateObserver();
 }

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingMaybeObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingMaybeObserver.java
@@ -17,10 +17,17 @@
 package com.uber.autodispose.observers;
 
 import io.reactivex.MaybeObserver;
+import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 
 /**
  * A {@link Disposable} {@link MaybeObserver} that can automatically dispose itself.
  * Interface here for type safety but enforcement is left to the implementation.
  */
-public interface AutoDisposingMaybeObserver<T> extends MaybeObserver<T>, Disposable {}
+public interface AutoDisposingMaybeObserver<T> extends MaybeObserver<T>, Disposable {
+
+    /**
+     * @return {@Link Observer} The delegate Observer that is used under the hood for introspection purposes.
+     */
+    MaybeObserver<? super T> delegateObserver();
+}

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingObserver.java
@@ -26,7 +26,7 @@ import io.reactivex.disposables.Disposable;
 public interface AutoDisposingObserver<T> extends Observer<T>, Disposable {
 
     /**
-     * @return {@link Observer} The delegate Observer that is used under the hood for introspection purposes.
+     * @return The delegate {@link Observer} that is used under the hood for introspection purposes.
      */
     Observer<? super T> delegateObserver();
 }

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingObserver.java
@@ -17,6 +17,7 @@
 package com.uber.autodispose.observers;
 
 import io.reactivex.Observer;
+import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 
 /**
@@ -26,7 +27,9 @@ import io.reactivex.disposables.Disposable;
 public interface AutoDisposingObserver<T> extends Observer<T>, Disposable {
 
   /**
-   * @return The delegate {@link Observer} that is used under the hood for introspection purposes.
+   * @return The delegate {@link Observer} that is used under the hood for introspection purpose.
+   * This will be updated once LambdaIntrospection is out of @Experimental in RxJava.
    */
+  @Experimental
   Observer<? super T> delegateObserver();
 }

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingObserver.java
@@ -25,8 +25,8 @@ import io.reactivex.disposables.Disposable;
  */
 public interface AutoDisposingObserver<T> extends Observer<T>, Disposable {
 
-    /**
-     * @return The delegate {@link Observer} that is used under the hood for introspection purposes.
-     */
-    Observer<? super T> delegateObserver();
+  /**
+   * @return The delegate {@link Observer} that is used under the hood for introspection purposes.
+   */
+  Observer<? super T> delegateObserver();
 }

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingObserver.java
@@ -23,4 +23,10 @@ import io.reactivex.disposables.Disposable;
  * A {@link Disposable} {@link Observer} that can automatically dispose itself.
  * Interface here for type safety but enforcement is left to the implementation.
  */
-public interface AutoDisposingObserver<T> extends Observer<T>, Disposable {}
+public interface AutoDisposingObserver<T> extends Observer<T>, Disposable {
+
+    /**
+     * @return {@link Observer} The delegate Observer that is used under the hood for introspection purposes.
+     */
+    Observer<? super T> delegateObserver();
+}

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSingleObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSingleObserver.java
@@ -16,6 +16,7 @@
 
 package com.uber.autodispose.observers;
 
+import io.reactivex.Observer;
 import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
 
@@ -23,4 +24,11 @@ import io.reactivex.disposables.Disposable;
  * A {@link Disposable} {@link SingleObserver} that can automatically dispose itself.
  * Interface here for type safety but enforcement is left to the implementation.
  */
-public interface AutoDisposingSingleObserver<T> extends SingleObserver<T>, Disposable {}
+public interface AutoDisposingSingleObserver<T> extends SingleObserver<T>, Disposable {
+
+    /**
+     * @return {@link SingleObserver} The delegate SingleObserver that is used under the hood for introspection
+     * purposes.
+     */
+    SingleObserver<? super T> delegateObserver();
+}

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSingleObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSingleObserver.java
@@ -16,7 +16,6 @@
 
 package com.uber.autodispose.observers;
 
-import io.reactivex.Observer;
 import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
 
@@ -26,8 +25,9 @@ import io.reactivex.disposables.Disposable;
  */
 public interface AutoDisposingSingleObserver<T> extends SingleObserver<T>, Disposable {
 
-    /**
-     * @return The delegate {@link SingleObserver} that is used under the hood for introspection purposes.
-     */
-    SingleObserver<? super T> delegateObserver();
+  /**
+   * @return The delegate {@link SingleObserver} that is used under the hood for introspection
+   * purposes.
+   */
+  SingleObserver<? super T> delegateObserver();
 }

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSingleObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSingleObserver.java
@@ -27,8 +27,7 @@ import io.reactivex.disposables.Disposable;
 public interface AutoDisposingSingleObserver<T> extends SingleObserver<T>, Disposable {
 
     /**
-     * @return {@link SingleObserver} The delegate SingleObserver that is used under the hood for introspection
-     * purposes.
+     * @return The delegate {@link SingleObserver} that is used under the hood for introspection purposes.
      */
     SingleObserver<? super T> delegateObserver();
 }

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSingleObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSingleObserver.java
@@ -17,6 +17,7 @@
 package com.uber.autodispose.observers;
 
 import io.reactivex.SingleObserver;
+import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 
 /**
@@ -27,7 +28,8 @@ public interface AutoDisposingSingleObserver<T> extends SingleObserver<T>, Dispo
 
   /**
    * @return The delegate {@link SingleObserver} that is used under the hood for introspection
-   * purposes.
+   * purposes. This will be updated once LambdaIntrospection is out of @Experimental in RxJava.
    */
+  @Experimental
   SingleObserver<? super T> delegateObserver();
 }

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSubscriber.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSubscriber.java
@@ -25,10 +25,12 @@ import org.reactivestreams.Subscription;
  * A {@link Disposable} {@link Subscriber} that can automatically dispose itself. Interface here
  * for type safety but enforcement is left to the implementation.
  */
-public interface AutoDisposingSubscriber<T> extends FlowableSubscriber<T>, Subscription, Disposable {
+public interface AutoDisposingSubscriber<T>
+        extends FlowableSubscriber<T>, Subscription, Disposable {
 
-    /**
-     * @return The delegate {@link Subscriber} that is used under the hood for introspection purposes.
-     */
-    Subscriber<? super T> delegateSubscriber();
+  /**
+   * @return The delegate {@link Subscriber} that is used under the hood for introspection
+   * purposes.
+   */
+  Subscriber<? super T> delegateSubscriber();
 }

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSubscriber.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSubscriber.java
@@ -17,6 +17,7 @@
 package com.uber.autodispose.observers;
 
 import io.reactivex.FlowableSubscriber;
+import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -30,7 +31,8 @@ public interface AutoDisposingSubscriber<T>
 
   /**
    * @return The delegate {@link Subscriber} that is used under the hood for introspection
-   * purposes.
+   * purposes. This will be updated once LambdaIntrospection is out of @Experimental in RxJava.
    */
+  @Experimental
   Subscriber<? super T> delegateSubscriber();
 }

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSubscriber.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSubscriber.java
@@ -25,4 +25,10 @@ import org.reactivestreams.Subscription;
  * A {@link Disposable} {@link Subscriber} that can automatically dispose itself. Interface here
  * for type safety but enforcement is left to the implementation.
  */
-public interface AutoDisposingSubscriber<T> extends FlowableSubscriber<T>, Subscription, Disposable {}
+public interface AutoDisposingSubscriber<T> extends FlowableSubscriber<T>, Subscription, Disposable {
+
+    /**
+     * @return {@link Subscriber} The delegate Subscriber that is used under the hood for introspection purposes.
+     */
+    Subscriber<? super T> delegateSubscriber();
+}

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSubscriber.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSubscriber.java
@@ -16,6 +16,7 @@
 
 package com.uber.autodispose.observers;
 
+import io.reactivex.FlowableSubscriber;
 import io.reactivex.disposables.Disposable;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -24,4 +25,4 @@ import org.reactivestreams.Subscription;
  * A {@link Disposable} {@link Subscriber} that can automatically dispose itself. Interface here
  * for type safety but enforcement is left to the implementation.
  */
-public interface AutoDisposingSubscriber<T> extends Subscriber<T>, Subscription, Disposable {}
+public interface AutoDisposingSubscriber<T> extends FlowableSubscriber<T>, Subscription, Disposable {}

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSubscriber.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingSubscriber.java
@@ -28,7 +28,7 @@ import org.reactivestreams.Subscription;
 public interface AutoDisposingSubscriber<T> extends FlowableSubscriber<T>, Subscription, Disposable {
 
     /**
-     * @return {@link Subscriber} The delegate Subscriber that is used under the hood for introspection purposes.
+     * @return The delegate {@link Subscriber} that is used under the hood for introspection purposes.
      */
     Subscriber<? super T> delegateSubscriber();
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -53,9 +53,6 @@ public class AutoDisposeCompletableObserverTest {
     }
   };
 
-  private final AtomicReference<CompletableObserver> atomicObserver = new AtomicReference<>();
-  private final AtomicReference<CompletableObserver> atomicAutoDisposingObserver = new AtomicReference<>();
-
   @After public void resetPlugins() {
     AutoDisposePlugins.reset();
   }
@@ -289,6 +286,8 @@ public class AutoDisposeCompletableObserverTest {
   }
 
   @Test public void verifyObserverDelegate() {
+    final AtomicReference<CompletableObserver> atomicObserver = new AtomicReference<>();
+    final AtomicReference<CompletableObserver> atomicAutoDisposingObserver = new AtomicReference<>();
     try {
       RxJavaPlugins.setOnCompletableSubscribe(new BiFunction<Completable, CompletableObserver, CompletableObserver>() {
         @Override public CompletableObserver apply(Completable source, CompletableObserver observer) {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -47,14 +47,14 @@ import static com.uber.autodispose.TestUtil.makeProvider;
 
 public class AutoDisposeCompletableObserverTest {
 
-  private final AtomicReference<CompletableObserver> atomicObserver = new AtomicReference<>();
-  private final AtomicReference<CompletableObserver> atomicAutoDisposingObserver = new AtomicReference<>();
-
   private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
     @Override public void log(String message) {
       System.out.println(AutoDisposeCompletableObserverTest.class.getSimpleName() + ": " + message);
     }
   };
+
+  private final AtomicReference<CompletableObserver> atomicObserver = new AtomicReference<>();
+  private final AtomicReference<CompletableObserver> atomicAutoDisposingObserver = new AtomicReference<>();
 
   @After public void resetPlugins() {
     AutoDisposePlugins.reset();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -307,7 +307,7 @@ public class AutoDisposeCompletableObserverTest {
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingCompletableObserver.class);
       assertThat(((AutoDisposingCompletableObserver)atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
       assertThat(((AutoDisposingCompletableObserver)atomicAutoDisposingObserver.get()).delegateObserver())
-              .isEqualTo(atomicObserver.get());
+              .isSameAs(atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -24,8 +24,6 @@ import io.reactivex.CompletableEmitter;
 import io.reactivex.CompletableObserver;
 import io.reactivex.CompletableOnSubscribe;
 import io.reactivex.Maybe;
-import io.reactivex.Observable;
-import io.reactivex.Observer;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;
@@ -35,6 +33,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.CompletableSubject;
 import io.reactivex.subjects.MaybeSubject;
+
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -48,16 +47,19 @@ import static com.uber.autodispose.TestUtil.makeProvider;
 public class AutoDisposeCompletableObserverTest {
 
   private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
-    @Override public void log(String message) {
+    @Override
+    public void log(String message) {
       System.out.println(AutoDisposeCompletableObserverTest.class.getSimpleName() + ": " + message);
     }
   };
 
-  @After public void resetPlugins() {
+  @After
+  public void resetPlugins() {
     AutoDisposePlugins.reset();
   }
 
-  @Test public void autoDispose_withMaybe_normal() {
+  @Test
+  public void autoDispose_withMaybe_normal() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     CompletableSubject source = CompletableSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
@@ -78,7 +80,8 @@ public class AutoDisposeCompletableObserverTest {
     assertThat(lifecycle.hasObservers()).isFalse();
   }
 
-  @Test public void autoDispose_withMaybe_interrupted() {
+  @Test
+  public void autoDispose_withMaybe_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     CompletableSubject source = CompletableSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
@@ -99,7 +102,8 @@ public class AutoDisposeCompletableObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test public void autoDispose_withProvider_completion() {
+  @Test
+  public void autoDispose_withProvider_completion() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     CompletableSubject source = CompletableSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
@@ -119,7 +123,8 @@ public class AutoDisposeCompletableObserverTest {
     assertThat(scope.hasObservers()).isFalse();
   }
 
-  @Test public void autoDispose_withProvider_interrupted() {
+  @Test
+  public void autoDispose_withProvider_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     CompletableSubject source = CompletableSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
@@ -142,7 +147,8 @@ public class AutoDisposeCompletableObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test public void autoDispose_withLifecycleProvider_completion() {
+  @Test
+  public void autoDispose_withLifecycleProvider_completion() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     CompletableSubject source = CompletableSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
@@ -167,7 +173,8 @@ public class AutoDisposeCompletableObserverTest {
     assertThat(lifecycle.hasObservers()).isFalse();
   }
 
-  @Test public void autoDispose_withLifecycleProvider_interrupted() {
+  @Test
+  public void autoDispose_withLifecycleProvider_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     CompletableSubject source = CompletableSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
@@ -195,7 +202,8 @@ public class AutoDisposeCompletableObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test public void autoDispose_withLifecycleProvider_withoutStartingLifecycle_shouldFail() {
+  @Test
+  public void autoDispose_withLifecycleProvider_withoutStartingLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
@@ -207,7 +215,8 @@ public class AutoDisposeCompletableObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleNotStartedException.class);
   }
 
-  @Test public void autoDispose_withLifecycleProvider_afterLifecycle_shouldFail() {
+  @Test
+  public void autoDispose_withLifecycleProvider_afterLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
     lifecycle.onNext(2);
@@ -222,9 +231,11 @@ public class AutoDisposeCompletableObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
   }
 
-  @Test public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
+  @Test
+  public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override public void accept(OutsideLifecycleException e) throws Exception { }
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception { }
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     TestObserver<Integer> o = new TestObserver<>();
@@ -239,9 +250,11 @@ public class AutoDisposeCompletableObserverTest {
     o.assertNoErrors();
   }
 
-  @Test public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
+  @Test
+  public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override public void accept(OutsideLifecycleException e) throws Exception {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
         // Noop
       }
     });
@@ -261,9 +274,11 @@ public class AutoDisposeCompletableObserverTest {
     o.assertNoErrors();
   }
 
-  @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithWrappedExp() {
+  @Test
+  public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithWrappedExp() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override public void accept(OutsideLifecycleException e) throws Exception {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
         // Wrap in an IllegalStateException so we can verify this is the exception we see on the
         // other side
         throw new IllegalStateException(e);
@@ -278,19 +293,26 @@ public class AutoDisposeCompletableObserverTest {
 
     o.assertNoValues();
     o.assertError(new Predicate<Throwable>() {
-      @Override public boolean test(Throwable throwable) throws Exception {
+      @Override
+      public boolean test(Throwable throwable) throws Exception {
         return throwable instanceof IllegalStateException
             && throwable.getCause() instanceof OutsideLifecycleException;
       }
     });
   }
 
-  @Test public void verifyObserverDelegate() {
+  @Test
+  public void verifyObserverDelegate() {
     final AtomicReference<CompletableObserver> atomicObserver = new AtomicReference<>();
-    final AtomicReference<CompletableObserver> atomicAutoDisposingObserver = new AtomicReference<>();
+    final AtomicReference<CompletableObserver> atomicAutoDisposingObserver
+        = new AtomicReference<>();
     try {
-      RxJavaPlugins.setOnCompletableSubscribe(new BiFunction<Completable, CompletableObserver, CompletableObserver>() {
-        @Override public CompletableObserver apply(Completable source, CompletableObserver observer) {
+      RxJavaPlugins.setOnCompletableSubscribe(new BiFunction<Completable,
+          CompletableObserver,
+          CompletableObserver>() {
+        @Override public CompletableObserver apply(
+            Completable source,
+            CompletableObserver observer) {
           if (atomicObserver.get() == null) {
             atomicObserver.set(observer);
           } else if (atomicAutoDisposingObserver.get() == null) {
@@ -303,22 +325,27 @@ public class AutoDisposeCompletableObserverTest {
       Completable.complete().to(new CompletableScoper(Maybe.never())).subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
-      assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingCompletableObserver.class);
-      assertThat(((AutoDisposingCompletableObserver)atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
-      assertThat(((AutoDisposingCompletableObserver)atomicAutoDisposingObserver.get()).delegateObserver())
-              .isSameAs(atomicObserver.get());
+      assertThat(atomicAutoDisposingObserver.get())
+          .isInstanceOf(AutoDisposingCompletableObserver.class);
+      assertThat(((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get())
+          .delegateObserver()).isNotNull();
+      assertThat(((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get())
+          .delegateObserver()).isSameAs(atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }
   }
 
-  @Test public void verifyCancellation() throws Exception {
+  @Test
+  public void verifyCancellation() throws Exception {
     final AtomicInteger i = new AtomicInteger();
     //noinspection unchecked because Java
     Completable source = Completable.create(new CompletableOnSubscribe() {
-      @Override public void subscribe(CompletableEmitter e) throws Exception {
+      @Override
+      public void subscribe(CompletableEmitter e) throws Exception {
         e.setCancellable(new Cancellable() {
-          @Override public void cancel() throws Exception {
+          @Override
+          public void cancel() throws Exception {
             i.incrementAndGet();
           }
         });

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -52,10 +52,6 @@ public class AutoDisposeMaybeObserverTest {
     }
   };
 
-  private final AtomicReference<MaybeObserver> atomicObserver = new AtomicReference<>();
-  private final AtomicReference<MaybeObserver> atomicAutoDisposingObserver = new AtomicReference<>();
-
-
   @After public void resetPlugins() {
     AutoDisposePlugins.reset();
   }
@@ -336,6 +332,8 @@ public class AutoDisposeMaybeObserverTest {
   }
 
   @Test public void verifyObserverDelegate() {
+    final AtomicReference<MaybeObserver> atomicObserver = new AtomicReference<>();
+    final AtomicReference<MaybeObserver> atomicAutoDisposingObserver = new AtomicReference<>();
     try {
       RxJavaPlugins.setOnMaybeSubscribe(new BiFunction<Maybe, MaybeObserver, MaybeObserver>() {
         @Override public MaybeObserver apply(Maybe source, MaybeObserver observer) {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -19,13 +19,10 @@ package com.uber.autodispose;
 import com.uber.autodispose.test.RecordingObserver;
 import com.uber.autodispose.observers.AutoDisposingMaybeObserver;
 
-import io.reactivex.CompletableObserver;
 import io.reactivex.Maybe;
 import io.reactivex.MaybeEmitter;
 import io.reactivex.MaybeObserver;
 import io.reactivex.MaybeOnSubscribe;
-import io.reactivex.Observable;
-import io.reactivex.Observer;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;
@@ -34,6 +31,7 @@ import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
+
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -47,16 +45,19 @@ import static com.uber.autodispose.TestUtil.makeProvider;
 public class AutoDisposeMaybeObserverTest {
 
   private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
-    @Override public void log(String message) {
+    @Override
+    public void log(String message) {
       System.out.println(AutoDisposeMaybeObserverTest.class.getSimpleName() + ": " + message);
     }
   };
 
-  @After public void resetPlugins() {
+  @After
+  public void resetPlugins() {
     AutoDisposePlugins.reset();
   }
 
-  @Test public void autoDispose_withMaybe_normal() {
+  @Test
+  public void autoDispose_withMaybe_normal() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
@@ -77,23 +78,27 @@ public class AutoDisposeMaybeObserverTest {
     assertThat(lifecycle.hasObservers()).isFalse();
   }
 
-  @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
+  @Test
+  public void autoDispose_withSuperClassGenerics_compilesFine() {
     Maybe.just(new BClass())
         .to(new MaybeScoper<AClass>(Maybe.never()))
         .subscribe(new Consumer<AClass>() {
-          @Override public void accept(AClass aClass) throws Exception {
+          @Override
+          public void accept(AClass aClass) throws Exception {
 
           }
         });
   }
 
-  @Test public void autoDispose_noGenericsOnEmpty_isFine() {
+  @Test
+  public void autoDispose_noGenericsOnEmpty_isFine() {
     Maybe.just(new BClass())
         .to(new MaybeScoper<>(Maybe.never()))
         .subscribe();
   }
 
-  @Test public void autoDispose_withMaybe_interrupted() {
+  @Test
+  public void autoDispose_withMaybe_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
@@ -101,7 +106,8 @@ public class AutoDisposeMaybeObserverTest {
         .subscribe(o);
     source.to(new MaybeScoper<Integer>(lifecycle))
         .subscribe(new Consumer<Integer>() {
-          @Override public void accept(Integer integer) throws Exception {
+          @Override
+          public void accept(Integer integer) throws Exception {
 
           }
         });
@@ -120,7 +126,8 @@ public class AutoDisposeMaybeObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test public void autoDispose_withProvider_success() {
+  @Test
+  public void autoDispose_withProvider_success() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
@@ -145,7 +152,8 @@ public class AutoDisposeMaybeObserverTest {
     assertThat(lifecycle.hasObservers()).isFalse();
   }
 
-  @Test public void autoDispose_withProvider_completion() {
+  @Test
+  public void autoDispose_withProvider_completion() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
@@ -165,7 +173,8 @@ public class AutoDisposeMaybeObserverTest {
     assertThat(scope.hasObservers()).isFalse();
   }
 
-  @Test public void autoDispose_withProvider_interrupted() {
+  @Test
+  public void autoDispose_withProvider_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
@@ -188,7 +197,8 @@ public class AutoDisposeMaybeObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test public void autoDispose_withLifecycleProvider_completion() {
+  @Test
+  public void autoDispose_withLifecycleProvider_completion() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
@@ -213,7 +223,8 @@ public class AutoDisposeMaybeObserverTest {
     assertThat(lifecycle.hasObservers()).isFalse();
   }
 
-  @Test public void autoDispose_withLifecycleProvider_interrupted() {
+  @Test
+  public void autoDispose_withLifecycleProvider_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
@@ -241,7 +252,8 @@ public class AutoDisposeMaybeObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test public void autoDispose_withLifecycleProvider_withoutStartingLifecycle_shouldFail() {
+  @Test
+  public void autoDispose_withLifecycleProvider_withoutStartingLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
@@ -253,7 +265,8 @@ public class AutoDisposeMaybeObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleNotStartedException.class);
   }
 
-  @Test public void autoDispose_withLifecycleProvider_afterLifecycle_shouldFail() {
+  @Test
+  public void autoDispose_withLifecycleProvider_afterLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
     lifecycle.onNext(2);
@@ -268,9 +281,11 @@ public class AutoDisposeMaybeObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
   }
 
-  @Test public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
+  @Test
+  public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override public void accept(OutsideLifecycleException e) throws Exception { }
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception { }
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     TestObserver<Integer> o = new TestObserver<>();
@@ -285,9 +300,11 @@ public class AutoDisposeMaybeObserverTest {
     o.assertNoErrors();
   }
 
-  @Test public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
+  @Test
+  public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override public void accept(OutsideLifecycleException e) throws Exception {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
         // Noop
       }
     });
@@ -307,9 +324,11 @@ public class AutoDisposeMaybeObserverTest {
     o.assertNoErrors();
   }
 
-  @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithWrappedExp() {
+  @Test
+  public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithWrappedExp() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override public void accept(OutsideLifecycleException e) throws Exception {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
         // Wrap in an IllegalStateException so we can verify this is the exception we see on the
         // other side
         throw new IllegalStateException(e);
@@ -324,14 +343,16 @@ public class AutoDisposeMaybeObserverTest {
 
     o.assertNoValues();
     o.assertError(new Predicate<Throwable>() {
-      @Override public boolean test(Throwable throwable) throws Exception {
+      @Override
+      public boolean test(Throwable throwable) throws Exception {
         return throwable instanceof IllegalStateException
             && throwable.getCause() instanceof OutsideLifecycleException;
       }
     });
   }
 
-  @Test public void verifyObserverDelegate() {
+  @Test
+  public void verifyObserverDelegate() {
     final AtomicReference<MaybeObserver> atomicObserver = new AtomicReference<>();
     final AtomicReference<MaybeObserver> atomicAutoDisposingObserver = new AtomicReference<>();
     try {
@@ -350,21 +371,25 @@ public class AutoDisposeMaybeObserverTest {
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingMaybeObserver.class);
-      assertThat(((AutoDisposingMaybeObserver)atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
-      assertThat(((AutoDisposingMaybeObserver)atomicAutoDisposingObserver.get()).delegateObserver())
-              .isSameAs(atomicObserver.get());
+      assertThat(((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get())
+          .delegateObserver()).isNotNull();
+      assertThat(((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get())
+          .delegateObserver()).isSameAs(atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }
   }
 
-  @Test public void verifyCancellation() throws Exception {
+  @Test
+  public void verifyCancellation() throws Exception {
     final AtomicInteger i = new AtomicInteger();
     //noinspection unchecked because Java
     Maybe<Integer> source = Maybe.create(new MaybeOnSubscribe<Integer>() {
-      @Override public void subscribe(MaybeEmitter<Integer> e) throws Exception {
+      @Override
+      public void subscribe(MaybeEmitter<Integer> e) throws Exception {
         e.setCancellable(new Cancellable() {
-          @Override public void cancel() throws Exception {
+          @Override
+          public void cancel() throws Exception {
             i.incrementAndGet();
           }
         });

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -354,7 +354,7 @@ public class AutoDisposeMaybeObserverTest {
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingMaybeObserver.class);
       assertThat(((AutoDisposingMaybeObserver)atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
       assertThat(((AutoDisposingMaybeObserver)atomicAutoDisposingObserver.get()).delegateObserver())
-              .isEqualTo(atomicObserver.get());
+              .isSameAs(atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -162,7 +162,7 @@ public class AutoDisposeObserverTest {
     lifecycle.onNext(1);
     source.onNext(2);
 
-    assertThat(source.hasObservers()).isTrue();Å
+    assertThat(source.hasObservers()).isTrue();
     assertThat(lifecycle.hasObservers()).isTrue();
     assertThat(o.takeNext()).isEqualTo(2);
 

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -280,8 +280,9 @@ public class AutoDisposeObserverTest {
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingObserver.class);
-      assertThat(((AutoDisposingObserver)atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
-      assertThat(((AutoDisposingObserver)atomicAutoDisposingObserver.get()).delegateObserver())
+      assertThat(((AutoDisposingObserver) atomicAutoDisposingObserver.get()).delegateObserver())
+              .isNotNull();
+      assertThat(((AutoDisposingObserver) atomicAutoDisposingObserver.get()).delegateObserver())
               .isSameAs(atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -48,9 +48,6 @@ public class AutoDisposeObserverTest {
     }
   };
 
-  private final AtomicReference<Observer> atomicObserver = new AtomicReference();
-  private final AtomicReference<Observer> atomicAutoDisposingObserver = new AtomicReference<>();
-
   @After public void resetPlugins() {
     AutoDisposePlugins.reset();
   }
@@ -265,6 +262,8 @@ public class AutoDisposeObserverTest {
   }
 
   @Test public void verifyObserverDelegate() {
+    final AtomicReference<Observer> atomicObserver = new AtomicReference();
+    final AtomicReference<Observer> atomicAutoDisposingObserver = new AtomicReference();
     try {
       RxJavaPlugins.setOnObservableSubscribe(new BiFunction<Observable, Observer, Observer>() {
         @Override public Observer apply(Observable source, Observer observer) {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -283,7 +283,7 @@ public class AutoDisposeObserverTest {
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingObserver.class);
       assertThat(((AutoDisposingObserver)atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
       assertThat(((AutoDisposingObserver)atomicAutoDisposingObserver.get()).delegateObserver())
-              .isEqualTo(atomicObserver.get());
+              .isSameAs(atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -42,14 +42,14 @@ import static com.google.common.truth.Truth.assertThat;
 
 public class AutoDisposeObserverTest {
 
-  private final AtomicReference<Observer> atomicObserver = new AtomicReference();
-  private final AtomicReference<Observer> atomicAutoDisposingObserver = new AtomicReference<>();
-
   private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
     @Override public void log(String message) {
       System.out.println(AutoDisposeObserverTest.class.getSimpleName() + ": " + message);
     }
   };
+
+  private final AtomicReference<Observer> atomicObserver = new AtomicReference();
+  private final AtomicReference<Observer> atomicAutoDisposingObserver = new AtomicReference<>();
 
   @After public void resetPlugins() {
     AutoDisposePlugins.reset();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -18,7 +18,6 @@ package com.uber.autodispose;
 
 import com.uber.autodispose.test.RecordingObserver;
 import com.uber.autodispose.observers.AutoDisposingSingleObserver;
-
 import io.reactivex.Maybe;
 import io.reactivex.Single;
 import io.reactivex.SingleEmitter;
@@ -50,9 +49,6 @@ public class AutoDisposeSingleObserverTest {
       System.out.println(AutoDisposeSingleObserverTest.class.getSimpleName() + ": " + message);
     }
   };
-
-  private final AtomicReference<SingleObserver> atomicObserver = new AtomicReference<>();
-  private final AtomicReference<SingleObserver> atomicAutoDisposingObserver = new AtomicReference<>();
 
   @After public void resetPlugins() {
     AutoDisposePlugins.reset();
@@ -303,6 +299,8 @@ public class AutoDisposeSingleObserverTest {
   }
 
   @Test public void verifyObserverDelegate() {
+    final AtomicReference<SingleObserver> atomicObserver = new AtomicReference<>();
+    final AtomicReference<SingleObserver> atomicAutoDisposingObserver = new AtomicReference<>();
     try {
       RxJavaPlugins.setOnSingleSubscribe(new BiFunction<Single, SingleObserver, SingleObserver>() {
         @Override public SingleObserver apply(Single source, SingleObserver observer) {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -18,6 +18,7 @@ package com.uber.autodispose;
 
 import com.uber.autodispose.test.RecordingObserver;
 import com.uber.autodispose.observers.AutoDisposingSingleObserver;
+
 import io.reactivex.Maybe;
 import io.reactivex.Single;
 import io.reactivex.SingleEmitter;
@@ -32,6 +33,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subjects.SingleSubject;
+
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -45,16 +47,19 @@ import static com.uber.autodispose.TestUtil.makeProvider;
 public class AutoDisposeSingleObserverTest {
 
   private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
-    @Override public void log(String message) {
+    @Override
+    public void log(String message) {
       System.out.println(AutoDisposeSingleObserverTest.class.getSimpleName() + ": " + message);
     }
   };
 
-  @After public void resetPlugins() {
+  @After
+  public void resetPlugins() {
     AutoDisposePlugins.reset();
   }
 
-  @Test public void autoDispose_withMaybe_normal() {
+  @Test
+  public void autoDispose_withMaybe_normal() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
@@ -75,23 +80,27 @@ public class AutoDisposeSingleObserverTest {
     assertThat(lifecycle.hasObservers()).isFalse();
   }
 
-  @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
+  @Test
+  public void autoDispose_withSuperClassGenerics_compilesFine() {
     Single.just(new BClass())
         .to(new SingleScoper<AClass>(Maybe.never()))
         .subscribe(new Consumer<AClass>() {
-          @Override public void accept(AClass aClass) throws Exception {
+          @Override
+          public void accept(AClass aClass) throws Exception {
 
           }
         });
   }
 
-  @Test public void autoDispose_noGenericsOnEmpty_isFine() {
+  @Test
+  public void autoDispose_noGenericsOnEmpty_isFine() {
     Single.just(new BClass())
         .to(new SingleScoper<>(Maybe.never()))
         .subscribe();
   }
 
-  @Test public void autoDispose_withMaybe_interrupted() {
+  @Test
+  public void autoDispose_withMaybe_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     MaybeSubject<Integer> lifecycle = MaybeSubject.create();
@@ -112,7 +121,8 @@ public class AutoDisposeSingleObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test public void autoDispose_withProvider() {
+  @Test
+  public void autoDispose_withProvider() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
@@ -133,7 +143,8 @@ public class AutoDisposeSingleObserverTest {
     assertThat(scope.hasObservers()).isFalse();
   }
 
-  @Test public void autoDispose_withProvider_interrupted() {
+  @Test
+  public void autoDispose_withProvider_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     MaybeSubject<Integer> scope = MaybeSubject.create();
@@ -155,7 +166,8 @@ public class AutoDisposeSingleObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test public void autoDispose_withLifecycleProvider() {
+  @Test
+  public void autoDispose_withLifecycleProvider() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
@@ -181,7 +193,8 @@ public class AutoDisposeSingleObserverTest {
     assertThat(lifecycle.hasObservers()).isFalse();
   }
 
-  @Test public void autoDispose_withLifecycleProvider_interrupted() {
+  @Test
+  public void autoDispose_withLifecycleProvider_interrupted() {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
@@ -208,7 +221,8 @@ public class AutoDisposeSingleObserverTest {
     o.assertNoMoreEvents();
   }
 
-  @Test public void autoDispose_withProvider_withoutStartingLifecycle_shouldFail() {
+  @Test
+  public void autoDispose_withProvider_withoutStartingLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
@@ -220,7 +234,8 @@ public class AutoDisposeSingleObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleNotStartedException.class);
   }
 
-  @Test public void autoDispose_withProvider_afterLifecycle_shouldFail() {
+  @Test
+  public void autoDispose_withProvider_afterLifecycle_shouldFail() {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
     lifecycle.onNext(2);
@@ -235,9 +250,11 @@ public class AutoDisposeSingleObserverTest {
     assertThat(o.takeError()).isInstanceOf(LifecycleEndedException.class);
   }
 
-  @Test public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
+  @Test
+  public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override public void accept(OutsideLifecycleException e) throws Exception { }
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception { }
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     TestObserver<Integer> o = new TestObserver<>();
@@ -252,9 +269,11 @@ public class AutoDisposeSingleObserverTest {
     o.assertNoErrors();
   }
 
-  @Test public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
+  @Test
+  public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override public void accept(OutsideLifecycleException e) throws Exception {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
         // Noop
       }
     });
@@ -274,9 +293,11 @@ public class AutoDisposeSingleObserverTest {
     o.assertNoErrors();
   }
 
-  @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithExp() {
+  @Test
+  public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithExp() {
     AutoDisposePlugins.setOutsideLifecycleHandler(new Consumer<OutsideLifecycleException>() {
-      @Override public void accept(OutsideLifecycleException e) throws Exception {
+      @Override
+      public void accept(OutsideLifecycleException e) throws Exception {
         // Wrap in an IllegalStateException so we can verify this is the exception we see on the
         // other side
         throw new IllegalStateException(e);
@@ -291,14 +312,16 @@ public class AutoDisposeSingleObserverTest {
 
     o.assertNoValues();
     o.assertError(new Predicate<Throwable>() {
-      @Override public boolean test(Throwable throwable) throws Exception {
+      @Override
+      public boolean test(Throwable throwable) throws Exception {
         return throwable instanceof IllegalStateException
             && throwable.getCause() instanceof OutsideLifecycleException;
       }
     });
   }
 
-  @Test public void verifyObserverDelegate() {
+  @Test
+  public void verifyObserverDelegate() {
     final AtomicReference<SingleObserver> atomicObserver = new AtomicReference<>();
     final AtomicReference<SingleObserver> atomicAutoDisposingObserver = new AtomicReference<>();
     try {
@@ -317,21 +340,25 @@ public class AutoDisposeSingleObserverTest {
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingSingleObserver.class);
-      assertThat(((AutoDisposingSingleObserver)atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
-      assertThat(((AutoDisposingSingleObserver)atomicAutoDisposingObserver.get()).delegateObserver())
-              .isSameAs(atomicObserver.get());
+      assertThat(((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get())
+          .delegateObserver()).isNotNull();
+      assertThat(((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get())
+          .delegateObserver()).isSameAs(atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }
   }
 
-  @Test public void verifyCancellation() throws Exception {
+  @Test
+  public void verifyCancellation() throws Exception {
     final AtomicInteger i = new AtomicInteger();
     //noinspection unchecked because Java
     Single<Integer> source = Single.create(new SingleOnSubscribe<Integer>() {
-      @Override public void subscribe(SingleEmitter<Integer> e) throws Exception {
+      @Override
+      public void subscribe(SingleEmitter<Integer> e) throws Exception {
         e.setCancellable(new Cancellable() {
-          @Override public void cancel() throws Exception {
+          @Override
+          public void cancel() throws Exception {
             i.incrementAndGet();
           }
         });

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -321,7 +321,7 @@ public class AutoDisposeSingleObserverTest {
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingSingleObserver.class);
       assertThat(((AutoDisposingSingleObserver)atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
       assertThat(((AutoDisposingSingleObserver)atomicAutoDisposingObserver.get()).delegateObserver())
-              .isEqualTo(atomicObserver.get());
+              .isSameAs(atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -16,27 +16,40 @@
 
 package com.uber.autodispose;
 
+import com.uber.autodispose.observers.AutoDisposingSubscriber;
+
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
 import io.reactivex.FlowableEmitter;
 import io.reactivex.FlowableOnSubscribe;
 import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.functions.BiFunction;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Predicate;
+import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
 import io.reactivex.subscribers.TestSubscriber;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.reactivestreams.Subscriber;
+
 import org.junit.After;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 
 public class AutoDisposeSubscriberTest {
+
+  private final AtomicReference<Subscriber> atomicSubscriber = new AtomicReference<>();
+  private final AtomicReference<Subscriber> atomicAutoDisposingSubscriber = new AtomicReference<>();
 
   @After public void resetPlugins() {
     AutoDisposePlugins.reset();
@@ -261,6 +274,33 @@ public class AutoDisposeSubscriberTest {
             && throwable.getCause() instanceof OutsideLifecycleException;
       }
     });
+  }
+
+  @Test public void verifySubscriberDelegate() {
+    try {
+      RxJavaPlugins.setOnFlowableSubscribe(new BiFunction<Flowable, Subscriber, Subscriber>() {
+        @Override public Subscriber apply(Flowable source, Subscriber subscriber) {
+          if (atomicSubscriber.get() == null) {
+            System.out.println(subscriber.getClass().toString());
+            atomicSubscriber.set(subscriber);
+          } else if (atomicAutoDisposingSubscriber.get() == null) {
+            System.out.println(subscriber.getClass().toString());
+            atomicAutoDisposingSubscriber.set(subscriber);
+            RxJavaPlugins.setOnFlowableSubscribe(null);
+          }
+          return subscriber;
+        }
+      });
+      Flowable.just(1).to(new FlowableScoper<Integer>(Maybe.never())).subscribe();
+
+      assertThat(atomicAutoDisposingSubscriber.get()).isNotNull();
+      assertThat(atomicAutoDisposingSubscriber.get()).isInstanceOf(AutoDisposingSubscriber.class);
+      assertThat(((AutoDisposingSubscriber)atomicAutoDisposingSubscriber.get()).delegateSubscriber()).isNotNull();
+      assertThat(((AutoDisposingSubscriber)atomicAutoDisposingSubscriber.get()).delegateSubscriber())
+              .isEqualTo(atomicSubscriber.get());
+    } finally {
+      RxJavaPlugins.reset();
+    }
   }
 
   @Test public void verifyCancellation() throws Exception {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -48,9 +48,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 public class AutoDisposeSubscriberTest {
 
-  private final AtomicReference<Subscriber> atomicSubscriber = new AtomicReference<>();
-  private final AtomicReference<Subscriber> atomicAutoDisposingSubscriber = new AtomicReference<>();
-
   @After public void resetPlugins() {
     AutoDisposePlugins.reset();
   }
@@ -277,6 +274,8 @@ public class AutoDisposeSubscriberTest {
   }
 
   @Test public void verifySubscriberDelegate() {
+    final AtomicReference<Subscriber> atomicSubscriber = new AtomicReference<>();
+    final AtomicReference<Subscriber> atomicAutoDisposingSubscriber = new AtomicReference<>();
     try {
       RxJavaPlugins.setOnFlowableSubscribe(new BiFunction<Flowable, Subscriber, Subscriber>() {
         @Override public Subscriber apply(Flowable source, Subscriber subscriber) {

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -297,7 +297,7 @@ public class AutoDisposeSubscriberTest {
       assertThat(atomicAutoDisposingSubscriber.get()).isInstanceOf(AutoDisposingSubscriber.class);
       assertThat(((AutoDisposingSubscriber)atomicAutoDisposingSubscriber.get()).delegateSubscriber()).isNotNull();
       assertThat(((AutoDisposingSubscriber)atomicAutoDisposingSubscriber.get()).delegateSubscriber())
-              .isEqualTo(atomicSubscriber.get());
+              .isSameAs(atomicSubscriber.get());
     } finally {
       RxJavaPlugins.reset();
     }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -23,9 +23,6 @@ import io.reactivex.Flowable;
 import io.reactivex.FlowableEmitter;
 import io.reactivex.FlowableOnSubscribe;
 import io.reactivex.Maybe;
-import io.reactivex.MaybeObserver;
-import io.reactivex.Single;
-import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.functions.Cancellable;
@@ -294,9 +291,10 @@ public class AutoDisposeSubscriberTest {
 
       assertThat(atomicAutoDisposingSubscriber.get()).isNotNull();
       assertThat(atomicAutoDisposingSubscriber.get()).isInstanceOf(AutoDisposingSubscriber.class);
-      assertThat(((AutoDisposingSubscriber)atomicAutoDisposingSubscriber.get()).delegateSubscriber()).isNotNull();
-      assertThat(((AutoDisposingSubscriber)atomicAutoDisposingSubscriber.get()).delegateSubscriber())
-              .isSameAs(atomicSubscriber.get());
+      assertThat(((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get())
+          .delegateSubscriber()).isNotNull();
+      assertThat(((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get())
+          .delegateSubscriber()).isSameAs(atomicSubscriber.get());
     } finally {
       RxJavaPlugins.reset();
     }


### PR DESCRIPTION
Resolves #78

This change updated `AutoDisposingSubscriber` implement `FlowableSubscriber` instead of `Subscriber`. We wanted to have more consistency with how the rest of the `Observer`s are handled in RxJava. This change remains backward compatible because `FlowableSubscriber` still extends `Subscriber`.

This also exposes all the different implementations of `Observer` to allow for introspection to the delegate `Observer`. This will be particularly useful for https://github.com/ReactiveX/RxJava/pull/5590.