### PR TITLE
Don't lazyset maindisposable in scope completions

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingCompletableObserverImpl.java
@@ -52,7 +52,6 @@ final class AutoDisposingCompletableObserverImpl implements AutoDisposingComplet
       }
 
       @Override public void onComplete() {
-        mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         // Noop - we're unbound now
       }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingMaybeObserverImpl.java
@@ -52,7 +52,6 @@ final class AutoDisposingMaybeObserverImpl<T> implements AutoDisposingMaybeObser
       }
 
       @Override public void onComplete() {
-        mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         // Noop - we're unbound now
       }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingObserverImpl.java
@@ -54,7 +54,6 @@ final class AutoDisposingObserverImpl<T> extends AtomicInteger implements AutoDi
       }
 
       @Override public void onComplete() {
-        mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         // Noop - we're unbound now
       }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSingleObserverImpl.java
@@ -52,7 +52,6 @@ final class AutoDisposingSingleObserverImpl<T> implements AutoDisposingSingleObs
       }
 
       @Override public void onComplete() {
-        mainDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         // Noop - we're unbound now
       }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposingSubscriberImpl.java
@@ -59,7 +59,6 @@ final class AutoDisposingSubscriberImpl<T> extends AtomicInteger
       }
 
       @Override public void onComplete() {
-        mainSubscription.lazySet(AutoSubscriptionHelper.CANCELLED);
         lifecycleDisposable.lazySet(AutoDisposableHelper.DISPOSED);
         // Noop - we're unbound now
       }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -320,12 +320,11 @@ public class AutoDisposeCompletableObserverTest {
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(
           AutoDisposingCompletableObserver.class);
-      assertThat(((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get())
-              .delegateObserver())
-          .isNotNull();
-      assertThat(((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get())
-              .delegateObserver())
-          .isSameAs(atomicObserver.get());
+      assertThat(
+          ((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
+      assertThat(
+          ((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isSameAs(
+          atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }
@@ -361,11 +360,23 @@ public class AutoDisposeCompletableObserverTest {
   @Test public void autoDispose_withScopeProviderCompleted_shouldNotReportDoubleSubscriptions() {
     TestObserver<Object> o = new TestObserver<>();
     CompletableSubject.create()
-        .to(AutoDispose.with(ScopeProvider.UNBOUND).forCompletable())
+        .to(AutoDispose.with(ScopeProvider.UNBOUND)
+            .forCompletable())
         .subscribe(o);
     o.assertNoValues();
     o.assertNoErrors();
 
     rule.assertNoErrors();
+  }
+
+  @Test public void unbound_shouldStillPassValues() {
+    TestObserver<Object> o = new TestObserver<>();
+    CompletableSubject s = CompletableSubject.create();
+    s.to(AutoDispose.with(ScopeProvider.UNBOUND)
+        .forCompletable())
+        .subscribe(o);
+
+    s.onComplete();
+    o.assertComplete();
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -321,9 +321,11 @@ public class AutoDisposeCompletableObserverTest {
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(
           AutoDisposingCompletableObserver.class);
       assertThat(
-          ((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
+          ((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get()).delegateObserver())
+          .isNotNull();
       assertThat(
-          ((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isSameAs(
+          ((AutoDisposingCompletableObserver) atomicAutoDisposingObserver.get()).delegateObserver())
+          .isSameAs(
           atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -351,12 +351,11 @@ public class AutoDisposeMaybeObserverTest {
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingMaybeObserver.class);
-      assertThat(((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get())
-              .delegateObserver())
-          .isNotNull();
-      assertThat(((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get())
-              .delegateObserver())
-          .isSameAs(atomicObserver.get());
+      assertThat(
+          ((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
+      assertThat(
+          ((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isSameAs(
+          atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }
@@ -391,11 +390,22 @@ public class AutoDisposeMaybeObserverTest {
   @Test public void autoDispose_withScopeProviderCompleted_shouldNotReportDoubleSubscriptions() {
     TestObserver<Object> o = new TestObserver<>();
     MaybeSubject.create()
-        .to(AutoDispose.with(ScopeProvider.UNBOUND).forMaybe())
+        .to(AutoDispose.with(ScopeProvider.UNBOUND)
+            .forMaybe())
         .subscribe(o);
     o.assertNoValues();
     o.assertNoErrors();
 
     rule.assertNoErrors();
+  }
+
+  @Test public void unbound_shouldStillPassValues() {
+    TestObserver<Integer> o = new TestObserver<>();
+    MaybeSubject<Integer> s = MaybeSubject.create();
+    s.to(AutoDispose.with(ScopeProvider.UNBOUND).<Integer>forMaybe())
+        .subscribe(o);
+
+    s.onSuccess(1);
+    o.assertValue(1);
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -352,10 +352,11 @@ public class AutoDisposeMaybeObserverTest {
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingMaybeObserver.class);
       assertThat(
-          ((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
+          ((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get()).delegateObserver())
+          .isNotNull();
       assertThat(
-          ((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isSameAs(
-          atomicObserver.get());
+          ((AutoDisposingMaybeObserver) atomicAutoDisposingObserver.get()).delegateObserver())
+          .isSameAs(atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -337,4 +337,15 @@ public class AutoDisposeObserverTest {
 
     rule.assertNoErrors();
   }
+
+  @Test public void unbound_shouldStillPassValues() {
+    TestObserver<Integer> o = new TestObserver<>();
+    PublishSubject<Integer> s = PublishSubject.create();
+    s.to(AutoDispose.with(ScopeProvider.UNBOUND).<Integer>forObservable())
+        .subscribe(o);
+
+    s.onNext(1);
+    o.assertValue(1);
+    o.dispose();
+  }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -321,12 +321,11 @@ public class AutoDisposeSingleObserverTest {
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingSingleObserver.class);
-      assertThat(((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get())
-              .delegateObserver())
-          .isNotNull();
-      assertThat(((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get())
-              .delegateObserver())
-          .isSameAs(atomicObserver.get());
+      assertThat(
+          ((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
+      assertThat(
+          ((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isSameAs(
+          atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }
@@ -361,11 +360,22 @@ public class AutoDisposeSingleObserverTest {
   @Test public void autoDispose_withScopeProviderCompleted_shouldNotReportDoubleSubscriptions() {
     TestObserver<Object> o = new TestObserver<>();
     SingleSubject.create()
-        .to(AutoDispose.with(ScopeProvider.UNBOUND).forSingle())
+        .to(AutoDispose.with(ScopeProvider.UNBOUND)
+            .forSingle())
         .subscribe(o);
     o.assertNoValues();
     o.assertNoErrors();
 
     rule.assertNoErrors();
+  }
+
+  @Test public void unbound_shouldStillPassValues() {
+    TestObserver<Integer> o = new TestObserver<>();
+    SingleSubject<Integer> s = SingleSubject.create();
+    s.to(AutoDispose.with(ScopeProvider.UNBOUND).<Integer>forSingle())
+        .subscribe(o);
+
+    s.onSuccess(1);
+    o.assertValue(1);
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -322,10 +322,11 @@ public class AutoDisposeSingleObserverTest {
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
       assertThat(atomicAutoDisposingObserver.get()).isInstanceOf(AutoDisposingSingleObserver.class);
       assertThat(
-          ((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isNotNull();
+          ((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get()).delegateObserver())
+          .isNotNull();
       assertThat(
-          ((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get()).delegateObserver()).isSameAs(
-          atomicObserver.get());
+          ((AutoDisposingSingleObserver) atomicAutoDisposingObserver.get()).delegateObserver())
+          .isSameAs(atomicObserver.get());
     } finally {
       RxJavaPlugins.reset();
     }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -296,12 +296,11 @@ public class AutoDisposeSubscriberTest {
 
       assertThat(atomicAutoDisposingSubscriber.get()).isNotNull();
       assertThat(atomicAutoDisposingSubscriber.get()).isInstanceOf(AutoDisposingSubscriber.class);
-      assertThat(((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get())
-              .delegateSubscriber())
-          .isNotNull();
-      assertThat(((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get())
-              .delegateSubscriber())
-          .isSameAs(atomicSubscriber.get());
+      assertThat(
+          ((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get()).delegateSubscriber()).isNotNull();
+      assertThat(
+          ((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get()).delegateSubscriber()).isSameAs(
+          atomicSubscriber.get());
     } finally {
       RxJavaPlugins.reset();
     }
@@ -341,11 +340,23 @@ public class AutoDisposeSubscriberTest {
   @Test public void autoDispose_withScopeProviderCompleted_shouldNotReportDoubleSubscriptions() {
     TestSubscriber<Object> o = new TestSubscriber<>();
     PublishProcessor.create()
-        .to(AutoDispose.with(ScopeProvider.UNBOUND).forFlowable())
+        .to(AutoDispose.with(ScopeProvider.UNBOUND)
+            .forFlowable())
         .subscribe(o);
     o.assertNoValues();
     o.assertNoErrors();
 
     rule.assertNoErrors();
+  }
+
+  @Test public void unbound_shouldStillPassValues() {
+    TestSubscriber<Integer> o = new TestSubscriber<>();
+    PublishProcessor<Integer> s = PublishProcessor.create();
+    s.to(AutoDispose.with(ScopeProvider.UNBOUND).<Integer>forFlowable())
+        .subscribe(o);
+
+    s.onNext(1);
+    o.assertValue(1);
+    o.dispose();
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -297,10 +297,11 @@ public class AutoDisposeSubscriberTest {
       assertThat(atomicAutoDisposingSubscriber.get()).isNotNull();
       assertThat(atomicAutoDisposingSubscriber.get()).isInstanceOf(AutoDisposingSubscriber.class);
       assertThat(
-          ((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get()).delegateSubscriber()).isNotNull();
+          ((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get()).delegateSubscriber())
+          .isNotNull();
       assertThat(
-          ((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get()).delegateSubscriber()).isSameAs(
-          atomicSubscriber.get());
+          ((AutoDisposingSubscriber) atomicAutoDisposingSubscriber.get()).delegateSubscriber())
+          .isSameAs(atomicSubscriber.get());
     } finally {
       RxJavaPlugins.reset();
     }


### PR DESCRIPTION
This was the wrong behavior, as the main disposable shouldn't be considered disposable at this point

Fixes #148