### PR TITLE
Update Arch Components to beta1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,7 +16,7 @@
 
 def versions = [
     androidTest: '0.5',
-    archComponents: '1.0.0-alpha8',
+    archComponents: '1.0.0-beta1',
     errorProne: '2.1.1',
     kotlin: '1.1.4-2',
     support: '25.1.0'


### PR DESCRIPTION
This is API-stable, which makes us safe for release