### PR TITLE
Switch to arch components common artifact for slimmer dependencies

### DIFF
--- a/android/autodispose-android-archcomponents-test/build.gradle
+++ b/android/autodispose-android-archcomponents-test/build.gradle
@@ -49,8 +49,8 @@ dependencies {
   testAnnotationProcessor deps.build.nullAway
 
   compile project(':autodispose')
+  compile deps.support.arch.lifecycle.common
   compile deps.support.arch.lifecycle.runtime
-  compile deps.support.arch.lifecycle.extensions
 
   provided deps.misc.errorProneAnnotations
   provided deps.misc.javaxExtras

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -76,7 +76,7 @@ def support = [
     arch: [
         lifecycle: [
             compiler: "android.arch.lifecycle:compiler:${versions.archComponents}",
-            common: "android.arch.lifecycle:extensions:${versions.archComponents}",
+            common: "android.arch.lifecycle:common:${versions.archComponents}",
             runtime: "android.arch.lifecycle:runtime:${versions.archRuntime}"
         ]
     ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -76,7 +76,7 @@ def support = [
     arch: [
         lifecycle: [
             compiler: "android.arch.lifecycle:compiler:${versions.archComponents}",
-            extensions: "android.arch.lifecycle:extensions:${versions.archComponents}",
+            common: "android.arch.lifecycle:extensions:${versions.archComponents}",
             runtime: "android.arch.lifecycle:runtime:${versions.archRuntime}"
         ]
     ]


### PR DESCRIPTION
Checked with the framework folks and got confirmation that this should be ok to depend on. Now the archcomponents-test artifact no longer depends on livedata or viewmodel transitively
