### PR TITLE
Make AndroidLifecycleScopeProvider reusable by deferring backfill to peekLifecycle

### DIFF
--- a/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProvider.java
+++ b/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProvider.java
@@ -49,7 +49,7 @@ public final class AndroidLifecycleScopeProvider
             case ON_STOP:
             case ON_DESTROY:
             default:
-              throw new LifecycleEndedException();
+              throw new LifecycleEndedException("Lifecycle has ended! Last event was " + lastEvent);
           }
         }
       };
@@ -145,6 +145,7 @@ public final class AndroidLifecycleScopeProvider
   }
 
   @Override public Lifecycle.Event peekLifecycle() {
+    lifecycleObservable.backfillEvents();
     return lifecycleObservable.getValue();
   }
 

--- a/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/LifecycleEventsObservable.java
+++ b/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/LifecycleEventsObservable.java
@@ -48,10 +48,12 @@ import static com.uber.autodispose.android.internal.AutoDisposeAndroidUtil.isMai
     return eventsObservable.getValue();
   }
 
+  /**
+   * Backfill if already created for boundary checking. We do a trick here for corresponding events
+   * where we pretend something is created upon initialized state so that it assumes the
+   * corresponding event is DESTROY.
+   */
   void backfillEvents() {
-    // Backfill if already created for boundary checking
-    // We do a trick here for corresponding events where we pretend something is created
-    // upon initialized state so that it assumes the corresponding event is DESTROY.
     @Nullable Lifecycle.Event correspondingEvent;
     switch (lifecycle.getCurrentState()) {
       case INITIALIZED:

--- a/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/LifecycleEventsObservable.java
+++ b/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/LifecycleEventsObservable.java
@@ -28,6 +28,10 @@ import io.reactivex.Observer;
 import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.subjects.BehaviorSubject;
 
+import static android.arch.lifecycle.Lifecycle.Event.ON_CREATE;
+import static android.arch.lifecycle.Lifecycle.Event.ON_DESTROY;
+import static android.arch.lifecycle.Lifecycle.Event.ON_RESUME;
+import static android.arch.lifecycle.Lifecycle.Event.ON_START;
 import static android.support.annotation.RestrictTo.Scope.LIBRARY;
 import static com.uber.autodispose.android.internal.AutoDisposeAndroidUtil.isMainThread;
 
@@ -51,18 +55,18 @@ import static com.uber.autodispose.android.internal.AutoDisposeAndroidUtil.isMai
     @Nullable Lifecycle.Event correspondingEvent;
     switch (lifecycle.getCurrentState()) {
       case INITIALIZED:
-        correspondingEvent = Lifecycle.Event.ON_CREATE;
+        correspondingEvent = ON_CREATE;
         break;
       case CREATED:
-        correspondingEvent = Lifecycle.Event.ON_START;
+        correspondingEvent = ON_START;
         break;
       case STARTED:
       case RESUMED:
-        correspondingEvent = Lifecycle.Event.ON_RESUME;
+        correspondingEvent = ON_RESUME;
         break;
       case DESTROYED:
       default:
-        correspondingEvent = Lifecycle.Event.ON_DESTROY;
+        correspondingEvent = ON_DESTROY;
         break;
     }
     eventsObservable.onNext(correspondingEvent);
@@ -99,7 +103,7 @@ import static com.uber.autodispose.android.internal.AutoDisposeAndroidUtil.isMai
 
     @OnLifecycleEvent(Event.ON_ANY) void onStateChange(LifecycleOwner owner, Event event) {
       if (!isDisposed()) {
-        if (!(event == Event.ON_CREATE && eventsObservable.getValue() == event)) {
+        if (!(event == ON_CREATE && eventsObservable.getValue() == event)) {
           // Due to the INITIALIZED->ON_CREATE mapping trick we do in backfill(),
           // we fire this conditionally to avoid duplicate CREATE events.
           eventsObservable.onNext(event);

--- a/sample/src/main/kotlin/com/uber/autodispose/sample/KotlinActivity.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/sample/KotlinActivity.kt
@@ -32,6 +32,9 @@ import java.util.concurrent.TimeUnit
  */
 class KotlinActivity : AppCompatActivity() {
 
+  // Can be reused
+  private val scopeProvider by lazy { AndroidLifecycleScopeProvider.from(this) }
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     Log.d(TAG, "onCreate()")
@@ -41,7 +44,7 @@ class KotlinActivity : AppCompatActivity() {
     // dispose is onDestroy (the opposite of onCreate).
     Observable.interval(1, TimeUnit.SECONDS)
         .doOnDispose { Log.i(TAG, "Disposing subscription from onCreate()") }
-        .autoDisposeWith(AndroidLifecycleScopeProvider.from(this))
+        .autoDisposeWith(scopeProvider)
         .subscribe { num -> Log.i(TAG, "Started in onCreate(), running until onDestroy(): " + num) }
   }
 
@@ -54,7 +57,7 @@ class KotlinActivity : AppCompatActivity() {
     // dispose is onStop (the opposite of onStart).
     Observable.interval(1, TimeUnit.SECONDS)
         .doOnDispose { Log.i(TAG, "Disposing subscription from onStart()") }
-        .autoDisposeWith(AndroidLifecycleScopeProvider.from(this))
+        .autoDisposeWith(scopeProvider)
         .subscribe { num -> Log.i(TAG, "Started in onStart(), running until in onStop(): " + num) }
   }
 
@@ -67,7 +70,7 @@ class KotlinActivity : AppCompatActivity() {
     // dispose is onPause (the opposite of onResume).
     Observable.interval(1, TimeUnit.SECONDS)
         .doOnDispose { Log.i(TAG, "Disposing subscription from onResume()") }
-        .autoDisposeWith(AndroidLifecycleScopeProvider.from(this))
+        .autoDisposeWith(scopeProvider)
         .subscribe { num ->
           Log.i(TAG, "Started in onResume(), running until in onPause(): " + num)
         }


### PR DESCRIPTION
This moves backfilling out of a one-time thing in the constructor to something we do every time the lifecycle is peeked. It feels a bit weird though, but perhaps necessary because of the fact that arch lifecycle events are emitted _after_ the corresponding callback method.

Resolves #114, I think