### PR TITLE
Removed synthentic accessor from auto disposables and recording observer

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
@@ -81,7 +81,8 @@ final class AutoDisposingCompletableObserverImpl implements AutoDisposingComplet
     }
   }
 
-  private void callMainSubscribeIfNecessary(Disposable d) {
+  /* private */
+  void callMainSubscribeIfNecessary(Disposable d) {
     // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
     // onSubscribe and had a terminal event), we need to still send an empty disposable instance
     // to abide by the Observer contract.

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
@@ -81,7 +81,8 @@ final class AutoDisposingMaybeObserverImpl<T> implements AutoDisposingMaybeObser
     }
   }
 
-  private void callMainSubscribeIfNecessary(Disposable d) {
+  /* private */
+  void callMainSubscribeIfNecessary(Disposable d) {
     // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
     // onSubscribe and had a terminal event), we need to still send an empty disposable instance
     // to abide by the Observer contract.

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
@@ -81,7 +81,8 @@ final class AutoDisposingObserverImpl<T> implements AutoDisposingObserver<T> {
     }
   }
 
-  private void callMainSubscribeIfNecessary(Disposable d) {
+  /* private */
+  void callMainSubscribeIfNecessary(Disposable d) {
     // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
     // onSubscribe and had a terminal event), we need to still send an empty disposable instance
     // to abide by the Observer contract.

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
@@ -81,7 +81,8 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
     }
   }
 
-  private void callMainSubscribeIfNecessary(Disposable d) {
+  /* private */
+  void callMainSubscribeIfNecessary(Disposable d) {
     // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
     // onSubscribe and had a terminal event), we need to still send an empty disposable instance
     // to abide by the Observer contract.

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
@@ -99,7 +99,8 @@ final class AutoDisposingSubscriberImpl<T> implements AutoDisposingSubscriber<T>
     }
   }
 
-  private void callMainSubscribeIfNecessary(Subscription s) {
+  /* private */
+  void callMainSubscribeIfNecessary(Subscription s) {
     // If we've never actually started the upstream subscription (i.e. requested immediately in
     // onSubscribe and had a terminal event), we need to still send an empty subscription instance
     // to abide by the Subscriber contract.

--- a/test-utils/src/main/java/com/uber/autodispose/test/RecordingObserver.java
+++ b/test-utils/src/main/java/com/uber/autodispose/test/RecordingObserver.java
@@ -125,7 +125,8 @@ public final class RecordingObserver<T>
   private final class OnNext {
     final T value;
 
-    private OnNext(T value) {
+    /* private */
+    OnNext(T value) {
       this.value = value;
     }
 
@@ -141,9 +142,11 @@ public final class RecordingObserver<T>
   }
 
   private static final class OnError {
-    private final Throwable throwable;
+    /* private */
+    final Throwable throwable;
 
-    private OnError(Throwable throwable) {
+    /* private */
+    OnError(Throwable throwable) {
       this.throwable = throwable;
     }
 
@@ -153,9 +156,11 @@ public final class RecordingObserver<T>
   }
 
   private static final class OnSubscribe {
-    private final Disposable disposable;
+    /* private */
+    final Disposable disposable;
 
-    private OnSubscribe(Disposable disposable) {
+    /* private */
+    OnSubscribe(Disposable disposable) {
       this.disposable = disposable;
     }
 
@@ -165,9 +170,11 @@ public final class RecordingObserver<T>
   }
 
   private final class OnSuccess {
-    private final T value;
+    /* private */
+    final T value;
 
-    private OnSuccess(T value) {
+    /* private */
+    OnSuccess(T value) {
       this.value = value;
     }
 


### PR DESCRIPTION
Removed synthetic accessors.  Fixes - https://github.com/uber/AutoDispose/issues/102
Total dex count 
- autodispose package: Master - 454, New - 449, 
- recording observer - Master - 49, New - 42

