### PR TITLE
Change sample ViewHolders to implement LifecycleScopeProvider

### DIFF
--- a/sample/src/main/java/com/uber/autodispose/recipes/AutoDisposeViewHolder.java
+++ b/sample/src/main/java/com/uber/autodispose/recipes/AutoDisposeViewHolder.java
@@ -30,9 +30,9 @@ import io.reactivex.subjects.BehaviorSubject;
 
 /**
  * Example implementation of a {@link android.support.v7.widget.RecyclerView.ViewHolder}
- * implementation that implements {@link LifecycleScopeProvider}. This could be useful for cases where you
- * have subscriptions that should be disposed upon unbinding or otherwise aren't overwritten
- * in future binds.
+ * implementation that implements {@link LifecycleScopeProvider}. This could be useful for cases
+ * where you have subscriptions that should be disposed upon unbinding or otherwise aren't
+ * overwritten in future binds.
  */
 public abstract class AutoDisposeViewHolder
     extends BindAwareViewHolder
@@ -50,7 +50,7 @@ public abstract class AutoDisposeViewHolder
             case BIND:
               return ViewHolderEvent.UNBIND;
             default:
-              throw new LifecycleEndedException("Cannot use view holder lifecycle after unbind.");
+              throw new LifecycleEndedException("Cannot use ViewHolder lifecycle after unbind.");
           }
         }
       };

--- a/sample/src/main/java/com/uber/autodispose/recipes/AutoDisposeViewHolder.java
+++ b/sample/src/main/java/com/uber/autodispose/recipes/AutoDisposeViewHolder.java
@@ -16,51 +16,68 @@
 
 package com.uber.autodispose.recipes;
 
-import android.support.annotation.Nullable;
 import android.support.v7.widget.BindAwareViewHolder;
 import android.view.View;
-import com.uber.autodispose.ScopeProvider;
-import io.reactivex.Maybe;
-import io.reactivex.subjects.MaybeSubject;
+
+import com.uber.autodispose.LifecycleEndedException;
+import com.uber.autodispose.LifecycleScopeProvider;
+
+import javax.annotation.Nullable;
+
+import io.reactivex.Observable;
+import io.reactivex.functions.Function;
+import io.reactivex.subjects.BehaviorSubject;
 
 /**
  * Example implementation of a {@link android.support.v7.widget.RecyclerView.ViewHolder}
- * implementation that implements {@link ScopeProvider}. This could be useful for cases where you
+ * implementation that implements {@link LifecycleScopeProvider}. This could be useful for cases where you
  * have subscriptions that should be disposed upon unbinding or otherwise aren't overwritten
  * in future binds.
  */
-public abstract class AutoDisposeViewHolder extends BindAwareViewHolder implements ScopeProvider {
+public abstract class AutoDisposeViewHolder
+    extends BindAwareViewHolder
+    implements LifecycleScopeProvider<AutoDisposeViewHolder.ViewHolderEvent> {
 
-  private static final Object NOTIFICATION = new Object();
+  public enum ViewHolderEvent {
+    BIND, UNBIND
+  }
 
-  @Nullable private MaybeSubject<Object> unbindNotifier = null;
+  private static final Function<ViewHolderEvent, ViewHolderEvent> CORRESPONDING_EVENTS =
+      new Function<ViewHolderEvent, ViewHolderEvent>() {
+        @Override
+        public ViewHolderEvent apply(final ViewHolderEvent viewHolderEvent) throws Exception {
+          switch (viewHolderEvent) {
+            case BIND:
+              return ViewHolderEvent.UNBIND;
+            default:
+              throw new LifecycleEndedException("Cannot use view holder lifecycle after unbind.");
+          }
+        }
+      };
+
+  private final BehaviorSubject<ViewHolderEvent> lifecycleEvents = BehaviorSubject.create();
 
   public AutoDisposeViewHolder(View itemView) {
     super(itemView);
   }
 
-  private synchronized MaybeSubject<Object> notifier() {
-    MaybeSubject<Object> n = unbindNotifier;
-    if (n == null) {
-      n = MaybeSubject.create();
-      unbindNotifier = n;
-    }
-    return n;
+  @Override public Function<ViewHolderEvent, ViewHolderEvent> correspondingEvents() {
+    return CORRESPONDING_EVENTS;
+  }
+
+  @Override public Observable<ViewHolderEvent> lifecycle() {
+    return lifecycleEvents.hide();
+  }
+
+  @Nullable @Override public ViewHolderEvent peekLifecycle() {
+    return lifecycleEvents.getValue();
+  }
+
+  @Override protected void onBind() {
+    lifecycleEvents.onNext(ViewHolderEvent.BIND);
   }
 
   @Override protected void onUnbind() {
-    emitUnbindIfPresent();
-    unbindNotifier = null;
-  }
-
-  private void emitUnbindIfPresent() {
-    MaybeSubject<Object> notifier = unbindNotifier;
-    if (notifier != null && !notifier.hasComplete()) {
-      notifier.onSuccess(NOTIFICATION);
-    }
-  }
-
-  @Override public final Maybe<?> requestScope() {
-    return notifier();
+    lifecycleEvents.onNext(ViewHolderEvent.UNBIND);
   }
 }

--- a/sample/src/main/kotlin/com/uber/autodispose/recipes/AutoDisposeViewHolderKotlin.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/recipes/AutoDisposeViewHolderKotlin.kt
@@ -37,38 +37,28 @@ private object NOTIFICATION
 abstract class AutoDisposeViewHolderKotlin(itemView: View)
   : BindAwareViewHolder(itemView), LifecycleScopeProvider<AutoDisposeViewHolderKotlin.ViewHolderEvent> {
 
-  private val lifecycleEvents = BehaviorSubject.create<ViewHolderEvent>()
+  private val lifecycleEvents by lazy { BehaviorSubject.create<ViewHolderEvent>() }
 
   enum class ViewHolderEvent {
     BIND, UNBIND
   }
 
-  override fun onBind() {
-    lifecycleEvents.onNext(BIND)
-  }
+  override fun onBind() = lifecycleEvents.onNext(BIND)
 
-  override fun onUnbind() {
-    lifecycleEvents.onNext(UNBIND)
-  }
+  override fun onUnbind() = lifecycleEvents.onNext(UNBIND)
 
-  override fun lifecycle(): Observable<ViewHolderEvent> {
-    return lifecycleEvents.hide()
-  }
+  override fun lifecycle(): Observable<ViewHolderEvent> = lifecycleEvents.hide()
 
-  override fun correspondingEvents(): Function<ViewHolderEvent, ViewHolderEvent> {
-    return CORRESPONDING_EVENTS
-  }
+  override fun correspondingEvents(): Function<ViewHolderEvent, ViewHolderEvent> = CORRESPONDING_EVENTS
 
-  override fun peekLifecycle(): ViewHolderEvent? {
-    return lifecycleEvents.value
-  }
+  override fun peekLifecycle(): ViewHolderEvent? = lifecycleEvents.value
 
   companion object {
 
     private val CORRESPONDING_EVENTS = Function<ViewHolderEvent, ViewHolderEvent> { viewHolderEvent ->
       when (viewHolderEvent) {
         BIND -> UNBIND
-        else -> throw LifecycleEndedException("Cannot use view holder lifecycle after unbind.")
+        else -> throw LifecycleEndedException("Cannot use ViewHolder lifecycle after unbind.")
       }
     }
   }


### PR DESCRIPTION
**Description**:
Change AutoDisposeViewHolder from a ScopeProvider to a LifecycleScopeProvider. This better matches the underlying programming model, and provides some safety guarantees around subscription timing, as well as helping to detect certain issues that may arise from support library version bumps and changes to internal RecyclerView/ViewHolder logic.