### PR TITLE
Add proguard rule for error prone annotations.

### DIFF
--- a/android/autodispose-android-archcomponents-kotlin/consumer-proguard-rules.txt
+++ b/android/autodispose-android-archcomponents-kotlin/consumer-proguard-rules.txt
@@ -1,1 +1,2 @@
 -dontwarn com.uber.javaxextras.**
+-dontwarn com.google.errorprone.annotations.**

--- a/android/autodispose-android-archcomponents-test-kotlin/consumer-proguard-rules.txt
+++ b/android/autodispose-android-archcomponents-test-kotlin/consumer-proguard-rules.txt
@@ -1,1 +1,2 @@
 -dontwarn com.uber.javaxextras.**
+-dontwarn com.google.errorprone.annotations.**

--- a/android/autodispose-android-archcomponents-test/consumer-proguard-rules.txt
+++ b/android/autodispose-android-archcomponents-test/consumer-proguard-rules.txt
@@ -1,1 +1,2 @@
 -dontwarn com.uber.javaxextras.**
+-dontwarn com.google.errorprone.annotations.**

--- a/android/autodispose-android-archcomponents/consumer-proguard-rules.txt
+++ b/android/autodispose-android-archcomponents/consumer-proguard-rules.txt
@@ -1,2 +1,3 @@
 -dontwarn com.uber.javaxextras.**
+-dontwarn com.google.errorprone.annotations.**
 -keep class * implements android.arch.lifecycle.GeneratedAdapter {<init>(...);}

--- a/android/autodispose-android-kotlin/consumer-proguard-rules.txt
+++ b/android/autodispose-android-kotlin/consumer-proguard-rules.txt
@@ -1,1 +1,2 @@
 -dontwarn com.uber.javaxextras.**
+-dontwarn com.google.errorprone.annotations.**

--- a/android/autodispose-android/consumer-proguard-rules.txt
+++ b/android/autodispose-android/consumer-proguard-rules.txt
@@ -1,1 +1,2 @@
 -dontwarn com.uber.javaxextras.**
+-dontwarn com.google.errorprone.annotations.**


### PR DESCRIPTION
Was seeing proguard build failures due to the `@DoNotMock` annotation.

This change adds an additional proguard rule to exclude the compileOnly errorprone annotations for all Android modules.

Tested by running a proguard build of Robinhood with the given rule.