### PR TITLE
Lint suppressions and use custom observers in lifecycle subscriptions

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
@@ -81,7 +81,7 @@ final class AutoDisposingCompletableObserverImpl implements AutoDisposingComplet
     }
   }
 
-  /* private */
+  @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors
   void callMainSubscribeIfNecessary(Disposable d) {
     // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
     // onSubscribe and had a terminal event), we need to still send an empty disposable instance

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
@@ -21,7 +21,6 @@ import io.reactivex.CompletableObserver;
 import io.reactivex.Maybe;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
-import io.reactivex.functions.BiConsumer;
 import io.reactivex.observers.DisposableMaybeObserver;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -43,24 +42,22 @@ final class AutoDisposingCompletableObserverImpl implements AutoDisposingComplet
 
   @Override public void onSubscribe(final Disposable d) {
     if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable,
-        lifecycle.doOnEvent(new BiConsumer<Object, Throwable>() {
-          @Override public void accept(Object o, Throwable throwable) throws Exception {
+        lifecycle.subscribeWith(new DisposableMaybeObserver<Object>() {
+          @Override public void onSuccess(Object o) {
             callMainSubscribeIfNecessary(d);
+            AutoDisposingCompletableObserverImpl.this.dispose();
           }
-        })
-            .subscribeWith(new DisposableMaybeObserver<Object>() {
-              @Override public void onSuccess(Object o) {
-                AutoDisposingCompletableObserverImpl.this.dispose();
-              }
 
-              @Override public void onError(Throwable e) {
-                AutoDisposingCompletableObserverImpl.this.onError(e);
-              }
+          @Override public void onError(Throwable e) {
+            callMainSubscribeIfNecessary(d);
+            AutoDisposingCompletableObserverImpl.this.onError(e);
+          }
 
-              @Override public void onComplete() {
-                // Noop - we're unbound now
-              }
-            }),
+          @Override public void onComplete() {
+            callMainSubscribeIfNecessary(d);
+            // Noop - we're unbound now
+          }
+        }),
         getClass())) {
       if (AutoDisposeEndConsumerHelper.setOnce(mainDisposable, d, getClass())) {
         delegate.onSubscribe(this);

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
@@ -22,7 +22,7 @@ import io.reactivex.Maybe;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.functions.BiConsumer;
-import io.reactivex.functions.Consumer;
+import io.reactivex.observers.DisposableMaybeObserver;
 import java.util.concurrent.atomic.AtomicReference;
 
 final class AutoDisposingCompletableObserverImpl implements AutoDisposingCompletableObserver {
@@ -48,15 +48,20 @@ final class AutoDisposingCompletableObserverImpl implements AutoDisposingComplet
             callMainSubscribeIfNecessary(d);
           }
         })
-            .subscribe(new Consumer<Object>() {
-              @Override public void accept(Object o) throws Exception {
-                dispose();
+            .subscribeWith(new DisposableMaybeObserver<Object>() {
+              @Override public void onSuccess(Object o) {
+                AutoDisposingCompletableObserverImpl.this.dispose();
               }
-            }, new Consumer<Throwable>() {
-              @Override public void accept(Throwable e1) throws Exception {
-                onError(e1);
+
+              @Override public void onError(Throwable e) {
+                AutoDisposingCompletableObserverImpl.this.onError(e);
               }
-            }), getClass())) {
+
+              @Override public void onComplete() {
+                // Noop - we're unbound now
+              }
+            }),
+        getClass())) {
       if (AutoDisposeEndConsumerHelper.setOnce(mainDisposable, d, getClass())) {
         delegate.onSubscribe(this);
       }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
@@ -81,7 +81,7 @@ final class AutoDisposingMaybeObserverImpl<T> implements AutoDisposingMaybeObser
     }
   }
 
-  /* private */
+  @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors
   void callMainSubscribeIfNecessary(Disposable d) {
     // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
     // onSubscribe and had a terminal event), we need to still send an empty disposable instance

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
@@ -21,7 +21,6 @@ import io.reactivex.Maybe;
 import io.reactivex.MaybeObserver;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
-import io.reactivex.functions.BiConsumer;
 import io.reactivex.observers.DisposableMaybeObserver;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -43,24 +42,22 @@ final class AutoDisposingMaybeObserverImpl<T> implements AutoDisposingMaybeObser
 
   @Override public void onSubscribe(final Disposable d) {
     if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable,
-        lifecycle.doOnEvent(new BiConsumer<Object, Throwable>() {
-          @Override public void accept(Object o, Throwable throwable) throws Exception {
+        lifecycle.subscribeWith(new DisposableMaybeObserver<Object>() {
+          @Override public void onSuccess(Object o) {
             callMainSubscribeIfNecessary(d);
+            AutoDisposingMaybeObserverImpl.this.dispose();
           }
-        })
-            .subscribeWith(new DisposableMaybeObserver<Object>() {
-              @Override public void onSuccess(Object o) {
-                AutoDisposingMaybeObserverImpl.this.dispose();
-              }
 
-              @Override public void onError(Throwable e) {
-                AutoDisposingMaybeObserverImpl.this.onError(e);
-              }
+          @Override public void onError(Throwable e) {
+            callMainSubscribeIfNecessary(d);
+            AutoDisposingMaybeObserverImpl.this.onError(e);
+          }
 
-              @Override public void onComplete() {
-                // Noop - we're unbound now
-              }
-            }),
+          @Override public void onComplete() {
+            callMainSubscribeIfNecessary(d);
+            // Noop - we're unbound now
+          }
+        }),
         getClass())) {
       if (AutoDisposeEndConsumerHelper.setOnce(mainDisposable, d, getClass())) {
         delegate.onSubscribe(this);

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
@@ -21,7 +21,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
-import io.reactivex.functions.BiConsumer;
 import io.reactivex.observers.DisposableMaybeObserver;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -43,24 +42,22 @@ final class AutoDisposingObserverImpl<T> implements AutoDisposingObserver<T> {
 
   @Override public void onSubscribe(final Disposable d) {
     if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable,
-        lifecycle.doOnEvent(new BiConsumer<Object, Throwable>() {
-          @Override public void accept(Object o, Throwable throwable) throws Exception {
+        lifecycle.subscribeWith(new DisposableMaybeObserver<Object>() {
+          @Override public void onSuccess(Object o) {
             callMainSubscribeIfNecessary(d);
+            AutoDisposingObserverImpl.this.dispose();
           }
-        })
-            .subscribeWith(new DisposableMaybeObserver<Object>() {
-              @Override public void onSuccess(Object o) {
-                AutoDisposingObserverImpl.this.dispose();
-              }
 
-              @Override public void onError(Throwable e) {
-                AutoDisposingObserverImpl.this.onError(e);
-              }
+          @Override public void onError(Throwable e) {
+            callMainSubscribeIfNecessary(d);
+            AutoDisposingObserverImpl.this.onError(e);
+          }
 
-              @Override public void onComplete() {
-                // Noop - we're unbound now
-              }
-            }),
+          @Override public void onComplete() {
+            callMainSubscribeIfNecessary(d);
+            // Noop - we're unbound now
+          }
+        }),
         getClass())) {
       if (AutoDisposeEndConsumerHelper.setOnce(mainDisposable, d, getClass())) {
         delegate.onSubscribe(this);

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
@@ -81,7 +81,7 @@ final class AutoDisposingObserverImpl<T> implements AutoDisposingObserver<T> {
     }
   }
 
-  /* private */
+  @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors
   void callMainSubscribeIfNecessary(Disposable d) {
     // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
     // onSubscribe and had a terminal event), we need to still send an empty disposable instance

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
@@ -21,7 +21,6 @@ import io.reactivex.Maybe;
 import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
-import io.reactivex.functions.BiConsumer;
 import io.reactivex.observers.DisposableMaybeObserver;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -43,24 +42,22 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
 
   @Override public void onSubscribe(final Disposable d) {
     if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable,
-        lifecycle.doOnEvent(new BiConsumer<Object, Throwable>() {
-          @Override public void accept(Object o, Throwable throwable) throws Exception {
+        lifecycle.subscribeWith(new DisposableMaybeObserver<Object>() {
+          @Override public void onSuccess(Object o) {
             callMainSubscribeIfNecessary(d);
+            AutoDisposingSingleObserverImpl.this.dispose();
           }
-        })
-            .subscribeWith(new DisposableMaybeObserver<Object>() {
-              @Override public void onSuccess(Object o) {
-                AutoDisposingSingleObserverImpl.this.dispose();
-              }
 
-              @Override public void onError(Throwable e) {
-                AutoDisposingSingleObserverImpl.this.onError(e);
-              }
+          @Override public void onError(Throwable e) {
+            callMainSubscribeIfNecessary(d);
+            AutoDisposingSingleObserverImpl.this.onError(e);
+          }
 
-              @Override public void onComplete() {
-                // Noop - we're unbound now
-              }
-            }),
+          @Override public void onComplete() {
+            callMainSubscribeIfNecessary(d);
+            // Noop - we're unbound now
+          }
+        }),
         getClass())) {
       if (AutoDisposeEndConsumerHelper.setOnce(mainDisposable, d, getClass())) {
         delegate.onSubscribe(this);

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
@@ -22,7 +22,7 @@ import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.functions.BiConsumer;
-import io.reactivex.functions.Consumer;
+import io.reactivex.observers.DisposableMaybeObserver;
 import java.util.concurrent.atomic.AtomicReference;
 
 final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObserver<T> {
@@ -48,15 +48,20 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
             callMainSubscribeIfNecessary(d);
           }
         })
-            .subscribe(new Consumer<Object>() {
-              @Override public void accept(Object o) throws Exception {
-                dispose();
+            .subscribeWith(new DisposableMaybeObserver<Object>() {
+              @Override public void onSuccess(Object o) {
+                AutoDisposingSingleObserverImpl.this.dispose();
               }
-            }, new Consumer<Throwable>() {
-              @Override public void accept(Throwable e) throws Exception {
+
+              @Override public void onError(Throwable e) {
                 AutoDisposingSingleObserverImpl.this.onError(e);
               }
-            }), getClass())) {
+
+              @Override public void onComplete() {
+                // Noop - we're unbound now
+              }
+            }),
+        getClass())) {
       if (AutoDisposeEndConsumerHelper.setOnce(mainDisposable, d, getClass())) {
         delegate.onSubscribe(this);
       }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
@@ -81,7 +81,7 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
     }
   }
 
-  /* private */
+  @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors
   void callMainSubscribeIfNecessary(Disposable d) {
     // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
     // onSubscribe and had a terminal event), we need to still send an empty disposable instance

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
@@ -57,7 +57,8 @@ final class AutoDisposingSubscriberImpl<T> implements AutoDisposingSubscriber<T>
               @Override public void accept(Throwable e) throws Exception {
                 AutoDisposingSubscriberImpl.this.onError(e);
               }
-            }), getClass())) {
+            }),
+        getClass())) {
       if (AutoDisposeEndConsumerHelper.setOnce(mainSubscription, s, getClass())) {
         delegate.onSubscribe(this);
       }
@@ -99,7 +100,7 @@ final class AutoDisposingSubscriberImpl<T> implements AutoDisposingSubscriber<T>
     }
   }
 
-  /* private */
+  @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors
   void callMainSubscribeIfNecessary(Subscription s) {
     // If we've never actually started the upstream subscription (i.e. requested immediately in
     // onSubscribe and had a terminal event), we need to still send an empty subscription instance

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
@@ -19,7 +19,6 @@ package com.uber.autodispose;
 import com.uber.autodispose.observers.AutoDisposingSubscriber;
 import io.reactivex.Maybe;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.BiConsumer;
 import io.reactivex.internal.subscriptions.EmptySubscription;
 import io.reactivex.observers.DisposableMaybeObserver;
 import java.util.concurrent.atomic.AtomicReference;
@@ -44,24 +43,22 @@ final class AutoDisposingSubscriberImpl<T> implements AutoDisposingSubscriber<T>
 
   @Override public void onSubscribe(final Subscription s) {
     if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable,
-        lifecycle.doOnEvent(new BiConsumer<Object, Throwable>() {
-          @Override public void accept(Object o, Throwable throwable) throws Exception {
+        lifecycle.subscribeWith(new DisposableMaybeObserver<Object>() {
+          @Override public void onSuccess(Object o) {
             callMainSubscribeIfNecessary(s);
+            AutoDisposingSubscriberImpl.this.dispose();
           }
-        })
-            .subscribeWith(new DisposableMaybeObserver<Object>() {
-              @Override public void onSuccess(Object o) {
-                AutoDisposingSubscriberImpl.this.dispose();
-              }
 
-              @Override public void onError(Throwable e) {
-                AutoDisposingSubscriberImpl.this.onError(e);
-              }
+          @Override public void onError(Throwable e) {
+            callMainSubscribeIfNecessary(s);
+            AutoDisposingSubscriberImpl.this.onError(e);
+          }
 
-              @Override public void onComplete() {
-                // Noop - we're unbound now
-              }
-            }),
+          @Override public void onComplete() {
+            callMainSubscribeIfNecessary(s);
+            // Noop - we're unbound now
+          }
+        }),
         getClass())) {
       if (AutoDisposeEndConsumerHelper.setOnce(mainSubscription, s, getClass())) {
         delegate.onSubscribe(this);

--- a/autodispose/src/main/java/com/uber/autodispose/TestScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/TestScopeProvider.java
@@ -47,6 +47,16 @@ public final class TestScopeProvider implements ScopeProvider {
     return new TestScopeProvider(delegate);
   }
 
+  /**
+   * Creates a new provider that is "unbound", e.g. will emit a completion event to signal that the
+   * scope is unbound.
+   *
+   * @return the created TestScopeProvider
+   */
+  public static TestScopeProvider unbound() {
+    return create(Maybe.empty());
+  }
+
   private final MaybeSubject<Object> innerMaybe = MaybeSubject.create();
 
   private TestScopeProvider(Maybe<?> delegate) {


### PR DESCRIPTION
This does a couple opportunistic cleanups:

- Adds some lint suppressions regarding the recent synthetic accessor changes
- Create full disposable observers with documented no-op completions. This gives us two things:
  - A minor perf improvement by less objects by creating one single observer rather than two consumers + LambdaObserver and the inner bits of `doOnEvent` (three-ish allocs). This saves about 5 allocations per subscribe in total. Relates to #105
  - Closes #101. After thinking on it quite a bit, I think `Maybe` makes sense. There are some cases where the lifecycle is deferred and may resolve to be "unbound". I've also added an `unbound()` factory to `TestScopeProvider` to mimic this.