### PR TITLE
Error prone DoNotMock annotation added to elements with test helpers

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/LifecycleScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/LifecycleScopeProvider.java
@@ -16,6 +16,7 @@
 
 package com.uber.autodispose;
 
+import com.google.errorprone.annotations.DoNotMock;
 import io.reactivex.Observable;
 import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.functions.Function;
@@ -28,6 +29,7 @@ import javax.annotation.Nullable;
  *
  * @param <E> the lifecycle event type.
  */
+@DoNotMock(value = "Use TestLifecycleScopeProvider instead")
 public interface LifecycleScopeProvider<E> {
 
   /**

--- a/autodispose/src/main/java/com/uber/autodispose/ScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/ScopeProvider.java
@@ -16,12 +16,14 @@
 
 package com.uber.autodispose;
 
+import com.google.errorprone.annotations.DoNotMock;
 import io.reactivex.Maybe;
 import io.reactivex.annotations.CheckReturnValue;
 
 /**
  * Proves a {@link Maybe} representation of a scope. The emission of this is the signal
  */
+@DoNotMock(value = "Use TestScopeProvider instead")
 public interface ScopeProvider {
 
   /**


### PR DESCRIPTION
Elements with test helpers shouldn't be mocked as it can break during an update. Use Test helpers instead. Fixes - https://github.com/uber/AutoDispose/issues/146

The annotation is currently just an indication to developer as the relevant check to enforce this is not yet open sourced - https://github.com/google/error-prone/issues/572
