### PR TITLE
Fix code snippets in javadocs for autoDisposable methods

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -270,7 +270,7 @@ public final class AutoDispose {
    * Example usage:
    * <pre><code>
    *   Observable.just(1)
-   *        .to(AutoDispose.<Integer>autoDisposable(scope))
+   *        .as(AutoDispose.<Integer>autoDisposable(scope))
    *        .subscribe(...)
    * </code></pre>
    *
@@ -294,7 +294,7 @@ public final class AutoDispose {
    * Example usage:
    * <pre><code>
    *   Observable.just(1)
-   *        .to(AutoDispose.<Integer>autoDisposable(scope))
+   *        .as(AutoDispose.<Integer>autoDisposable(scope))
    *        .subscribe(...)
    * </code></pre>
    *
@@ -314,7 +314,7 @@ public final class AutoDispose {
    * Example usage:
    * <pre><code>
    *   Observable.just(1)
-   *        .to(AutoDispose.<Integer>autoDisposable(scope))
+   *        .as(AutoDispose.<Integer>autoDisposable(scope))
    *        .subscribe(...)
    * </code></pre>
    *


### PR DESCRIPTION
<!--
Thank you for contributing to AutoDispose. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**: code snippets aren't reflecting latest API changes, i.e. `autoDisposable` static methods are not returning functions anymore, so can't be used as input for `to` Rx operator.

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**: N/A, fix is trivial

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
