### PR TITLE
Move unbound() shorthand to ScopeProvider itself

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/ScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/ScopeProvider.java
@@ -24,6 +24,12 @@ import io.reactivex.annotations.CheckReturnValue;
  */
 public interface ScopeProvider {
 
+  ScopeProvider UNBOUND = new ScopeProvider() {
+    @Override public Maybe<?> requestScope() {
+      return Maybe.empty();
+    }
+  };
+
   /**
    * @return a Maybe that, upon emission, will trigger disposal.
    */

--- a/autodispose/src/main/java/com/uber/autodispose/ScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/ScopeProvider.java
@@ -24,6 +24,10 @@ import io.reactivex.annotations.CheckReturnValue;
  */
 public interface ScopeProvider {
 
+  /**
+   * A new provider that is "unbound", e.g. will emit a completion event to signal that the
+   * scope is unbound.
+   */
   ScopeProvider UNBOUND = new ScopeProvider() {
     @Override public Maybe<?> requestScope() {
       return Maybe.empty();

--- a/autodispose/src/main/java/com/uber/autodispose/TestScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/TestScopeProvider.java
@@ -54,8 +54,7 @@ public final class TestScopeProvider implements ScopeProvider {
    * @return the created TestScopeProvider
    * @deprecated in favor of {@link ScopeProvider#UNBOUND}. This method will be removed in 1.0.
    */
-  @Deprecated
-  public static TestScopeProvider unbound() {
+  @Deprecated public static TestScopeProvider unbound() {
     return create(Maybe.empty());
   }
 

--- a/autodispose/src/main/java/com/uber/autodispose/TestScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/TestScopeProvider.java
@@ -52,7 +52,9 @@ public final class TestScopeProvider implements ScopeProvider {
    * scope is unbound.
    *
    * @return the created TestScopeProvider
+   * @deprecated in favor of {@link ScopeProvider#UNBOUND}. This method will be removed in 1.0.
    */
+  @Deprecated
   public static TestScopeProvider unbound() {
     return create(Maybe.empty());
   }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -22,7 +22,6 @@ import io.reactivex.Completable;
 import io.reactivex.CompletableEmitter;
 import io.reactivex.CompletableObserver;
 import io.reactivex.CompletableOnSubscribe;
-import io.reactivex.Maybe;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -311,7 +311,7 @@ public class AutoDisposeCompletableObserverTest {
             }
           });
       Completable.complete()
-          .to(AutoDispose.with(Maybe.never())
+          .to(AutoDispose.with(ScopeProvider.UNBOUND)
               .forCompletable())
           .subscribe();
 

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -74,7 +74,7 @@ public class AutoDisposeMaybeObserverTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Maybe.just(new BClass())
-        .to(AutoDispose.with(Maybe.never()).<AClass>forMaybe())
+        .to(AutoDispose.with(ScopeProvider.UNBOUND).<AClass>forMaybe())
         .subscribe(new Consumer<AClass>() {
           @Override public void accept(AClass aClass) throws Exception {
 
@@ -84,7 +84,7 @@ public class AutoDisposeMaybeObserverTest {
 
   @Test public void autoDispose_noGenericsOnEmpty_isFine() {
     Maybe.just(new BClass())
-        .to(AutoDispose.with(Maybe.never())
+        .to(AutoDispose.with(ScopeProvider.UNBOUND)
             .forMaybe())
         .subscribe();
   }
@@ -343,7 +343,7 @@ public class AutoDisposeMaybeObserverTest {
         }
       });
       Maybe.just(1)
-          .to(AutoDispose.with(Maybe.never()).<Integer>forMaybe())
+          .to(AutoDispose.with(ScopeProvider.UNBOUND).<Integer>forMaybe())
           .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -77,7 +77,7 @@ public class AutoDisposeObserverTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Observable.just(new BClass())
-        .to(AutoDispose.with(Maybe.never()).<AClass>forObservable())
+        .to(AutoDispose.with(ScopeProvider.UNBOUND).<AClass>forObservable())
         .subscribe(new Consumer<AClass>() {
           @Override public void accept(AClass aClass) throws Exception {
 
@@ -87,7 +87,7 @@ public class AutoDisposeObserverTest {
 
   @Test public void autoDispose_noGenericsOnEmpty_isFine() {
     Observable.just(new BClass())
-        .to(AutoDispose.with(Maybe.never())
+        .to(AutoDispose.with(ScopeProvider.UNBOUND)
             .forObservable())
         .subscribe();
   }
@@ -278,7 +278,7 @@ public class AutoDisposeObserverTest {
         }
       });
       Observable.just(1)
-          .to(AutoDispose.with(Maybe.never()).<Integer>forObservable())
+          .to(AutoDispose.with(ScopeProvider.UNBOUND).<Integer>forObservable())
           .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -18,7 +18,6 @@ package com.uber.autodispose;
 
 import com.uber.autodispose.observers.AutoDisposingObserver;
 import com.uber.autodispose.test.RecordingObserver;
-import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.ObservableEmitter;
 import io.reactivex.ObservableOnSubscribe;

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -76,7 +76,7 @@ public class AutoDisposeSingleObserverTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Single.just(new BClass())
-        .to(AutoDispose.with(Maybe.never()).<AClass>forSingle())
+        .to(AutoDispose.with(ScopeProvider.UNBOUND).<AClass>forSingle())
         .subscribe(new Consumer<AClass>() {
           @Override public void accept(AClass aClass) throws Exception {
 
@@ -86,7 +86,7 @@ public class AutoDisposeSingleObserverTest {
 
   @Test public void autoDispose_noGenericsOnEmpty_isFine() {
     Single.just(new BClass())
-        .to(AutoDispose.with(Maybe.never())
+        .to(AutoDispose.with(ScopeProvider.UNBOUND)
             .forSingle())
         .subscribe();
   }
@@ -314,7 +314,7 @@ public class AutoDisposeSingleObserverTest {
         }
       });
       Single.just(1)
-          .to(AutoDispose.with(Maybe.never()).<Integer>forSingle())
+          .to(AutoDispose.with(ScopeProvider.UNBOUND).<Integer>forSingle())
           .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -18,7 +18,6 @@ package com.uber.autodispose;
 
 import com.uber.autodispose.observers.AutoDisposingSingleObserver;
 import com.uber.autodispose.test.RecordingObserver;
-import io.reactivex.Maybe;
 import io.reactivex.Single;
 import io.reactivex.SingleEmitter;
 import io.reactivex.SingleObserver;

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -72,7 +72,7 @@ public class AutoDisposeSubscriberTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Flowable.just(new BClass())
-        .to(AutoDispose.with(Maybe.never()).<AClass>forFlowable())
+        .to(AutoDispose.with(ScopeProvider.UNBOUND).<AClass>forFlowable())
         .subscribe(new Consumer<AClass>() {
           @Override public void accept(AClass aClass) throws Exception {
 
@@ -82,7 +82,7 @@ public class AutoDisposeSubscriberTest {
 
   @Test public void autoDispose_noGenericsOnEmpty_isFine() {
     Flowable.just(new BClass())
-        .to(AutoDispose.with(Maybe.never())
+        .to(AutoDispose.with(ScopeProvider.UNBOUND)
             .forFlowable())
         .subscribe();
   }
@@ -289,7 +289,7 @@ public class AutoDisposeSubscriberTest {
         }
       });
       Flowable.just(1)
-          .to(AutoDispose.with(Maybe.never()).<Integer>forFlowable())
+          .to(AutoDispose.with(ScopeProvider.UNBOUND).<Integer>forFlowable())
           .subscribe();
 
       assertThat(atomicAutoDisposingSubscriber.get()).isNotNull();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -21,7 +21,6 @@ import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
 import io.reactivex.FlowableEmitter;
 import io.reactivex.FlowableOnSubscribe;
-import io.reactivex.Maybe;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.BiFunction;
 import io.reactivex.functions.Cancellable;


### PR DESCRIPTION
This makes `UNBOUND` a singleton instance on `ScopeProvider` itself, allowing for its use in regular non-test code too and a more flexible shorthand.