### PR TITLE
Add untilEvent overload for AndroidLifecycleScopeProvider#from

### DIFF
--- a/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProvider.java
+++ b/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProvider.java
@@ -74,7 +74,8 @@ public final class AndroidLifecycleScopeProvider
    * @return a {@link AndroidLifecycleScopeProvider} against this owner.
    */
   public static AndroidLifecycleScopeProvider from(
-          LifecycleOwner owner, Lifecycle.Event untilEvent) {
+          LifecycleOwner owner,
+          Lifecycle.Event untilEvent) {
     return from(owner.getLifecycle(), untilEvent);
   }
 
@@ -96,7 +97,8 @@ public final class AndroidLifecycleScopeProvider
    * @return a {@link AndroidLifecycleScopeProvider} against this lifecycle.
    */
   public static AndroidLifecycleScopeProvider from(
-          Lifecycle lifecycle, Lifecycle.Event untilEvent) {
+          Lifecycle lifecycle,
+          Lifecycle.Event untilEvent) {
     return new AndroidLifecycleScopeProvider(lifecycle, untilEvent);
   }
 

--- a/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProvider.java
+++ b/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProvider.java
@@ -34,7 +34,7 @@ import io.reactivex.functions.Function;
 public final class AndroidLifecycleScopeProvider
     implements LifecycleScopeProvider<Lifecycle.Event> {
 
-  private static final Function<Lifecycle.Event, Lifecycle.Event> CORRESPONDING_EVENTS =
+  private static final Function<Lifecycle.Event, Lifecycle.Event> DEFAULT_CORRESPONDING_EVENTS =
       new Function<Lifecycle.Event, Lifecycle.Event>() {
         @Override public Lifecycle.Event apply(Lifecycle.Event lastEvent) throws Exception {
           switch (lastEvent) {
@@ -54,10 +54,12 @@ public final class AndroidLifecycleScopeProvider
         }
       };
 
+  private final Function<Lifecycle.Event, Lifecycle.Event> correspondingEvents;
+
   /**
    * Creates a {@link AndroidLifecycleScopeProvider} for Android LifecycleOwners.
    *
-   * @param owner the owner to scope for
+   * @param owner the owner to scope for.
    * @return a {@link AndroidLifecycleScopeProvider} against this owner.
    */
   public static AndroidLifecycleScopeProvider from(LifecycleOwner owner) {
@@ -65,19 +67,48 @@ public final class AndroidLifecycleScopeProvider
   }
 
   /**
+   * Creates a {@link AndroidLifecycleScopeProvider} for Android LifecycleOwners.
+   *
+   * @param owner the owner to scope for.
+   * @param untilEvent the event until the scope is valid.
+   * @return a {@link AndroidLifecycleScopeProvider} against this owner.
+   */
+  public static AndroidLifecycleScopeProvider from(LifecycleOwner owner,
+                                                   Lifecycle.Event untilEvent) {
+    return from(owner.getLifecycle(), untilEvent);
+  }
+
+  /**
    * Creates a {@link AndroidLifecycleScopeProvider} for Android Lifecycles.
    *
-   * @param lifecycle the lifecycle to scope for
+   * @param lifecycle the lifecycle to scope for.
    * @return a {@link AndroidLifecycleScopeProvider} against this lifecycle.
    */
   public static AndroidLifecycleScopeProvider from(Lifecycle lifecycle) {
     return new AndroidLifecycleScopeProvider(lifecycle);
   }
 
+  /**
+   * Creates a {@link AndroidLifecycleScopeProvider} for Android Lifecycles.
+   *
+   * @param lifecycle the lifecycle to scope for.
+   * @param untilEvent the event until the scope is valid.
+   * @return a {@link AndroidLifecycleScopeProvider} against this lifecycle.
+   */
+  public static AndroidLifecycleScopeProvider from(Lifecycle lifecycle, Lifecycle.Event untilEvent) {
+    return new AndroidLifecycleScopeProvider(lifecycle, untilEvent);
+  }
+
   private final LifecycleEventsObservable lifecycleObservable;
 
   private AndroidLifecycleScopeProvider(Lifecycle lifecycle) {
     this.lifecycleObservable = new LifecycleEventsObservable(lifecycle);
+    this.correspondingEvents = DEFAULT_CORRESPONDING_EVENTS;
+  }
+
+  private AndroidLifecycleScopeProvider(Lifecycle lifecycle, Lifecycle.Event untilEvent) {
+    this.lifecycleObservable = new LifecycleEventsObservable(lifecycle);
+    this.correspondingEvents = new UntilEventFunction(untilEvent);
   }
 
   @Override public Observable<Lifecycle.Event> lifecycle() {
@@ -85,10 +116,23 @@ public final class AndroidLifecycleScopeProvider
   }
 
   @Override public Function<Lifecycle.Event, Lifecycle.Event> correspondingEvents() {
-    return CORRESPONDING_EVENTS;
+    return correspondingEvents;
   }
 
   @Override public Lifecycle.Event peekLifecycle() {
     return lifecycleObservable.getValue();
+  }
+
+  private static class UntilEventFunction implements Function<Lifecycle.Event, Lifecycle.Event> {
+    private final Lifecycle.Event untilEvent;
+
+    UntilEventFunction(Lifecycle.Event untilEvent) {
+      this.untilEvent = untilEvent;
+    }
+
+    @Override
+    public Lifecycle.Event apply(Lifecycle.Event event) throws Exception {
+      return untilEvent;
+    }
   }
 }

--- a/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProvider.java
+++ b/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProvider.java
@@ -73,8 +73,8 @@ public final class AndroidLifecycleScopeProvider
    * @param untilEvent the event until the scope is valid.
    * @return a {@link AndroidLifecycleScopeProvider} against this owner.
    */
-  public static AndroidLifecycleScopeProvider from(LifecycleOwner owner,
-                                                   Lifecycle.Event untilEvent) {
+  public static AndroidLifecycleScopeProvider from(
+          LifecycleOwner owner, Lifecycle.Event untilEvent) {
     return from(owner.getLifecycle(), untilEvent);
   }
 
@@ -95,7 +95,8 @@ public final class AndroidLifecycleScopeProvider
    * @param untilEvent the event until the scope is valid.
    * @return a {@link AndroidLifecycleScopeProvider} against this lifecycle.
    */
-  public static AndroidLifecycleScopeProvider from(Lifecycle lifecycle, Lifecycle.Event untilEvent) {
+  public static AndroidLifecycleScopeProvider from(
+          Lifecycle lifecycle, Lifecycle.Event untilEvent) {
     return new AndroidLifecycleScopeProvider(lifecycle, untilEvent);
   }
 

--- a/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProvider.java
+++ b/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProvider.java
@@ -130,8 +130,7 @@ public final class AndroidLifecycleScopeProvider
       this.untilEvent = untilEvent;
     }
 
-    @Override
-    public Lifecycle.Event apply(Lifecycle.Event event) throws Exception {
+    @Override public Lifecycle.Event apply(Lifecycle.Event event) throws Exception {
       return untilEvent;
     }
   }

--- a/sample/src/main/kotlin/com/uber/autodispose/sample/KotlinActivity.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/sample/KotlinActivity.kt
@@ -16,6 +16,7 @@
 
 package com.uber.autodispose.sample
 
+import android.arch.lifecycle.Lifecycle
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
@@ -69,6 +70,16 @@ class KotlinActivity : AppCompatActivity() {
         .autoDisposeWith(AndroidLifecycleScopeProvider.from(this))
         .subscribe { num ->
           Log.i(TAG, "Started in onResume(), running until in onPause(): " + num)
+        }
+
+    // Setting a specific untilEvent, this should dispose in onDestroy.
+    Observable.interval(1, TimeUnit.SECONDS)
+        .doOnDispose {
+          Log.i(TAG, "Disposing subscription from onResume() with untilEvent ON_DESTROY")
+        }
+        .autoDisposeWith(AndroidLifecycleScopeProvider.from(this, Lifecycle.Event.ON_DESTROY))
+        .subscribe{ num ->
+          Log.i(TAG, "Started in onResume(), running until in onDestroy(): " + num)
         }
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to AutoDispose. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**: This adds two overloads to the `AndroidLifecycleScopeProvider#from` methods, to achieve the same functionality as `RxLifecycle`'s `bindUntilEvent`.

I have taken the approach of returning the set value in the `correspondingEvents` function. It works, but I'm not sure if that is the right way.

I also fixed minor issues I found while scanning through the code. I can revert those if not appropriate.

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**: #72, #104

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
