### PR TITLE
Various arch components support fixes

### DIFF
--- a/autodispose-android-archcomponents/build.gradle
+++ b/autodispose-android-archcomponents/build.gradle
@@ -69,5 +69,4 @@ tasks.withType(JavaCompile) {
                            "-XepOpt:NullAway:AnnotatedPackages=com.uber"]
 }
 
-// Disable for now until we're ready to release this
-// apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleTest.java
+++ b/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleTest.java
@@ -17,15 +17,12 @@
 package com.uber.autodispose.android.lifecycle;
 
 import android.arch.lifecycle.Lifecycle;
-import android.arch.lifecycle.LifecycleOwner;
-import android.arch.lifecycle.LifecycleRegistry;
 import android.support.test.annotation.UiThreadTest;
 import android.support.test.rule.UiThreadTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Log;
 import com.uber.autodispose.AutoDispose;
 import com.uber.autodispose.LifecycleEndedException;
-import com.uber.autodispose.LifecycleNotStartedException;
 import com.uber.autodispose.test.RecordingObserver;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.subjects.PublishSubject;
@@ -96,21 +93,6 @@ import static com.google.common.truth.Truth.assertThat;
     assertThat(d.isDisposed()).isTrue();
   }
 
-  @Test @UiThreadTest public void observable_offBeforeCreate_shouldFail() {
-    final RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
-    final PublishSubject<Integer> subject = PublishSubject.create();
-
-    UninitializedLifecycleOwner owner = new UninitializedLifecycleOwner();
-    subject.to(AutoDispose.with(AndroidLifecycle.from(owner)).<Integer>forObservable())
-        .subscribe(o);
-
-    Disposable d = o.takeSubscribe();
-    Throwable t = o.takeError();
-    assertThat(t).isInstanceOf(LifecycleNotStartedException.class);
-    o.assertNoMoreEvents();
-    assertThat(d.isDisposed()).isTrue();
-  }
-
   @Test @UiThreadTest public void observable_offAfterDestroy_shouldFail() {
     final RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     final PublishSubject<Integer> subject = PublishSubject.create();
@@ -152,14 +134,5 @@ import static com.google.common.truth.Truth.assertThat;
     assertThat(t).isInstanceOf(LifecycleEndedException.class);
     o.assertNoMoreEvents();
     assertThat(d.isDisposed()).isTrue();
-  }
-
-  private static class UninitializedLifecycleOwner implements LifecycleOwner {
-
-    LifecycleRegistry registry = new LifecycleRegistry(this);
-
-    @Override public LifecycleRegistry getLifecycle() {
-      return registry;
-    }
   }
 }

--- a/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/TestAndroidLifecycle.java
+++ b/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/TestAndroidLifecycle.java
@@ -17,8 +17,8 @@
 package com.uber.autodispose.android.lifecycle;
 
 import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleOwner;
 import android.arch.lifecycle.LifecycleRegistry;
-import android.arch.lifecycle.LifecycleRegistryOwner;
 import android.support.annotation.Nullable;
 import android.support.annotation.RestrictTo;
 
@@ -28,8 +28,7 @@ import static android.support.annotation.RestrictTo.Scope.TESTS;
  * AndroidLifecycle implementation for testing. You can either back it with your own
  * instance, or just stub it in place and use its public emit() API.
  */
-@RestrictTo(TESTS) public final class TestAndroidLifecycle
-    implements LifecycleRegistryOwner {
+@RestrictTo(TESTS) public final class TestAndroidLifecycle implements LifecycleOwner {
 
   private final LifecycleRegistry registry;
 


### PR DESCRIPTION
This is a few miscellaneous arch components fixes:
- Enabled releases now
- Fix a deprecated implementation to use `LifecycleOwner`
- Make tests more comprehensive and realistic
- Fix #93 by offsetting backfilling up one. See issue there for more info, but the gist is that lifecycle `State`s are always the preceding event until after the callback is completed. A little confusing, but we can hide the weirdness under the hood as implementation detail.