### PR TITLE
Update various dependencies

### DIFF
--- a/autodispose-android-archcomponents/build.gradle
+++ b/autodispose-android-archcomponents/build.gradle
@@ -66,9 +66,7 @@ dependencies {
 
 tasks.withType(JavaCompile) {
   options.compilerArgs += ["-Xep:NullAway:ERROR",
-                           "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                           // Because arch components doesn't generate @Override
-                           "-Xep:MissingOverride:OFF"]
+                           "-XepOpt:NullAway:AnnotatedPackages=com.uber"]
 }
 
 // Disable for now until we're ready to release this

--- a/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/archcomponents/AndroidLifecycleScopeProviderTest.java
+++ b/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/archcomponents/AndroidLifecycleScopeProviderTest.java
@@ -17,8 +17,8 @@
 package com.uber.autodispose.android.archcomponents;
 
 import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleOwner;
 import android.arch.lifecycle.LifecycleRegistry;
-import android.arch.lifecycle.LifecycleRegistryOwner;
 import android.support.test.annotation.UiThreadTest;
 import android.support.test.rule.UiThreadTestRule;
 import android.support.test.runner.AndroidJUnit4;
@@ -150,7 +150,7 @@ import static com.google.common.truth.Truth.assertThat;
     assertThat(d.isDisposed()).isTrue();
   }
 
-  private static class UninitializedLifecycleOwner implements LifecycleRegistryOwner {
+  private static class UninitializedLifecycleOwner implements LifecycleOwner {
 
     LifecycleRegistry registry = new LifecycleRegistry(this);
 

--- a/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
+++ b/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
@@ -36,7 +36,6 @@ import org.junit.runner.RunWith;
 import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(AndroidJUnit4.class)
-@SuppressWarnings("NullAway") // https://github.com/uber/NullAway/issues/18
 public final class ViewScopeProviderTest {
 
   private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -31,7 +31,7 @@ def build = [
 
     checkerFramework: 'org.checkerframework:dataflow:2.1.14',
     errorProne: "com.google.errorprone:error_prone_core:${versions.errorProne}",
-    nullAway: 'com.uber.nullaway:nullaway:0.1.2',
+    nullAway: 'com.uber.nullaway:nullaway:0.1.4',
 
     repositories: [
         plugins: 'https://plugins.gradle.org/m2/'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -75,7 +75,7 @@ def test = [
     androidRunner: "com.android.support.test:runner:${versions.androidTest}",
     androidRules: "com.android.support.test:rules:${versions.androidTest}",
     junit: 'junit:junit:4.12',
-    truth: 'com.google.truth:truth:0.34'
+    truth: 'com.google.truth:truth:0.36'
 ]
 
 ext.deps = [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ def versions = [
     archComponents: '1.0.0-beta1',
     errorProne: '2.1.1',
     kotlin: '1.1.50',
-    support: '25.1.0'
+    support: '26.1.0'
 ]
 
 def build = [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,7 +18,7 @@ def versions = [
     androidTest: '0.5',
     archComponents: '1.0.0-beta1',
     errorProne: '2.1.1',
-    kotlin: '1.1.4-2',
+    kotlin: '1.1.50',
     support: '25.1.0'
 ]
 


### PR DESCRIPTION
- Truth 0.36
- Support library 26.1.0
  - This is what arch components depends on, so keeping parity with it as our new standard
- Nullaway 0.1.4 (plus remove the suppressions)
- Kotlin 1.1.50