### PR TITLE
Rename AndroidLifecycle back to AndroidLifecycleScopeProvider

### DIFF
--- a/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProviderTest.java
+++ b/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProviderTest.java
@@ -32,11 +32,11 @@ import org.junit.runner.RunWith;
 
 import static com.google.common.truth.Truth.assertThat;
 
-@RunWith(AndroidJUnit4.class) public final class AndroidLifecycleTest {
+@RunWith(AndroidJUnit4.class) public final class AndroidLifecycleScopeProviderTest {
 
   private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
     @Override public void log(String message) {
-      Log.d(AndroidLifecycleTest.class.getSimpleName(), message);
+      Log.d(AndroidLifecycleScopeProviderTest.class.getSimpleName(), message);
     }
   };
 
@@ -47,8 +47,9 @@ import static com.google.common.truth.Truth.assertThat;
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestAndroidLifecycle lifecycle = new TestAndroidLifecycle();
-    subject.to(AutoDispose.with(AndroidLifecycle.from(lifecycle)).<Integer>forObservable())
+    TestAndroidLifecycleScopeProvider lifecycle = new TestAndroidLifecycleScopeProvider();
+    subject.to(AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle))
+        .<Integer>forObservable())
         .subscribe(o);
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     lifecycle.emit(Lifecycle.Event.ON_START);
@@ -76,9 +77,10 @@ import static com.google.common.truth.Truth.assertThat;
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestAndroidLifecycle lifecycle = new TestAndroidLifecycle();
+    TestAndroidLifecycleScopeProvider lifecycle = new TestAndroidLifecycleScopeProvider();
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
-    subject.to(AutoDispose.with(AndroidLifecycle.from(lifecycle)).<Integer>forObservable())
+    subject.to(AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle))
+        .<Integer>forObservable())
         .subscribe(o);
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
@@ -105,10 +107,11 @@ import static com.google.common.truth.Truth.assertThat;
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestAndroidLifecycle lifecycle = new TestAndroidLifecycle();
+    TestAndroidLifecycleScopeProvider lifecycle = new TestAndroidLifecycleScopeProvider();
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     lifecycle.emit(Lifecycle.Event.ON_START);
-    subject.to(AutoDispose.with(AndroidLifecycle.from(lifecycle)).<Integer>forObservable())
+    subject.to(AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle))
+        .<Integer>forObservable())
         .subscribe(o);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
 
@@ -136,11 +139,12 @@ import static com.google.common.truth.Truth.assertThat;
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestAndroidLifecycle lifecycle = new TestAndroidLifecycle();
+    TestAndroidLifecycleScopeProvider lifecycle = new TestAndroidLifecycleScopeProvider();
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
-    subject.to(AutoDispose.with(AndroidLifecycle.from(lifecycle)).<Integer>forObservable())
+    subject.to(AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle))
+        .<Integer>forObservable())
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -166,11 +170,12 @@ import static com.google.common.truth.Truth.assertThat;
     PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestAndroidLifecycle lifecycle = new TestAndroidLifecycle();
+    TestAndroidLifecycleScopeProvider lifecycle = new TestAndroidLifecycleScopeProvider();
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
-    subject.to(AutoDispose.with(AndroidLifecycle.from(lifecycle)).<Integer>forObservable())
+    subject.to(AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle))
+        .<Integer>forObservable())
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -185,14 +190,15 @@ import static com.google.common.truth.Truth.assertThat;
     final RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     final PublishSubject<Integer> subject = PublishSubject.create();
 
-    TestAndroidLifecycle lifecycle = new TestAndroidLifecycle();
+    TestAndroidLifecycleScopeProvider lifecycle = new TestAndroidLifecycleScopeProvider();
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
     lifecycle.emit(Lifecycle.Event.ON_PAUSE);
     lifecycle.emit(Lifecycle.Event.ON_STOP);
     lifecycle.emit(Lifecycle.Event.ON_DESTROY);
-    subject.to(AutoDispose.with(AndroidLifecycle.from(lifecycle)).<Integer>forObservable())
+    subject.to(AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle))
+        .<Integer>forObservable())
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -206,13 +212,14 @@ import static com.google.common.truth.Truth.assertThat;
     final RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     final PublishSubject<Integer> subject = PublishSubject.create();
 
-    TestAndroidLifecycle lifecycle = new TestAndroidLifecycle();
+    TestAndroidLifecycleScopeProvider lifecycle = new TestAndroidLifecycleScopeProvider();
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
     lifecycle.emit(Lifecycle.Event.ON_PAUSE);
     lifecycle.emit(Lifecycle.Event.ON_STOP);
-    subject.to(AutoDispose.with(AndroidLifecycle.from(lifecycle)).<Integer>forObservable())
+    subject.to(AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycle))
+        .<Integer>forObservable())
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();

--- a/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProvider.java
+++ b/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProvider.java
@@ -28,10 +28,10 @@ import io.reactivex.functions.Function;
  * {@link LifecycleOwner} classes.
  * <p>
  * <pre><code>
- *   AutoDispose.with(AndroidLifecycle.from(lifecycleOwner))
+ *   AutoDispose.with(AndroidLifecycleScopeProvider.from(lifecycleOwner))
  * </code></pre>
  */
-public final class AndroidLifecycle
+public final class AndroidLifecycleScopeProvider
     implements LifecycleScopeProvider<Lifecycle.Event> {
 
   private static final Function<Lifecycle.Event, Lifecycle.Event> CORRESPONDING_EVENTS =
@@ -55,28 +55,28 @@ public final class AndroidLifecycle
       };
 
   /**
-   * Creates a {@link AndroidLifecycle} for Android LifecycleOwners.
+   * Creates a {@link AndroidLifecycleScopeProvider} for Android LifecycleOwners.
    *
    * @param owner the owner to scope for
-   * @return a {@link AndroidLifecycle} against this owner.
+   * @return a {@link AndroidLifecycleScopeProvider} against this owner.
    */
-  public static AndroidLifecycle from(LifecycleOwner owner) {
+  public static AndroidLifecycleScopeProvider from(LifecycleOwner owner) {
     return from(owner.getLifecycle());
   }
 
   /**
-   * Creates a {@link AndroidLifecycle} for Android Lifecycles.
+   * Creates a {@link AndroidLifecycleScopeProvider} for Android Lifecycles.
    *
    * @param lifecycle the lifecycle to scope for
-   * @return a {@link AndroidLifecycle} against this lifecycle.
+   * @return a {@link AndroidLifecycleScopeProvider} against this lifecycle.
    */
-  public static AndroidLifecycle from(Lifecycle lifecycle) {
-    return new AndroidLifecycle(lifecycle);
+  public static AndroidLifecycleScopeProvider from(Lifecycle lifecycle) {
+    return new AndroidLifecycleScopeProvider(lifecycle);
   }
 
   private final LifecycleEventsObservable lifecycleObservable;
 
-  private AndroidLifecycle(Lifecycle lifecycle) {
+  private AndroidLifecycleScopeProvider(Lifecycle lifecycle) {
     this.lifecycleObservable = new LifecycleEventsObservable(lifecycle);
   }
 

--- a/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/TestAndroidLifecycleScopeProvider.java
+++ b/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/TestAndroidLifecycleScopeProvider.java
@@ -25,17 +25,17 @@ import android.support.annotation.RestrictTo;
 import static android.support.annotation.RestrictTo.Scope.TESTS;
 
 /**
- * AndroidLifecycle implementation for testing. You can either back it with your own
- * instance, or just stub it in place and use its public emit() API.
+ * {@link AndroidLifecycleScopeProvider} implementation for testing. You can either back it with
+ * your own instance or just stub it in place and use its public emit() API.
  */
-@RestrictTo(TESTS) public final class TestAndroidLifecycle implements LifecycleOwner {
+@RestrictTo(TESTS) public final class TestAndroidLifecycleScopeProvider implements LifecycleOwner {
 
   private final LifecycleRegistry registry;
 
   /**
    * Default constructor, creates and maintains its own {@link LifecycleRegistry} under the hood.
    */
-  public TestAndroidLifecycle() {
+  public TestAndroidLifecycleScopeProvider() {
     this(null);
   }
 
@@ -43,7 +43,7 @@ import static android.support.annotation.RestrictTo.Scope.TESTS;
    * @param registry an optional custom {@link LifecycleRegistry} if you want to provide one. If
    * {@code null}, a default implementation will be created and maintained under the hood.
    */
-  public TestAndroidLifecycle(@Nullable LifecycleRegistry registry) {
+  public TestAndroidLifecycleScopeProvider(@Nullable LifecycleRegistry registry) {
     this.registry = registry == null ? new LifecycleRegistry(this) : registry;
   }
 
@@ -75,8 +75,8 @@ import static android.support.annotation.RestrictTo.Scope.TESTS;
         registry.markState(Lifecycle.State.DESTROYED);
         break;
       case ON_ANY:
-        throw new IllegalArgumentException(
-            "Event#ON_ANY is not a valid event to the emit() method.");
+        throw new IllegalArgumentException("Event#ON_ANY is not a valid event to the emit() "
+            + "method.");
     }
   }
 }

--- a/sample/src/main/java/com/uber/autodispose/sample/MainActivity.java
+++ b/sample/src/main/java/com/uber/autodispose/sample/MainActivity.java
@@ -20,7 +20,7 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import com.uber.autodispose.AutoDispose;
-import com.uber.autodispose.android.lifecycle.AndroidLifecycle;
+import com.uber.autodispose.android.lifecycle.AndroidLifecycleScopeProvider;
 import io.reactivex.Observable;
 import io.reactivex.functions.Action;
 import io.reactivex.functions.Consumer;
@@ -50,7 +50,7 @@ public class MainActivity extends AppCompatActivity {
             Log.i(TAG, "Disposing subscription from onCreate()");
           }
         })
-        .to(AutoDispose.with(AndroidLifecycle.from(this)).<Long>forObservable())
+        .to(AutoDispose.with(AndroidLifecycleScopeProvider.from(this)).<Long>forObservable())
         .subscribe(new Consumer<Long>() {
           @Override public void accept(Long num) throws Exception {
             Log.i(TAG, "Started in onCreate(), running until onDestroy(): " + num);
@@ -71,7 +71,7 @@ public class MainActivity extends AppCompatActivity {
             Log.i(TAG, "Disposing subscription from onStart()");
           }
         })
-        .to(AutoDispose.with(AndroidLifecycle.from(this)).<Long>forObservable())
+        .to(AutoDispose.with(AndroidLifecycleScopeProvider.from(this)).<Long>forObservable())
         .subscribe(new Consumer<Long>() {
           @Override public void accept(Long num) throws Exception {
             Log.i(TAG, "Started in onStart(), running until in onStop(): " + num);
@@ -94,7 +94,7 @@ public class MainActivity extends AppCompatActivity {
         })
         // `.<Long>forObservable` is necessary if you're compiling on JDK7 or below.
         // If you're using JDK8+, then you can safely remove it.
-        .to(AutoDispose.with(AndroidLifecycle.from(this)).<Long>forObservable())
+        .to(AutoDispose.with(AndroidLifecycleScopeProvider.from(this)).<Long>forObservable())
         .subscribe(new Consumer<Long>() {
           @Override public void accept(Long num) throws Exception {
             Log.i(TAG, "Started in onResume(), running until in onDestroy(): " + num);

--- a/sample/src/main/kotlin/com/uber/autodispose/sample/KotlinActivity.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/sample/KotlinActivity.kt
@@ -19,7 +19,7 @@ package com.uber.autodispose.sample
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
-import com.uber.autodispose.android.lifecycle.AndroidLifecycle
+import com.uber.autodispose.android.lifecycle.AndroidLifecycleScopeProvider
 import com.uber.autodispose.kotlin.autoDisposeWith
 import io.reactivex.Observable
 import java.util.concurrent.TimeUnit
@@ -40,7 +40,7 @@ class KotlinActivity : AppCompatActivity() {
     // dispose is onDestroy (the opposite of onCreate).
     Observable.interval(1, TimeUnit.SECONDS)
         .doOnDispose { Log.i(TAG, "Disposing subscription from onCreate()") }
-        .autoDisposeWith(AndroidLifecycle.from(this))
+        .autoDisposeWith(AndroidLifecycleScopeProvider.from(this))
         .subscribe { num -> Log.i(TAG, "Started in onCreate(), running until onDestroy(): " + num) }
   }
 
@@ -53,7 +53,7 @@ class KotlinActivity : AppCompatActivity() {
     // dispose is onStop (the opposite of onStart).
     Observable.interval(1, TimeUnit.SECONDS)
         .doOnDispose { Log.i(TAG, "Disposing subscription from onStart()") }
-        .autoDisposeWith(AndroidLifecycle.from(this))
+        .autoDisposeWith(AndroidLifecycleScopeProvider.from(this))
         .subscribe { num -> Log.i(TAG, "Started in onStart(), running until in onStop(): " + num) }
   }
 
@@ -66,7 +66,7 @@ class KotlinActivity : AppCompatActivity() {
     // dispose is onPause (the opposite of onResume).
     Observable.interval(1, TimeUnit.SECONDS)
         .doOnDispose { Log.i(TAG, "Disposing subscription from onResume()") }
-        .autoDisposeWith(AndroidLifecycle.from(this))
+        .autoDisposeWith(AndroidLifecycleScopeProvider.from(this))
         .subscribe { num ->
           Log.i(TAG, "Started in onResume(), running until in onPause(): " + num)
         }


### PR DESCRIPTION
The established pattern now for concrete classes is to have this suffix, and it also is much more obvious what it's for when reading it.

Partially reverts #94 (sorry!)

This could partially be resolved by #75 in the future (if we could do something like `ScopeProviders.android(...)`)