### PR TITLE
Incorporate feedback from #130

### DIFF
--- a/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/LifecycleEventsObservable.java
+++ b/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/LifecycleEventsObservable.java
@@ -84,6 +84,9 @@ import static com.uber.autodispose.android.internal.AutoDisposeAndroidUtil.isMai
       return;
     }
     lifecycle.addObserver(archObserver);
+    if (archObserver.isDisposed()) {
+      lifecycle.removeObserver(archObserver);
+    }
   }
 
   static final class ArchLifecycleObserver extends MainThreadDisposable

--- a/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/LifecycleEventsObservable.java
+++ b/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/LifecycleEventsObservable.java
@@ -75,14 +75,14 @@ import static com.uber.autodispose.android.internal.AutoDisposeAndroidUtil.isMai
   }
 
   @Override protected void subscribeActual(Observer<? super Event> observer) {
+    ArchLifecycleObserver archObserver =
+        new ArchLifecycleObserver(lifecycle, observer, eventsObservable);
+    observer.onSubscribe(archObserver);
     if (!isMainThread()) {
       observer.onError(
           new IllegalStateException("Lifecycles can only be bound to on the main thread!"));
       return;
     }
-    ArchLifecycleObserver archObserver =
-        new ArchLifecycleObserver(lifecycle, observer, eventsObservable);
-    observer.onSubscribe(archObserver);
     lifecycle.addObserver(archObserver);
   }
 

--- a/android/autodispose-android/src/main/java/com/uber/autodispose/android/ViewAttachEventsObservable.java
+++ b/android/autodispose-android/src/main/java/com/uber/autodispose/android/ViewAttachEventsObservable.java
@@ -37,6 +37,8 @@ final class ViewAttachEventsObservable extends Observable<ViewLifecycleEvent> {
   }
 
   @Override protected void subscribeActual(Observer<? super ViewLifecycleEvent> observer) {
+    Listener listener = new Listener(view, observer);
+    observer.onSubscribe(listener);
     if (!isMainThread()) {
       observer.onError(new IllegalStateException("Views can only be bound to on the main thread!"));
       return;
@@ -46,8 +48,6 @@ final class ViewAttachEventsObservable extends Observable<ViewLifecycleEvent> {
       // Emit the last event, like a behavior subject
       observer.onNext(ViewLifecycleEvent.ATTACH);
     }
-    Listener listener = new Listener(view, observer);
-    observer.onSubscribe(listener);
     view.addOnAttachStateChangeListener(listener);
   }
 

--- a/android/autodispose-android/src/main/java/com/uber/autodispose/android/ViewAttachEventsObservable.java
+++ b/android/autodispose-android/src/main/java/com/uber/autodispose/android/ViewAttachEventsObservable.java
@@ -49,6 +49,9 @@ final class ViewAttachEventsObservable extends Observable<ViewLifecycleEvent> {
       observer.onNext(ViewLifecycleEvent.ATTACH);
     }
     view.addOnAttachStateChangeListener(listener);
+    if (listener.isDisposed()) {
+      view.removeOnAttachStateChangeListener(listener);
+    }
   }
 
   static final class Listener extends MainThreadDisposable

--- a/autodispose/src/main/java/com/uber/autodispose/AtomicThrowable.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AtomicThrowable.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.uber.autodispose;
+
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+/**
+ * Atomic container for Throwables including combining and having a
+ * terminal state via ExceptionHelper.
+ * <p>
+ * Watch out for the leaked AtomicReference methods!
+ */
+final class AtomicThrowable extends AtomicReference<Throwable> {
+
+  private static final long serialVersionUID = 3949248817947090603L;
+
+  /**
+   * Atomically adds a Throwable to this container (combining with a previous Throwable is
+   * necessary).
+   *
+   * @param t the throwable to add
+   * @return true if successful, false if the container has been terminated
+   */
+  public boolean addThrowable(Throwable t) {
+    return ExceptionHelper.addThrowable(this, t);
+  }
+
+  /**
+   * Atomically terminate the container and return the contents of the last
+   * non-terminal Throwable of it.
+   *
+   * @return the last Throwable
+   */
+  @Nullable
+  public Throwable terminate() {
+    return ExceptionHelper.terminate(this);
+  }
+
+  public boolean isTerminated() {
+    return get() == ExceptionHelper.TERMINATED;
+  }
+}

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -166,7 +166,7 @@ public final class AutoDispose {
     return new LifecycleScopeProviderHandlerImpl(scope);
   }
 
-  private static class MaybeScopeHandlerImpl implements ScopeHandler {
+  private static final class MaybeScopeHandlerImpl implements ScopeHandler {
 
     private final Maybe<?> scope;
 
@@ -196,7 +196,7 @@ public final class AutoDispose {
     }
   }
 
-  private static class ScopeProviderHandlerImpl implements ScopeHandler {
+  private static final class ScopeProviderHandlerImpl implements ScopeHandler {
 
     private final ScopeProvider scope;
 
@@ -226,7 +226,7 @@ public final class AutoDispose {
     }
   }
 
-  private static class LifecycleScopeProviderHandlerImpl implements ScopeHandler {
+  private static final class LifecycleScopeProviderHandlerImpl implements ScopeHandler {
 
     private final LifecycleScopeProvider<?> scope;
 

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -168,7 +168,7 @@ public final class AutoDispose {
 
   private static final class MaybeScopeHandlerImpl implements ScopeHandler {
 
-    private final Maybe<?> scope;
+    final Maybe<?> scope;
 
     MaybeScopeHandlerImpl(Maybe<?> scope) {
       this.scope = scope;
@@ -198,7 +198,7 @@ public final class AutoDispose {
 
   private static final class ScopeProviderHandlerImpl implements ScopeHandler {
 
-    private final ScopeProvider scope;
+    final ScopeProvider scope;
 
     ScopeProviderHandlerImpl(ScopeProvider scope) {
       this.scope = scope;
@@ -228,7 +228,7 @@ public final class AutoDispose {
 
   private static final class LifecycleScopeProviderHandlerImpl implements ScopeHandler {
 
-    private final LifecycleScopeProvider<?> scope;
+    final LifecycleScopeProvider<?> scope;
 
     LifecycleScopeProviderHandlerImpl(LifecycleScopeProvider<?> scope) {
       this.scope = scope;

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
@@ -79,11 +79,6 @@ final class AutoDisposingCompletableObserverImpl implements AutoDisposingComplet
     AutoDisposableHelper.dispose(mainDisposable);
   }
 
-  private void lazyDispose() {
-    AutoDisposableHelper.dispose(lifecycleDisposable);
-    mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
-  }
-
   @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors
   void callMainSubscribeIfNecessary(Disposable d) {
     // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
@@ -96,14 +91,16 @@ final class AutoDisposingCompletableObserverImpl implements AutoDisposingComplet
 
   @Override public void onComplete() {
     if (!isDisposed()) {
-      lazyDispose();
+      AutoDisposableHelper.dispose(lifecycleDisposable);
+      mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       delegate.onComplete();
     }
   }
 
   @Override public void onError(Throwable e) {
     if (!isDisposed()) {
-      lazyDispose();
+      AutoDisposableHelper.dispose(lifecycleDisposable);
+      mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       delegate.onError(e);
     }
   }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
@@ -47,9 +47,8 @@ final class AutoDisposingCompletableObserverImpl implements AutoDisposingComplet
       }
 
       @Override public void onError(Throwable e) {
-        AutoDisposingCompletableObserverImpl.this.onError(e);
-        mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        AutoDisposingCompletableObserverImpl.this.onError(e);
       }
 
       @Override public void onComplete() {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
@@ -70,17 +70,13 @@ final class AutoDisposingCompletableObserverImpl implements AutoDisposingComplet
   }
 
   @Override public void dispose() {
-    synchronized (this) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
-      AutoDisposableHelper.dispose(mainDisposable);
-    }
+    AutoDisposableHelper.dispose(lifecycleDisposable);
+    AutoDisposableHelper.dispose(mainDisposable);
   }
 
   private void lazyDispose() {
-    synchronized (this) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
-      mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
-    }
+    AutoDisposableHelper.dispose(lifecycleDisposable);
+    mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
   }
 
   @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
@@ -42,8 +42,8 @@ final class AutoDisposingCompletableObserverImpl implements AutoDisposingComplet
   @Override public void onSubscribe(final Disposable d) {
     DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
       @Override public void onSuccess(Object o) {
-        AutoDisposableHelper.dispose(mainDisposable);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        AutoDisposableHelper.dispose(mainDisposable);
       }
 
       @Override public void onError(Throwable e) {
@@ -76,16 +76,16 @@ final class AutoDisposingCompletableObserverImpl implements AutoDisposingComplet
 
   @Override public void onComplete() {
     if (!isDisposed()) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
       mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+      AutoDisposableHelper.dispose(lifecycleDisposable);
       delegate.onComplete();
     }
   }
 
   @Override public void onError(Throwable e) {
     if (!isDisposed()) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
       mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+      AutoDisposableHelper.dispose(lifecycleDisposable);
       delegate.onError(e);
     }
   }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
@@ -41,24 +41,24 @@ final class AutoDisposingCompletableObserverImpl implements AutoDisposingComplet
   }
 
   @Override public void onSubscribe(final Disposable d) {
-    if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable,
-        lifecycle.subscribeWith(new DisposableMaybeObserver<Object>() {
-          @Override public void onSuccess(Object o) {
-            callMainSubscribeIfNecessary(d);
-            AutoDisposingCompletableObserverImpl.this.dispose();
-          }
+    DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
+      @Override public void onSuccess(Object o) {
+        callMainSubscribeIfNecessary(d);
+        AutoDisposingCompletableObserverImpl.this.dispose();
+      }
 
-          @Override public void onError(Throwable e) {
-            callMainSubscribeIfNecessary(d);
-            AutoDisposingCompletableObserverImpl.this.onError(e);
-          }
+      @Override public void onError(Throwable e) {
+        callMainSubscribeIfNecessary(d);
+        AutoDisposingCompletableObserverImpl.this.onError(e);
+      }
 
-          @Override public void onComplete() {
-            callMainSubscribeIfNecessary(d);
-            // Noop - we're unbound now
-          }
-        }),
-        getClass())) {
+      @Override public void onComplete() {
+        callMainSubscribeIfNecessary(d);
+        // Noop - we're unbound now
+      }
+    };
+    if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable, o, getClass())) {
+      lifecycle.subscribe(o);
       if (AutoDisposeEndConsumerHelper.setOnce(mainDisposable, d, getClass())) {
         delegate.onSubscribe(this);
       }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
@@ -44,16 +44,21 @@ final class AutoDisposingCompletableObserverImpl implements AutoDisposingComplet
     DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
       @Override public void onSuccess(Object o) {
         callMainSubscribeIfNecessary(d);
-        AutoDisposingCompletableObserverImpl.this.dispose();
+        AutoDisposableHelper.dispose(mainDisposable);
+        lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       }
 
       @Override public void onError(Throwable e) {
         callMainSubscribeIfNecessary(d);
         AutoDisposingCompletableObserverImpl.this.onError(e);
+        mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       }
 
       @Override public void onComplete() {
         callMainSubscribeIfNecessary(d);
+        mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         // Noop - we're unbound now
       }
     };

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
@@ -20,7 +20,6 @@ import com.uber.autodispose.observers.AutoDisposingCompletableObserver;
 import io.reactivex.CompletableObserver;
 import io.reactivex.Maybe;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.disposables.Disposables;
 import io.reactivex.observers.DisposableMaybeObserver;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -43,30 +42,26 @@ final class AutoDisposingCompletableObserverImpl implements AutoDisposingComplet
   @Override public void onSubscribe(final Disposable d) {
     DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
       @Override public void onSuccess(Object o) {
-        callMainSubscribeIfNecessary(d);
         AutoDisposableHelper.dispose(mainDisposable);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       }
 
       @Override public void onError(Throwable e) {
-        callMainSubscribeIfNecessary(d);
         AutoDisposingCompletableObserverImpl.this.onError(e);
         mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       }
 
       @Override public void onComplete() {
-        callMainSubscribeIfNecessary(d);
         mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         // Noop - we're unbound now
       }
     };
     if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable, o, getClass())) {
+      delegate.onSubscribe(this);
       lifecycle.subscribe(o);
-      if (AutoDisposeEndConsumerHelper.setOnce(mainDisposable, d, getClass())) {
-        delegate.onSubscribe(this);
-      }
+      AutoDisposeEndConsumerHelper.setOnce(mainDisposable, d, getClass());
     }
   }
 
@@ -77,16 +72,6 @@ final class AutoDisposingCompletableObserverImpl implements AutoDisposingComplet
   @Override public void dispose() {
     AutoDisposableHelper.dispose(lifecycleDisposable);
     AutoDisposableHelper.dispose(mainDisposable);
-  }
-
-  @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors
-  void callMainSubscribeIfNecessary(Disposable d) {
-    // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
-    // onSubscribe and had a terminal event), we need to still send an empty disposable instance
-    // to abide by the Observer contract.
-    if (AutoDisposableHelper.setIfNotSet(mainDisposable, d)) {
-      delegate.onSubscribe(Disposables.disposed());
-    }
   }
 
   @Override public void onComplete() {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
@@ -79,11 +79,6 @@ final class AutoDisposingMaybeObserverImpl<T> implements AutoDisposingMaybeObser
     AutoDisposableHelper.dispose(mainDisposable);
   }
 
-  private void lazyDispose() {
-    AutoDisposableHelper.dispose(lifecycleDisposable);
-    mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
-  }
-
   @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors
   void callMainSubscribeIfNecessary(Disposable d) {
     // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
@@ -96,21 +91,24 @@ final class AutoDisposingMaybeObserverImpl<T> implements AutoDisposingMaybeObser
 
   @Override public void onSuccess(T value) {
     if (!isDisposed()) {
-      lazyDispose();
+      AutoDisposableHelper.dispose(lifecycleDisposable);
+      mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       delegate.onSuccess(value);
     }
   }
 
   @Override public void onError(Throwable e) {
     if (!isDisposed()) {
-      lazyDispose();
+      AutoDisposableHelper.dispose(lifecycleDisposable);
+      mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       delegate.onError(e);
     }
   }
 
   @Override public void onComplete() {
     if (!isDisposed()) {
-      lazyDispose();
+      AutoDisposableHelper.dispose(lifecycleDisposable);
+      mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       delegate.onComplete();
     }
   }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
@@ -70,17 +70,13 @@ final class AutoDisposingMaybeObserverImpl<T> implements AutoDisposingMaybeObser
   }
 
   @Override public void dispose() {
-    synchronized (this) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
-      AutoDisposableHelper.dispose(mainDisposable);
-    }
+    AutoDisposableHelper.dispose(lifecycleDisposable);
+    AutoDisposableHelper.dispose(mainDisposable);
   }
 
   private void lazyDispose() {
-    synchronized (this) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
-      mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
-    }
+    AutoDisposableHelper.dispose(lifecycleDisposable);
+    mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
   }
 
   @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
@@ -42,8 +42,8 @@ final class AutoDisposingMaybeObserverImpl<T> implements AutoDisposingMaybeObser
   @Override public void onSubscribe(final Disposable d) {
     DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
       @Override public void onSuccess(Object o) {
-        AutoDisposableHelper.dispose(mainDisposable);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        AutoDisposableHelper.dispose(mainDisposable);
       }
 
       @Override public void onError(Throwable e) {
@@ -76,24 +76,24 @@ final class AutoDisposingMaybeObserverImpl<T> implements AutoDisposingMaybeObser
 
   @Override public void onSuccess(T value) {
     if (!isDisposed()) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
       mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+      AutoDisposableHelper.dispose(lifecycleDisposable);
       delegate.onSuccess(value);
     }
   }
 
   @Override public void onError(Throwable e) {
     if (!isDisposed()) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
       mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+      AutoDisposableHelper.dispose(lifecycleDisposable);
       delegate.onError(e);
     }
   }
 
   @Override public void onComplete() {
     if (!isDisposed()) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
       mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+      AutoDisposableHelper.dispose(lifecycleDisposable);
       delegate.onComplete();
     }
   }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
@@ -44,16 +44,21 @@ final class AutoDisposingMaybeObserverImpl<T> implements AutoDisposingMaybeObser
     DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
       @Override public void onSuccess(Object o) {
         callMainSubscribeIfNecessary(d);
-        AutoDisposingMaybeObserverImpl.this.dispose();
+        AutoDisposableHelper.dispose(mainDisposable);
+        lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       }
 
       @Override public void onError(Throwable e) {
         callMainSubscribeIfNecessary(d);
         AutoDisposingMaybeObserverImpl.this.onError(e);
+        mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       }
 
       @Override public void onComplete() {
         callMainSubscribeIfNecessary(d);
+        mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         // Noop - we're unbound now
       }
     };

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
@@ -41,24 +41,24 @@ final class AutoDisposingMaybeObserverImpl<T> implements AutoDisposingMaybeObser
   }
 
   @Override public void onSubscribe(final Disposable d) {
-    if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable,
-        lifecycle.subscribeWith(new DisposableMaybeObserver<Object>() {
-          @Override public void onSuccess(Object o) {
-            callMainSubscribeIfNecessary(d);
-            AutoDisposingMaybeObserverImpl.this.dispose();
-          }
+    DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
+      @Override public void onSuccess(Object o) {
+        callMainSubscribeIfNecessary(d);
+        AutoDisposingMaybeObserverImpl.this.dispose();
+      }
 
-          @Override public void onError(Throwable e) {
-            callMainSubscribeIfNecessary(d);
-            AutoDisposingMaybeObserverImpl.this.onError(e);
-          }
+      @Override public void onError(Throwable e) {
+        callMainSubscribeIfNecessary(d);
+        AutoDisposingMaybeObserverImpl.this.onError(e);
+      }
 
-          @Override public void onComplete() {
-            callMainSubscribeIfNecessary(d);
-            // Noop - we're unbound now
-          }
-        }),
-        getClass())) {
+      @Override public void onComplete() {
+        callMainSubscribeIfNecessary(d);
+        // Noop - we're unbound now
+      }
+    };
+    if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable, o, getClass())) {
+      lifecycle.subscribe(o);
       if (AutoDisposeEndConsumerHelper.setOnce(mainDisposable, d, getClass())) {
         delegate.onSubscribe(this);
       }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
@@ -20,7 +20,6 @@ import com.uber.autodispose.observers.AutoDisposingMaybeObserver;
 import io.reactivex.Maybe;
 import io.reactivex.MaybeObserver;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.disposables.Disposables;
 import io.reactivex.observers.DisposableMaybeObserver;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -43,30 +42,26 @@ final class AutoDisposingMaybeObserverImpl<T> implements AutoDisposingMaybeObser
   @Override public void onSubscribe(final Disposable d) {
     DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
       @Override public void onSuccess(Object o) {
-        callMainSubscribeIfNecessary(d);
         AutoDisposableHelper.dispose(mainDisposable);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       }
 
       @Override public void onError(Throwable e) {
-        callMainSubscribeIfNecessary(d);
         AutoDisposingMaybeObserverImpl.this.onError(e);
         mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       }
 
       @Override public void onComplete() {
-        callMainSubscribeIfNecessary(d);
         mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         // Noop - we're unbound now
       }
     };
     if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable, o, getClass())) {
+      delegate.onSubscribe(this);
       lifecycle.subscribe(o);
-      if (AutoDisposeEndConsumerHelper.setOnce(mainDisposable, d, getClass())) {
-        delegate.onSubscribe(this);
-      }
+      AutoDisposeEndConsumerHelper.setOnce(mainDisposable, d, getClass());
     }
   }
 
@@ -77,16 +72,6 @@ final class AutoDisposingMaybeObserverImpl<T> implements AutoDisposingMaybeObser
   @Override public void dispose() {
     AutoDisposableHelper.dispose(lifecycleDisposable);
     AutoDisposableHelper.dispose(mainDisposable);
-  }
-
-  @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors
-  void callMainSubscribeIfNecessary(Disposable d) {
-    // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
-    // onSubscribe and had a terminal event), we need to still send an empty disposable instance
-    // to abide by the Observer contract.
-    if (AutoDisposableHelper.setIfNotSet(mainDisposable, d)) {
-      delegate.onSubscribe(Disposables.disposed());
-    }
   }
 
   @Override public void onSuccess(T value) {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
@@ -47,9 +47,8 @@ final class AutoDisposingMaybeObserverImpl<T> implements AutoDisposingMaybeObser
       }
 
       @Override public void onError(Throwable e) {
-        AutoDisposingMaybeObserverImpl.this.onError(e);
-        mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        AutoDisposingMaybeObserverImpl.this.onError(e);
       }
 
       @Override public void onComplete() {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
@@ -44,16 +44,21 @@ final class AutoDisposingObserverImpl<T> implements AutoDisposingObserver<T> {
     DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
       @Override public void onSuccess(Object o) {
         callMainSubscribeIfNecessary(d);
-        AutoDisposingObserverImpl.this.dispose();
+        AutoDisposableHelper.dispose(mainDisposable);
+        lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       }
 
       @Override public void onError(Throwable e) {
         callMainSubscribeIfNecessary(d);
         AutoDisposingObserverImpl.this.onError(e);
+        mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       }
 
       @Override public void onComplete() {
         callMainSubscribeIfNecessary(d);
+        mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         // Noop - we're unbound now
       }
     };

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
@@ -70,17 +70,13 @@ final class AutoDisposingObserverImpl<T> implements AutoDisposingObserver<T> {
   }
 
   @Override public void dispose() {
-    synchronized (this) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
-      AutoDisposableHelper.dispose(mainDisposable);
-    }
+    AutoDisposableHelper.dispose(lifecycleDisposable);
+    AutoDisposableHelper.dispose(mainDisposable);
   }
 
   private void lazyDispose() {
-    synchronized (this) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
-      mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
-    }
+    AutoDisposableHelper.dispose(lifecycleDisposable);
+    mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
   }
 
   @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
@@ -29,14 +29,13 @@ final class AutoDisposingObserverImpl<T> extends AtomicInteger implements AutoDi
 
   private final AtomicReference<Disposable> mainDisposable = new AtomicReference<>();
   private final AtomicReference<Disposable> lifecycleDisposable = new AtomicReference<>();
+  private final AtomicThrowable error = new AtomicThrowable();
   private final Maybe<?> lifecycle;
   private final Observer<? super T> delegate;
-  private final AtomicThrowable error;
 
   AutoDisposingObserverImpl(Maybe<?> lifecycle, Observer<? super T> delegate) {
     this.lifecycle = lifecycle;
     this.delegate = delegate;
-    this.error = new AtomicThrowable();
   }
 
   @Override public Observer<? super T> delegateObserver() {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
@@ -79,11 +79,6 @@ final class AutoDisposingObserverImpl<T> implements AutoDisposingObserver<T> {
     AutoDisposableHelper.dispose(mainDisposable);
   }
 
-  private void lazyDispose() {
-    AutoDisposableHelper.dispose(lifecycleDisposable);
-    mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
-  }
-
   @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors
   void callMainSubscribeIfNecessary(Disposable d) {
     // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
@@ -102,14 +97,16 @@ final class AutoDisposingObserverImpl<T> implements AutoDisposingObserver<T> {
 
   @Override public void onError(Throwable e) {
     if (!isDisposed()) {
-      lazyDispose();
+      AutoDisposableHelper.dispose(lifecycleDisposable);
+      mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       delegate.onError(e);
     }
   }
 
   @Override public void onComplete() {
     if (!isDisposed()) {
-      lazyDispose();
+      AutoDisposableHelper.dispose(lifecycleDisposable);
+      mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       delegate.onComplete();
     }
   }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
@@ -44,8 +44,8 @@ final class AutoDisposingObserverImpl<T> extends AtomicInteger implements AutoDi
   @Override public void onSubscribe(final Disposable d) {
     DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
       @Override public void onSuccess(Object o) {
-        AutoDisposableHelper.dispose(mainDisposable);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        AutoDisposableHelper.dispose(mainDisposable);
       }
 
       @Override public void onError(Throwable e) {
@@ -80,24 +80,24 @@ final class AutoDisposingObserverImpl<T> extends AtomicInteger implements AutoDi
     if (!isDisposed()) {
       if (HalfSerializer.onNext(delegate, value, this, error)) {
         // Terminal event occurred and was forwarded to the delegate, so clean up here
-        AutoDisposableHelper.dispose(lifecycleDisposable);
         mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        AutoDisposableHelper.dispose(lifecycleDisposable);
       }
     }
   }
 
   @Override public void onError(Throwable e) {
     if (!isDisposed()) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
       mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+      AutoDisposableHelper.dispose(lifecycleDisposable);
       HalfSerializer.onError(delegate, e, this, error);
     }
   }
 
   @Override public void onComplete() {
     if (!isDisposed()) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
       mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+      AutoDisposableHelper.dispose(lifecycleDisposable);
       HalfSerializer.onComplete(delegate, this, error);
     }
   }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
@@ -41,24 +41,24 @@ final class AutoDisposingObserverImpl<T> implements AutoDisposingObserver<T> {
   }
 
   @Override public void onSubscribe(final Disposable d) {
-    if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable,
-        lifecycle.subscribeWith(new DisposableMaybeObserver<Object>() {
-          @Override public void onSuccess(Object o) {
-            callMainSubscribeIfNecessary(d);
-            AutoDisposingObserverImpl.this.dispose();
-          }
+    DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
+      @Override public void onSuccess(Object o) {
+        callMainSubscribeIfNecessary(d);
+        AutoDisposingObserverImpl.this.dispose();
+      }
 
-          @Override public void onError(Throwable e) {
-            callMainSubscribeIfNecessary(d);
-            AutoDisposingObserverImpl.this.onError(e);
-          }
+      @Override public void onError(Throwable e) {
+        callMainSubscribeIfNecessary(d);
+        AutoDisposingObserverImpl.this.onError(e);
+      }
 
-          @Override public void onComplete() {
-            callMainSubscribeIfNecessary(d);
-            // Noop - we're unbound now
-          }
-        }),
-        getClass())) {
+      @Override public void onComplete() {
+        callMainSubscribeIfNecessary(d);
+        // Noop - we're unbound now
+      }
+    };
+    if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable, o, getClass())) {
+      lifecycle.subscribe(o);
       if (AutoDisposeEndConsumerHelper.setOnce(mainDisposable, d, getClass())) {
         delegate.onSubscribe(this);
       }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
@@ -49,9 +49,8 @@ final class AutoDisposingObserverImpl<T> extends AtomicInteger implements AutoDi
       }
 
       @Override public void onError(Throwable e) {
-        AutoDisposingObserverImpl.this.onError(e);
-        mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        AutoDisposingObserverImpl.this.onError(e);
       }
 
       @Override public void onComplete() {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
@@ -42,8 +42,8 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
   @Override public void onSubscribe(final Disposable d) {
     DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
       @Override public void onSuccess(Object o) {
-        AutoDisposableHelper.dispose(mainDisposable);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        AutoDisposableHelper.dispose(mainDisposable);
       }
 
       @Override public void onError(Throwable e) {
@@ -76,16 +76,16 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
 
   @Override public void onSuccess(T value) {
     if (!isDisposed()) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
       mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+      AutoDisposableHelper.dispose(lifecycleDisposable);
       delegate.onSuccess(value);
     }
   }
 
   @Override public void onError(Throwable e) {
     if (!isDisposed()) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
       mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+      AutoDisposableHelper.dispose(lifecycleDisposable);
       delegate.onError(e);
     }
   }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
@@ -20,7 +20,6 @@ import com.uber.autodispose.observers.AutoDisposingSingleObserver;
 import io.reactivex.Maybe;
 import io.reactivex.SingleObserver;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.disposables.Disposables;
 import io.reactivex.observers.DisposableMaybeObserver;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -43,30 +42,26 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
   @Override public void onSubscribe(final Disposable d) {
     DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
       @Override public void onSuccess(Object o) {
-        callMainSubscribeIfNecessary(d);
         AutoDisposableHelper.dispose(mainDisposable);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       }
 
       @Override public void onError(Throwable e) {
-        callMainSubscribeIfNecessary(d);
         AutoDisposingSingleObserverImpl.this.onError(e);
         mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       }
 
       @Override public void onComplete() {
-        callMainSubscribeIfNecessary(d);
         mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         // Noop - we're unbound now
       }
     };
     if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable, o, getClass())) {
+      delegate.onSubscribe(this);
       lifecycle.subscribe(o);
-      if (AutoDisposeEndConsumerHelper.setOnce(mainDisposable, d, getClass())) {
-        delegate.onSubscribe(this);
-      }
+      AutoDisposeEndConsumerHelper.setOnce(mainDisposable, d, getClass());
     }
   }
 
@@ -77,16 +72,6 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
   @Override public void dispose() {
     AutoDisposableHelper.dispose(lifecycleDisposable);
     AutoDisposableHelper.dispose(mainDisposable);
-  }
-
-  @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors
-  void callMainSubscribeIfNecessary(Disposable d) {
-    // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
-    // onSubscribe and had a terminal event), we need to still send an empty disposable instance
-    // to abide by the Observer contract.
-    if (AutoDisposableHelper.setIfNotSet(mainDisposable, d)) {
-      delegate.onSubscribe(Disposables.disposed());
-    }
   }
 
   @Override public void onSuccess(T value) {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
@@ -41,24 +41,24 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
   }
 
   @Override public void onSubscribe(final Disposable d) {
-    if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable,
-        lifecycle.subscribeWith(new DisposableMaybeObserver<Object>() {
-          @Override public void onSuccess(Object o) {
-            callMainSubscribeIfNecessary(d);
-            AutoDisposingSingleObserverImpl.this.dispose();
-          }
+    DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
+      @Override public void onSuccess(Object o) {
+        callMainSubscribeIfNecessary(d);
+        AutoDisposingSingleObserverImpl.this.dispose();
+      }
 
-          @Override public void onError(Throwable e) {
-            callMainSubscribeIfNecessary(d);
-            AutoDisposingSingleObserverImpl.this.onError(e);
-          }
+      @Override public void onError(Throwable e) {
+        callMainSubscribeIfNecessary(d);
+        AutoDisposingSingleObserverImpl.this.onError(e);
+      }
 
-          @Override public void onComplete() {
-            callMainSubscribeIfNecessary(d);
-            // Noop - we're unbound now
-          }
-        }),
-        getClass())) {
+      @Override public void onComplete() {
+        callMainSubscribeIfNecessary(d);
+        // Noop - we're unbound now
+      }
+    };
+    if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable, o, getClass())) {
+      lifecycle.subscribe(o);
       if (AutoDisposeEndConsumerHelper.setOnce(mainDisposable, d, getClass())) {
         delegate.onSubscribe(this);
       }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
@@ -44,16 +44,21 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
     DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
       @Override public void onSuccess(Object o) {
         callMainSubscribeIfNecessary(d);
-        AutoDisposingSingleObserverImpl.this.dispose();
+        AutoDisposableHelper.dispose(mainDisposable);
+        lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       }
 
       @Override public void onError(Throwable e) {
         callMainSubscribeIfNecessary(d);
         AutoDisposingSingleObserverImpl.this.onError(e);
+        mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       }
 
       @Override public void onComplete() {
         callMainSubscribeIfNecessary(d);
+        mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         // Noop - we're unbound now
       }
     };

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
@@ -70,17 +70,13 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
   }
 
   @Override public void dispose() {
-    synchronized (this) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
-      AutoDisposableHelper.dispose(mainDisposable);
-    }
+    AutoDisposableHelper.dispose(lifecycleDisposable);
+    AutoDisposableHelper.dispose(mainDisposable);
   }
 
   private void lazyDispose() {
-    synchronized (this) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
-      mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
-    }
+    AutoDisposableHelper.dispose(lifecycleDisposable);
+    mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
   }
 
   @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
@@ -79,11 +79,6 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
     AutoDisposableHelper.dispose(mainDisposable);
   }
 
-  private void lazyDispose() {
-    AutoDisposableHelper.dispose(lifecycleDisposable);
-    mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
-  }
-
   @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors
   void callMainSubscribeIfNecessary(Disposable d) {
     // If we've never actually called the downstream onSubscribe (i.e. requested immediately in
@@ -96,14 +91,16 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
 
   @Override public void onSuccess(T value) {
     if (!isDisposed()) {
-      lazyDispose();
+      AutoDisposableHelper.dispose(lifecycleDisposable);
+      mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       delegate.onSuccess(value);
     }
   }
 
   @Override public void onError(Throwable e) {
     if (!isDisposed()) {
-      lazyDispose();
+      AutoDisposableHelper.dispose(lifecycleDisposable);
+      mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       delegate.onError(e);
     }
   }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
@@ -47,9 +47,8 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
       }
 
       @Override public void onError(Throwable e) {
-        AutoDisposingSingleObserverImpl.this.onError(e);
-        mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        AutoDisposingSingleObserverImpl.this.onError(e);
       }
 
       @Override public void onComplete() {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
@@ -85,10 +85,7 @@ final class AutoDisposingSubscriberImpl<T> extends AtomicInteger
    * @param n the request amount, positive
    */
   @Override public void request(long n) {
-    Subscription s = mainSubscription.get();
-    if (s != null) {
-      s.request(n);
-    }
+    mainSubscription.get().request(n);
   }
 
   /**

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
@@ -45,16 +45,21 @@ final class AutoDisposingSubscriberImpl<T> implements AutoDisposingSubscriber<T>
     DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
       @Override public void onSuccess(Object o) {
         callMainSubscribeIfNecessary(s);
-        AutoDisposingSubscriberImpl.this.dispose();
+        AutoSubscriptionHelper.cancel(mainSubscription);
+        lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       }
 
       @Override public void onError(Throwable e) {
         callMainSubscribeIfNecessary(s);
         AutoDisposingSubscriberImpl.this.onError(e);
+        mainSubscription.lazySet(AutoSubscriptionHelper.CANCELLED);
+        lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
       }
 
       @Override public void onComplete() {
         callMainSubscribeIfNecessary(s);
+        mainSubscription.lazySet(AutoSubscriptionHelper.CANCELLED);
+        lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         // Noop - we're unbound now
       }
     };

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
@@ -19,7 +19,6 @@ package com.uber.autodispose;
 import com.uber.autodispose.observers.AutoDisposingSubscriber;
 import io.reactivex.Maybe;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.observers.DisposableMaybeObserver;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -70,7 +69,7 @@ final class AutoDisposingSubscriberImpl<T> extends AtomicInteger
       delegate.onSubscribe(this);
       lifecycle.subscribe(o);
       if (AutoDisposeEndConsumerHelper.setOnce(mainSubscription, s, getClass())) {
-        SubscriptionHelper.deferredSetOnce(ref, requested, s);
+        AutoSubscriptionHelper.deferredSetOnce(ref, requested, s);
       }
     }
   }
@@ -85,7 +84,7 @@ final class AutoDisposingSubscriberImpl<T> extends AtomicInteger
    * @param n the request amount, positive
    */
   @SuppressWarnings("NullAway") @Override public void request(long n) {
-    SubscriptionHelper.deferredRequest(ref, requested, n);
+    AutoSubscriptionHelper.deferredRequest(ref, requested, n);
   }
 
   /**

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
@@ -42,24 +42,24 @@ final class AutoDisposingSubscriberImpl<T> implements AutoDisposingSubscriber<T>
   }
 
   @Override public void onSubscribe(final Subscription s) {
-    if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable,
-        lifecycle.subscribeWith(new DisposableMaybeObserver<Object>() {
-          @Override public void onSuccess(Object o) {
-            callMainSubscribeIfNecessary(s);
-            AutoDisposingSubscriberImpl.this.dispose();
-          }
+    DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
+      @Override public void onSuccess(Object o) {
+        callMainSubscribeIfNecessary(s);
+        AutoDisposingSubscriberImpl.this.dispose();
+      }
 
-          @Override public void onError(Throwable e) {
-            callMainSubscribeIfNecessary(s);
-            AutoDisposingSubscriberImpl.this.onError(e);
-          }
+      @Override public void onError(Throwable e) {
+        callMainSubscribeIfNecessary(s);
+        AutoDisposingSubscriberImpl.this.onError(e);
+      }
 
-          @Override public void onComplete() {
-            callMainSubscribeIfNecessary(s);
-            // Noop - we're unbound now
-          }
-        }),
-        getClass())) {
+      @Override public void onComplete() {
+        callMainSubscribeIfNecessary(s);
+        // Noop - we're unbound now
+      }
+    };
+    if (AutoDisposeEndConsumerHelper.setOnce(lifecycleDisposable, o, getClass())) {
+      lifecycle.subscribe(o);
       if (AutoDisposeEndConsumerHelper.setOnce(mainSubscription, s, getClass())) {
         delegate.onSubscribe(this);
       }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
@@ -31,14 +31,13 @@ final class AutoDisposingSubscriberImpl<T> extends AtomicInteger
 
   private final AtomicReference<Subscription> mainSubscription = new AtomicReference<>();
   private final AtomicReference<Disposable> lifecycleDisposable = new AtomicReference<>();
+  private final AtomicThrowable error = new AtomicThrowable();
   private final Maybe<?> lifecycle;
   private final Subscriber<? super T> delegate;
-  private final AtomicThrowable error;
 
   AutoDisposingSubscriberImpl(Maybe<?> lifecycle, Subscriber<? super T> delegate) {
     this.lifecycle = lifecycle;
     this.delegate = delegate;
-    this.error = new AtomicThrowable();
   }
 
   @Override public Subscriber<? super T> delegateSubscriber() {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
@@ -54,9 +54,8 @@ final class AutoDisposingSubscriberImpl<T> extends AtomicInteger
       }
 
       @Override public void onError(Throwable e) {
-        AutoDisposingSubscriberImpl.this.onError(e);
-        mainSubscription.lazySet(AutoSubscriptionHelper.CANCELLED);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        AutoDisposingSubscriberImpl.this.onError(e);
       }
 
       @Override public void onComplete() {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
@@ -49,8 +49,8 @@ final class AutoDisposingSubscriberImpl<T> extends AtomicInteger
   @Override public void onSubscribe(final Subscription s) {
     DisposableMaybeObserver<Object> o = new DisposableMaybeObserver<Object>() {
       @Override public void onSuccess(Object o) {
-        AutoSubscriptionHelper.cancel(mainSubscription);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
+        AutoSubscriptionHelper.cancel(mainSubscription);
       }
 
       @Override public void onError(Throwable e) {
@@ -109,24 +109,24 @@ final class AutoDisposingSubscriberImpl<T> extends AtomicInteger
     if (!isDisposed()) {
       if (HalfSerializer.onNext(delegate, value, this, error)) {
         // Terminal event occurred and was forwarded to the delegate, so clean up here
-        AutoDisposableHelper.dispose(lifecycleDisposable);
         mainSubscription.lazySet(AutoSubscriptionHelper.CANCELLED);
+        AutoDisposableHelper.dispose(lifecycleDisposable);
       }
     }
   }
 
   @Override public void onError(Throwable e) {
     if (!isDisposed()) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
       mainSubscription.lazySet(AutoSubscriptionHelper.CANCELLED);
+      AutoDisposableHelper.dispose(lifecycleDisposable);
       HalfSerializer.onError(delegate, e, this, error);
     }
   }
 
   @Override public void onComplete() {
     if (!isDisposed()) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
       mainSubscription.lazySet(AutoSubscriptionHelper.CANCELLED);
+      AutoDisposableHelper.dispose(lifecycleDisposable);
       HalfSerializer.onComplete(delegate, this, error);
     }
   }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
@@ -84,8 +84,9 @@ final class AutoDisposingSubscriberImpl<T> extends AtomicInteger
    *
    * @param n the request amount, positive
    */
-  @Override public void request(long n) {
-    mainSubscription.get().request(n);
+  @SuppressWarnings("NullAway") @Override public void request(long n) {
+    mainSubscription.get()
+        .request(n);
   }
 
   /**

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
@@ -88,17 +88,13 @@ final class AutoDisposingSubscriberImpl<T> implements AutoDisposingSubscriber<T>
    * <p>This method is thread-safe and can be exposed as a public API.
    */
   @Override public void cancel() {
-    synchronized (this) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
-      AutoSubscriptionHelper.cancel(mainSubscription);
-    }
+    AutoDisposableHelper.dispose(lifecycleDisposable);
+    AutoSubscriptionHelper.cancel(mainSubscription);
   }
 
   private void lazyCancel() {
-    synchronized (this) {
-      AutoDisposableHelper.dispose(lifecycleDisposable);
-      mainSubscription.lazySet(AutoSubscriptionHelper.CANCELLED);
-    }
+    AutoDisposableHelper.dispose(lifecycleDisposable);
+    mainSubscription.lazySet(AutoSubscriptionHelper.CANCELLED);
   }
 
   @SuppressWarnings("WeakerAccess") // Avoiding synthetic accessors

--- a/autodispose/src/main/java/com/uber/autodispose/ExceptionHelper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/ExceptionHelper.java
@@ -73,7 +73,7 @@ final class ExceptionHelper {
       super("No further exceptions");
     }
 
-    @Override public Throwable fillInStackTrace() {
+    @Override public synchronized Throwable fillInStackTrace() {
       return this;
     }
   }

--- a/autodispose/src/main/java/com/uber/autodispose/ExceptionHelper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/ExceptionHelper.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.uber.autodispose;
+
+import io.reactivex.exceptions.CompositeException;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+/**
+ * Terminal atomics for Throwable containers.
+ */
+final class ExceptionHelper {
+
+  /** Utility class. */
+  private ExceptionHelper() {
+    throw new IllegalStateException("No instances!");
+  }
+
+  /**
+   * A singleton instance of a Throwable indicating a terminal state for exceptions,
+   * don't leak this.
+   */
+  public static final Throwable TERMINATED = new Termination();
+
+  public static boolean addThrowable(AtomicReference<Throwable> field, Throwable exception) {
+    for (; ; ) {
+      Throwable current = field.get();
+
+      if (current == TERMINATED) {
+        return false;
+      }
+
+      Throwable update;
+      if (current == null) {
+        update = exception;
+      } else {
+        update = new CompositeException(current, exception);
+      }
+
+      if (field.compareAndSet(current, update)) {
+        return true;
+      }
+    }
+  }
+
+  @Nullable
+  public static Throwable terminate(AtomicReference<Throwable> field) {
+    Throwable current = field.get();
+    if (current != TERMINATED) {
+      current = field.getAndSet(TERMINATED);
+    }
+    return current;
+  }
+
+  static final class Termination extends Throwable {
+
+    Termination() {
+      super("No further exceptions");
+    }
+
+    @Override public Throwable fillInStackTrace() {
+      return this;
+    }
+  }
+}

--- a/autodispose/src/main/java/com/uber/autodispose/HalfSerializer.java
+++ b/autodispose/src/main/java/com/uber/autodispose/HalfSerializer.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.uber.autodispose;
+
+import io.reactivex.Observer;
+import io.reactivex.plugins.RxJavaPlugins;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.reactivestreams.Subscriber;
+
+/**
+ * Utility methods to perform half-serialization: a form of serialization
+ * where onNext is guaranteed to be called from a single thread but
+ * onError or onComplete may be called from any threads.
+ * <p>
+ * The onNext methods have been modified to return a boolean indicating whether or not the delegate
+ * observer was sent a terminal event.
+ */
+final class HalfSerializer {
+  /** Utility class. */
+  private HalfSerializer() {
+    throw new IllegalStateException("No instances!");
+  }
+
+  /**
+   * Emits the given value if possible and terminates if there was an onComplete or onError
+   * while emitting, drops the value otherwise.
+   *
+   * @param <T> the value type
+   * @param subscriber the target Subscriber to emit to
+   * @param value the value to emit
+   * @param wip the serialization work-in-progress counter/indicator
+   * @param error the holder of Throwables
+   * @return true if a terminal event was emitted to {@code observer}, false if not
+   */
+  public static <T> boolean onNext(Subscriber<? super T> subscriber,
+      T value,
+      AtomicInteger wip,
+      AtomicThrowable error) {
+    if (wip.get() == 0 && wip.compareAndSet(0, 1)) {
+      subscriber.onNext(value);
+      if (wip.decrementAndGet() != 0) {
+        Throwable ex = error.terminate();
+        if (ex != null) {
+          subscriber.onError(ex);
+        } else {
+          subscriber.onComplete();
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Emits the given exception if possible or adds it to the given error container to
+   * be emitted by a concurrent onNext if one is running.
+   * Undeliverable exceptions are sent to the RxJavaPlugins.onError.
+   *
+   * @param subscriber the target Subscriber to emit to
+   * @param ex the Throwable to emit
+   * @param wip the serialization work-in-progress counter/indicator
+   * @param error the holder of Throwables
+   */
+  public static void onError(Subscriber<?> subscriber,
+      Throwable ex,
+      AtomicInteger wip,
+      AtomicThrowable error) {
+    if (error.addThrowable(ex)) {
+      if (wip.getAndIncrement() == 0) {
+        subscriber.onError(error.terminate());
+      }
+    } else {
+      RxJavaPlugins.onError(ex);
+    }
+  }
+
+  /**
+   * Emits an onComplete signal or an onError signal with the given error or indicates
+   * the concurrently running onNext should do that.
+   *
+   * @param subscriber the target Subscriber to emit to
+   * @param wip the serialization work-in-progress counter/indicator
+   * @param error the holder of Throwables
+   */
+  public static void onComplete(Subscriber<?> subscriber,
+      AtomicInteger wip,
+      AtomicThrowable error) {
+    if (wip.getAndIncrement() == 0) {
+      Throwable ex = error.terminate();
+      if (ex != null) {
+        subscriber.onError(ex);
+      } else {
+        subscriber.onComplete();
+      }
+    }
+  }
+
+  /**
+   * Emits the given value if possible and terminates if there was an onComplete or onError
+   * while emitting, drops the value otherwise.
+   *
+   * @param <T> the value type
+   * @param observer the target Observer to emit to
+   * @param value the value to emit
+   * @param wip the serialization work-in-progress counter/indicator
+   * @param error the holder of Throwables
+   * @return true if a terminal event was emitted to {@code observer}, false if not
+   */
+  public static <T> boolean onNext(Observer<? super T> observer,
+      T value,
+      AtomicInteger wip,
+      AtomicThrowable error) {
+    if (wip.get() == 0 && wip.compareAndSet(0, 1)) {
+      observer.onNext(value);
+      if (wip.decrementAndGet() != 0) {
+        Throwable ex = error.terminate();
+        if (ex != null) {
+          observer.onError(ex);
+        } else {
+          observer.onComplete();
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Emits the given exception if possible or adds it to the given error container to
+   * be emitted by a concurrent onNext if one is running.
+   * Undeliverable exceptions are sent to the RxJavaPlugins.onError.
+   *
+   * @param observer the target Subscriber to emit to
+   * @param ex the Throwable to emit
+   * @param wip the serialization work-in-progress counter/indicator
+   * @param error the holder of Throwables
+   */
+  public static void onError(Observer<?> observer,
+      Throwable ex,
+      AtomicInteger wip,
+      AtomicThrowable error) {
+    if (error.addThrowable(ex)) {
+      if (wip.getAndIncrement() == 0) {
+        observer.onError(error.terminate());
+      }
+    } else {
+      RxJavaPlugins.onError(ex);
+    }
+  }
+
+  /**
+   * Emits an onComplete signal or an onError signal with the given error or indicates
+   * the concurrently running onNext should do that.
+   *
+   * @param observer the target Subscriber to emit to
+   * @param wip the serialization work-in-progress counter/indicator
+   * @param error the holder of Throwables
+   */
+  public static void onComplete(Observer<?> observer, AtomicInteger wip, AtomicThrowable error) {
+    if (wip.getAndIncrement() == 0) {
+      Throwable ex = error.terminate();
+      if (ex != null) {
+        observer.onError(ex);
+      } else {
+        observer.onComplete();
+      }
+    }
+  }
+}

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingCompletableObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingCompletableObserver.java
@@ -27,7 +27,7 @@ import io.reactivex.disposables.Disposable;
 public interface AutoDisposingCompletableObserver extends CompletableObserver, Disposable {
 
   /**
-   * @return The delegate {@link CompletableObserver} that is used under the hood forintrospection
+   * @return The delegate {@link CompletableObserver} that is used under the hood for introspection
    * purposes. This will be updated once LambdaIntrospection is out of @Experimental in RxJava.
    */
   @Experimental

--- a/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingObserver.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/AutoDisposingObserver.java
@@ -27,7 +27,7 @@ import io.reactivex.disposables.Disposable;
 public interface AutoDisposingObserver<T> extends Observer<T>, Disposable {
 
   /**
-   * @return The delegate {@link Observer} that is used under the hood for introspection purpose.
+   * @return The delegate {@link Observer} that is used under the hood for introspection purposes.
    * This will be updated once LambdaIntrospection is out of @Experimental in RxJava.
    */
   @Experimental

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -34,6 +34,7 @@ import io.reactivex.subjects.MaybeSubject;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -47,6 +48,8 @@ public class AutoDisposeCompletableObserverTest {
       System.out.println(AutoDisposeCompletableObserverTest.class.getSimpleName() + ": " + message);
     }
   };
+
+  @Rule public RxErrorsRule rule = new RxErrorsRule();
 
   @After public void resetPlugins() {
     AutoDisposePlugins.reset();
@@ -353,5 +356,16 @@ public class AutoDisposeCompletableObserverTest {
     // Verify cancellation was called
     assertThat(i.get()).isEqualTo(1);
     assertThat(lifecycle.hasObservers()).isFalse();
+  }
+
+  @Test public void autoDispose_withScopeProviderCompleted_shouldNotReportDoubleSubscriptions() {
+    TestObserver<Object> o = new TestObserver<>();
+    CompletableSubject.create()
+        .to(AutoDispose.with(ScopeProvider.UNBOUND).forCompletable())
+        .subscribe(o);
+    o.assertNoValues();
+    o.assertNoErrors();
+
+    rule.assertNoErrors();
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -33,6 +33,7 @@ import io.reactivex.subjects.MaybeSubject;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -46,6 +47,8 @@ public class AutoDisposeMaybeObserverTest {
       System.out.println(AutoDisposeMaybeObserverTest.class.getSimpleName() + ": " + message);
     }
   };
+
+  @Rule public RxErrorsRule rule = new RxErrorsRule();
 
   @After public void resetPlugins() {
     AutoDisposePlugins.reset();
@@ -383,5 +386,16 @@ public class AutoDisposeMaybeObserverTest {
     // Verify cancellation was called
     assertThat(i.get()).isEqualTo(1);
     assertThat(lifecycle.hasObservers()).isFalse();
+  }
+
+  @Test public void autoDispose_withScopeProviderCompleted_shouldNotReportDoubleSubscriptions() {
+    TestObserver<Object> o = new TestObserver<>();
+    MaybeSubject.create()
+        .to(AutoDispose.with(ScopeProvider.UNBOUND).forMaybe())
+        .subscribe(o);
+    o.assertNoValues();
+    o.assertNoErrors();
+
+    rule.assertNoErrors();
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -35,6 +35,7 @@ import io.reactivex.subjects.PublishSubject;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -46,6 +47,8 @@ public class AutoDisposeObserverTest {
       System.out.println(AutoDisposeObserverTest.class.getSimpleName() + ": " + message);
     }
   };
+
+  @Rule public RxErrorsRule rule = new RxErrorsRule();
 
   @After public void resetPlugins() {
     AutoDisposePlugins.reset();
@@ -322,5 +325,16 @@ public class AutoDisposeObserverTest {
     // Verify cancellation was called
     assertThat(i.get()).isEqualTo(1);
     assertThat(lifecycle.hasObservers()).isFalse();
+  }
+
+  @Test public void autoDispose_withScopeProviderCompleted_shouldNotReportDoubleSubscriptions() {
+    TestObserver<Object> o = new TestObserver<>();
+    PublishSubject.create()
+        .to(AutoDispose.with(ScopeProvider.UNBOUND).forObservable())
+        .subscribe(o);
+    o.assertNoValues();
+    o.assertNoErrors();
+
+    rule.assertNoErrors();
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -34,6 +34,7 @@ import io.reactivex.subjects.SingleSubject;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -47,6 +48,8 @@ public class AutoDisposeSingleObserverTest {
       System.out.println(AutoDisposeSingleObserverTest.class.getSimpleName() + ": " + message);
     }
   };
+
+  @Rule public RxErrorsRule rule = new RxErrorsRule();
 
   @After public void resetPlugins() {
     AutoDisposePlugins.reset();
@@ -353,5 +356,16 @@ public class AutoDisposeSingleObserverTest {
     // Verify cancellation was called
     assertThat(i.get()).isEqualTo(1);
     assertThat(lifecycle.hasObservers()).isFalse();
+  }
+
+  @Test public void autoDispose_withScopeProviderCompleted_shouldNotReportDoubleSubscriptions() {
+    TestObserver<Object> o = new TestObserver<>();
+    SingleSubject.create()
+        .to(AutoDispose.with(ScopeProvider.UNBOUND).forSingle())
+        .subscribe(o);
+    o.assertNoValues();
+    o.assertNoErrors();
+
+    rule.assertNoErrors();
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -35,12 +35,15 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
 import static com.google.common.truth.Truth.assertThat;
 
 public class AutoDisposeSubscriberTest {
+
+  @Rule public RxErrorsRule rule = new RxErrorsRule();
 
   @After public void resetPlugins() {
     AutoDisposePlugins.reset();
@@ -333,5 +336,16 @@ public class AutoDisposeSubscriberTest {
     // Verify cancellation was called
     assertThat(i.get()).isEqualTo(1);
     assertThat(lifecycle.hasObservers()).isFalse();
+  }
+
+  @Test public void autoDispose_withScopeProviderCompleted_shouldNotReportDoubleSubscriptions() {
+    TestSubscriber<Object> o = new TestSubscriber<>();
+    PublishProcessor.create()
+        .to(AutoDispose.with(ScopeProvider.UNBOUND).forFlowable())
+        .subscribe(o);
+    o.assertNoValues();
+    o.assertNoErrors();
+
+    rule.assertNoErrors();
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/RxErrorsRule.java
+++ b/autodispose/src/test/java/com/uber/autodispose/RxErrorsRule.java
@@ -65,12 +65,13 @@ import static com.google.common.truth.Truth.assertThat;
   }
 
   public boolean hasErrors() {
-    Throwable error;
-    try {
-      error = errors.pollFirst(0, TimeUnit.SECONDS);
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
+    Throwable error = errors.peek();
     return error != null;
+  }
+
+  public void assertNoErrors() {
+    if (hasErrors()) {
+      throw new AssertionError("Expected no errors but found " + getErrors());
+    }
   }
 }


### PR DESCRIPTION
This PR incorporates feedback from #130, but it not currently complete yet. CC @akarnokd whenever you have time to review (no rush!)

## Completed

> AutoDisposePlugins.java#L36: Such lockdown support may not be desirable on Android. The same feature was aimed at server/J2EE container use of RxJava.

Mentioned in the issue, opted to keep this to match semantics of RxJava's plugins. We also operate on a large monorepo structure internally where this actually becomes useful to help catch downstream usages.

> dependencies.gradle#L65: Using a pretty old RxJava 2 version.

Touched on in the issue, and after thinking on it I think I'm going to keep this as is until there's a new minor release or new API we want to target. Keeping the lower API makes it easier for consumers to adopt without imposing newer versions if they haven't been able to update yet.

> AutoDisposingCompletableObserverImpl.java#L73: synchronized is pointless here.
> AutoDisposingCompletableObserverImpl.java#L80: synchronized is pointless here. If the purpose was to mutually exclude with #L73 then it is not worth it. If lazySet wins then dispose(ref) will do nothing, if they race, both cases could win probabilistically.

bd22bc2

> AutoDisposingCompletableObserver.java#L30: missing space in forintrospection.

caf904a

> AutoDisposingObserver.java#L30: missing tailing s from purpose?

79e6dbf

> AutoDispose.java#L169: class could be final.
> AutoDispose.java#L199: class could be final.
> AutoDispose.java#L229: class could be final.

94212eb

> AutoDisposingCompletableObserverImpl.java#L45: The DisposableMaybeObserver could be created and setOnce'd before the call to lifecycle.subscribe().

9bf1993
 
> AutoDisposingObserverImpl.java: Same problems as with the CompletableObserver implementation. Here one would need a HalfSerializer to mutually exclude the onXXX events (as there could be multiple onNext calls).

cb432a8. I think I've mostly got this. Main thing I'm not sure of is if it does terminate, do we need to dispose the lifecycle or does this mean that onError or onComplete have been hit in the main observer already (and doing so is a double dispose condition)

> ViewAttachEventsObservable.java#L41 If the call is not on the main thread, onSubscribe is not called which can lead to a NullPointerException in the dowstream. The no-op Disposable should be sent to the Observer first.

07f0f1e and corresponding one for `LifecycleEventsObservable` ec190c0

> ViewAttachEventsObservable.java#L51: The Observer may cancel immediately and since the listener is not registered with the view yet, it won't get removed but then added unconditionally. Assuming the events also come from the main thread, one could add the listener first, and call onSubscribe next. If adding the listener triggers an event emission immediately, keep the current order and after adding the listener, check if the listener has been disposed in the meantime and remove the listener.

I think this is covered as a part of 07f0f1e, but let me know if I've missed something

> AutoDisposingSubscriberImpl.java#L80: There is no onStart provided by the API and the delegate.onSubscribe is called after mainSubscription is definitely set: the null check should always pass and thus unnecessary.

b38d03f

## TODO

> AutoDisposingCompletableObserverImpl.java#L52: The mainDisposable could be already set and the delegate currently executing one of its onXXX methods which violates the contract unless it is guaranteed both the lifecycle signal and the onXXX calls happen on the same thread (i.e., forced observeOn(AndroidSchedulers.mainThread())). Possible solution: always call delegate.onSubscribe(this) first, mutually exclude the onXXX signals via an AtomicBoolean once.

If I subscribe first - couldn't it synchronously execute its entire sequence before the lifecycle gets a chance then? Part of ths reason it's done ater the lifecycle check is such that the lifecycle can indicate that it's ended, and just immediately dispose after onSubscribe().

> AutoDisposingCompletableObserverImpl.java#L58: May not be a good idea to leave the delegate non-terminated in this case, if the lifecycle actually can get onComplete.

Could you expand on this one a bit? I'm not sure I totally understood

> AutoDisposingSubscriberImpl.java#L80: Note though that if one does the setOnce(mainSubscription) before the lifecycle is attached, one may need to use deferred requesting to not trigger the upstream emission while the code is setting up other things in onSubscribe.

See comment below