### PR TITLE
Plugin for controlling whether or not to fill in stacktraces

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
@@ -28,6 +28,7 @@ public final class AutoDisposePlugins {
 
   @Nullable
   private static volatile Consumer<? super OutsideLifecycleException> outsideLifecycleHandler;
+  private static volatile boolean fillInOutsideLifecycleExceptionStacktraces;
 
   /**
    * Prevents changing the plugins.
@@ -53,7 +54,15 @@ public final class AutoDisposePlugins {
   }
 
   /**
-   * @return the consumer for handling {@link OutsideLifecycleException}.
+   * @return the value indicating whether or not to fill in stacktraces in
+   * {@link OutsideLifecycleException}.
+   */
+  public static boolean getFillInOutsideLifecycleExceptionStacktraces() {
+    return fillInOutsideLifecycleExceptionStacktraces;
+  }
+
+  /**
+   * @return the value for handling {@link OutsideLifecycleException}.
    */
   @Nullable
   public static Consumer<? super OutsideLifecycleException> getOutsideLifecycleHandler() {
@@ -69,6 +78,19 @@ public final class AutoDisposePlugins {
       throw new IllegalStateException("Plugins can't be changed anymore");
     }
     outsideLifecycleHandler = handler;
+  }
+
+  /**
+   * @param fillInStacktrace {@code true} to fill in stacktraces in
+   * {@link OutsideLifecycleException}s. {@code false} to disable them (and use them as signals
+   * only). Disabling them, if you don't care about the stacktraces, can result in some minor
+   * performance improvements.
+   */
+  public static void setFillInOutsideLifecycleExceptionStacktraces(boolean fillInStacktrace) {
+    if (lockdown) {
+      throw new IllegalStateException("Plugins can't be changed anymore");
+    }
+    fillInOutsideLifecycleExceptionStacktraces = fillInStacktrace;
   }
 
   /**

--- a/autodispose/src/main/java/com/uber/autodispose/OutsideLifecycleException.java
+++ b/autodispose/src/main/java/com/uber/autodispose/OutsideLifecycleException.java
@@ -24,4 +24,12 @@ public class OutsideLifecycleException extends RuntimeException {
   public OutsideLifecycleException(String s) {
     super(s);
   }
+
+  @Override public final synchronized Throwable fillInStackTrace() {
+    if (AutoDisposePlugins.getFillInOutsideLifecycleExceptionStacktraces()) {
+      return super.fillInStackTrace();
+    } else {
+      return this;
+    }
+  }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposePluginsTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposePluginsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public final class AutoDisposePluginsTest {
+
+  @After public void tearDown() {
+    AutoDisposePlugins.reset();
+  }
+
+  @Test public void noStacktraceFill_shouldHaveNoStacktrace() {
+    AutoDisposePlugins.setFillInOutsideLifecycleExceptionStacktraces(false);
+
+    LifecycleNotStartedException started =
+        new LifecycleNotStartedException("Lifecycle not started");
+    assertThat(started.getStackTrace()).isEmpty();
+
+    LifecycleEndedException ended = new LifecycleEndedException("Lifecycle ended");
+    assertThat(ended.getStackTrace()).isEmpty();
+  }
+
+  @Test public void defaultStacktraceFill_shouldHaveStacktrace() {
+    LifecycleNotStartedException started =
+        new LifecycleNotStartedException("Lifecycle not started");
+    assertThat(started.getStackTrace()).isNotEmpty();
+
+    LifecycleEndedException ended = new LifecycleEndedException("Lifecycle ended");
+    assertThat(ended.getStackTrace()).isNotEmpty();
+  }
+
+  @Test public void trueStacktraceFill_shouldHaveStacktrace() {
+    AutoDisposePlugins.setFillInOutsideLifecycleExceptionStacktraces(true);
+
+    LifecycleNotStartedException started =
+        new LifecycleNotStartedException("Lifecycle not started");
+    assertThat(started.getStackTrace()).isNotEmpty();
+
+    LifecycleEndedException ended = new LifecycleEndedException("Lifecycle ended");
+    assertThat(ended.getStackTrace()).isNotEmpty();
+  }
+}


### PR DESCRIPTION
Resolves #117

This implements support for controlling whether or not `OutsideLifecycleException`s fill in their stacktraces. This is a potentially expensive operation that is often used just for signaling, so we can save a little perf here.