### PR TITLE
AutoDisposeAndroidPlugins (and main thread checker hook)

### DIFF
--- a/android/autodispose-android/build.gradle
+++ b/android/autodispose-android/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 
   errorprone deps.build.errorProne
 
+  testCompile project(':test-utils')
+  testCompile deps.test.junit
+  testCompile deps.test.truth
   androidTestCompile project(':test-utils')
   androidTestCompile deps.support.annotations
   androidTestCompile deps.test.androidRunner

--- a/android/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeAndroidPlugins.java
+++ b/android/autodispose-android/src/main/java/com/uber/autodispose/android/AutoDisposeAndroidPlugins.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2018. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose.android;
+
+import android.support.annotation.Nullable;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.BooleanSupplier;
+
+/**
+ * Utility class to inject handlers to certain standard AutoDispose Android operations.
+ */
+public final class AutoDisposeAndroidPlugins {
+
+  private AutoDisposeAndroidPlugins() { }
+
+  @Nullable private static volatile BooleanSupplier onCheckMainThread;
+
+  /**
+   * Prevents changing the plugins.
+   */
+  static volatile boolean lockdown;
+
+  /**
+   * Prevents changing the plugins from then on.
+   * <p>
+   * This allows container-like environments to prevent client messing with plugins.
+   */
+  public static void lockdown() {
+    lockdown = true;
+  }
+
+  /**
+   * Returns true if the plugins were locked down.
+   *
+   * @return true if the plugins were locked down
+   */
+  public static boolean isLockdown() {
+    return lockdown;
+  }
+
+  /**
+   * Sets the preferred main thread checker. If not {@code null}, the {@code mainThreadChecker} will
+   * be preferred in all main thread checks in {@link #onCheckMainThread(BooleanSupplier)} calls.
+   * This can be useful for JVM testing environments, where standard Android Looper APIs cannot be
+   * stubbed and thus should be overridden with a custom check.
+   * <p>
+   * This is a reset-able API, which means you can pass {@code null} as the parameter value to reset
+   * it. Alternatively, you can call {@link #reset()}.
+   *
+   * @param mainThreadChecker a {@link BooleanSupplier} to call to check if current execution is
+   * on the main thread. Should return {@code true} if it is on the main
+   * thread or {@code false} if not.
+   */
+  public static void setOnCheckMainThread(@Nullable BooleanSupplier mainThreadChecker) {
+    if (lockdown) {
+      throw new IllegalStateException("Plugins can't be changed anymore");
+    }
+    onCheckMainThread = mainThreadChecker;
+  }
+
+  /**
+   * Returns {@code true} if called on the main thread, {@code false} if not. This will prefer a set
+   * checker via {@link #setOnCheckMainThread(BooleanSupplier)} if one is present, otherwise it will
+   * use {@code defaultChecker}.
+   *
+   * @param defaultChecker the default checker to fall back to if there is no main thread checker
+   * set.
+   * @return {@code true} if called on the main thread, {@code false} if not.
+   */
+  public static boolean onCheckMainThread(BooleanSupplier defaultChecker) {
+    if (defaultChecker == null) {
+      throw new NullPointerException("defaultChecker == null");
+    }
+    BooleanSupplier c = onCheckMainThread;
+    try {
+      if (c == null) {
+        return defaultChecker.getAsBoolean();
+      } else {
+        return c.getAsBoolean();
+      }
+    } catch (Exception ex) {
+      throw Exceptions.propagate(ex);
+    }
+  }
+
+  /**
+   * Removes all handlers and resets to default behavior.
+   */
+  public static void reset() {
+    setOnCheckMainThread(null);
+  }
+}

--- a/android/autodispose-android/src/main/java/com/uber/autodispose/android/internal/AutoDisposeAndroidUtil.java
+++ b/android/autodispose-android/src/main/java/com/uber/autodispose/android/internal/AutoDisposeAndroidUtil.java
@@ -20,21 +20,24 @@ import android.os.Build;
 import android.os.Looper;
 import android.support.annotation.RestrictTo;
 import android.view.View;
+import com.uber.autodispose.android.AutoDisposeAndroidPlugins;
+import io.reactivex.functions.BooleanSupplier;
 
 import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 
 @RestrictTo(LIBRARY_GROUP)
 public class AutoDisposeAndroidUtil {
 
+  private static BooleanSupplier MAIN_THREAD_CHECK = new BooleanSupplier() {
+    @Override public boolean getAsBoolean() {
+      return Looper.myLooper() == Looper.getMainLooper();
+    }
+  };
+
   private AutoDisposeAndroidUtil() { }
 
   public static boolean isMainThread() {
-    try {
-      return Looper.myLooper() == Looper.getMainLooper();
-    } catch (Exception e) {
-      // Cover for tests
-      return true;
-    }
+    return AutoDisposeAndroidPlugins.onCheckMainThread(MAIN_THREAD_CHECK);
   }
 
   public static boolean isAttached(View view) {

--- a/android/autodispose-android/src/test/java/com/uber/autodispose/android/AutoDisposeAndroidPluginsTest.java
+++ b/android/autodispose-android/src/test/java/com/uber/autodispose/android/AutoDisposeAndroidPluginsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2018. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose.android;
+
+import com.uber.autodispose.AutoDisposePlugins;
+import com.uber.autodispose.android.internal.AutoDisposeAndroidUtil;
+import io.reactivex.functions.BooleanSupplier;
+import org.junit.After;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public final class AutoDisposeAndroidPluginsTest {
+
+  @After public void tearDown() {
+    AutoDisposePlugins.reset();
+  }
+
+  @Test public void overridingMainThreadCheck_shouldWorkInUnitTests() {
+    expectLooperError();
+
+    AutoDisposeAndroidPlugins.setOnCheckMainThread(new BooleanSupplier() {
+      @Override public boolean getAsBoolean() {
+        return true;
+      }
+    });
+
+    assertThat(AutoDisposeAndroidUtil.isMainThread()).isTrue();
+
+    AutoDisposeAndroidPlugins.reset();
+
+    AutoDisposeAndroidPlugins.setOnCheckMainThread(new BooleanSupplier() {
+      @Override public boolean getAsBoolean() {
+        return false;
+      }
+    });
+
+    assertThat(AutoDisposeAndroidUtil.isMainThread()).isFalse();
+
+    // Now reset and confirm we're back to normal
+    AutoDisposeAndroidPlugins.setOnCheckMainThread(null);
+    expectLooperError();
+  }
+
+  private void expectLooperError() {
+    // Default case definitely hits the Looper code.
+    // This does not work in standard Android unit tests.
+    try {
+      AutoDisposeAndroidUtil.isMainThread();
+      throw new AssertionError("Expected to fail before this due to Looper not being stubbed!");
+    } catch (Exception e) {
+      // "Method myLooper in android.os.Looper not mocked. See http://g.co/androidstudio/not-mocked for details."
+      // Not testing this exact message as it's an implementation detail of the test framework.
+    }
+  }
+}


### PR DESCRIPTION
Resolves #181 

This introduces a new plugins mechanism for Android use via `AutoDisposeAndroidPlugins`. The first plugin is a hook for main thread checks, which will allow for supplying a custom `BooleanSupplier` impl that can customize how main thread checks work. The conventional use case of this is Android JUnit tests, where the `Looper` class is not stubbed in the mock android.jar and fails explosively when touched.

One could also use this at runtime to customize checks for more fine grained main thread checks behavior.

Will update the README. See test for example usage.