### PR TITLE
Arch components version update to released version

### DIFF
--- a/android/autodispose-android-archcomponents-test/build.gradle
+++ b/android/autodispose-android-archcomponents-test/build.gradle
@@ -50,7 +50,6 @@ dependencies {
 
   compile project(':autodispose')
   compile deps.support.arch.lifecycle.runtime
-  compile deps.support.arch.lifecycle.common
   compile deps.support.arch.lifecycle.extensions
 
   provided deps.misc.errorProneAnnotations

--- a/android/autodispose-android-archcomponents/build.gradle
+++ b/android/autodispose-android-archcomponents/build.gradle
@@ -55,7 +55,6 @@ dependencies {
   annotationProcessor deps.support.arch.lifecycle.compiler
 
   compile project(':android:autodispose-android')
-  compile deps.support.arch.lifecycle.common
   compile deps.support.arch.lifecycle.runtime
 
   provided deps.misc.errorProneAnnotations

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,6 +17,7 @@
 def versions = [
     androidTest: '0.5',
     archComponents: '1.0.0',
+    archRuntime: '1.0.3',
     dokka: '0.9.15',
     errorProne: '2.1.1',
     kotlin: '1.1.51',
@@ -68,10 +69,9 @@ def support = [
     annotations: "com.android.support:support-annotations:${versions.support}",
     arch: [
         lifecycle: [
-            common: "android.arch.lifecycle:common:1.0.3",
             compiler: "android.arch.lifecycle:compiler:${versions.archComponents}",
             extensions: "android.arch.lifecycle:extensions:${versions.archComponents}",
-            runtime: "android.arch.lifecycle:runtime:1.0.3"
+            runtime: "android.arch.lifecycle:runtime:${versions.archRuntime}"
         ]
     ]
 ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,7 +16,7 @@
 
 def versions = [
     androidTest: '0.5',
-    archComponents: '1.0.0-rc1',
+    archComponents: '1.0.0',
     dokka: '0.9.15',
     errorProne: '2.1.1',
     kotlin: '1.1.51',
@@ -71,7 +71,7 @@ def support = [
             common: "android.arch.lifecycle:common:1.0.3",
             compiler: "android.arch.lifecycle:compiler:${versions.archComponents}",
             extensions: "android.arch.lifecycle:extensions:${versions.archComponents}",
-            runtime: "android.arch.lifecycle:runtime:1.0.0"
+            runtime: "android.arch.lifecycle:runtime:1.0.3"
         ]
     ]
 ]


### PR DESCRIPTION
A few changes to unify the Android architecture components versions and reduce unnecessary dependency callouts.