### PR TITLE
Update osstrich handling in releasing

### DIFF
--- a/.buildscript/update_docs.sh
+++ b/.buildscript/update_docs.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+echo "Cloning osstrich..."
+mkdir tmp
+cd osstrich-tmp
+git clone git@github.com:square/osstrich.git
+cd osstrich
+echo "Packaging..."
+mvn package
+echo "Running..."
+rm -rf tmp/autodispose && java -jar target/osstrich-cli.jar tmp/autodispose git@github.com:uber/autodispose.git com.uber.autodispose
+echo "Cleaning up..."
+cd ../..
+rm -rf tmp
+echo "Finished!"

--- a/.buildscript/update_docs.sh
+++ b/.buildscript/update_docs.sh
@@ -2,7 +2,7 @@
 
 echo "Cloning osstrich..."
 mkdir tmp
-cd osstrich-tmp
+cd tmp
 git clone git@github.com:square/osstrich.git
 cd osstrich
 echo "Packaging..."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,10 +13,5 @@ Releasing
      - Select the artifact, click `close`, wait for it to close, then select again and click 
      `release`.
  10. After release propagates (wait ~1 hour), update Javadocs via [Osstrich](https://github.com/square/osstrich)
-     - Clone locally
-     - `mvn package`
-     - `rm -rf tmp/autodispose && java -jar target/osstrich-cli.jar tmp/autodispose git@github.com:uber/autodispose.git com.uber.autodispose`
-       - Note this step may [take a couple tries](https://github.com/square/osstrich/issues/17)
-       - If [this issue](https://github.com/square/osstrich/issues/18) is still open, edit the generated top-level `index.html` file to fix it and then push the fix after.
-         - To fix, adjust every kotlin artifact's `href` to point to the subdirectory of the same artifact name
-         - e.g. `<a href="autodispose-kotlin">autodispose-kotlin</a>` -> `<a href="autodispose-kotlin/autodispose-kotlin">autodispose-kotlin</a>`
+     - Make sure you have push access
+     - `./.buildscript/update_docs.sh`


### PR DESCRIPTION
This adds a helper script for running osstrich now that it's a bit more robust with kotlin projects