### PR TITLE
Update to AGP 3.1.0 final

### DIFF
--- a/android/autodispose-android-archcomponents-kotlin/build.gradle
+++ b/android/autodispose-android-archcomponents-kotlin/build.gradle
@@ -40,9 +40,8 @@ android {
 }
 
 dependencies {
-  compile deps.kotlin.stdlib
-  compile project(':android:autodispose-android-archcomponents')
-  androidTestCompile project(':test-utils')
+  implementation project(':android:autodispose-android-archcomponents')
+  androidTestImplementation project(':test-utils')
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/android/autodispose-android-archcomponents-kotlin/build.gradle
+++ b/android/autodispose-android-archcomponents-kotlin/build.gradle
@@ -37,11 +37,15 @@ android {
   sourceSets {
     main.java.srcDirs += 'src/main/kotlin'
   }
+  testOptions {
+    execution 'ANDROID_TEST_ORCHESTRATOR'
+  }
 }
 
 dependencies {
   implementation project(':android:autodispose-android-archcomponents')
   androidTestImplementation project(':test-utils')
+  androidTestUtil deps.test.androidOrchestrator
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/android/autodispose-android-archcomponents-test-kotlin/build.gradle
+++ b/android/autodispose-android-archcomponents-test-kotlin/build.gradle
@@ -37,11 +37,15 @@ android {
   sourceSets {
     main.java.srcDirs += 'src/main/kotlin'
   }
+  testOptions {
+    execution 'ANDROID_TEST_ORCHESTRATOR'
+  }
 }
 
 dependencies {
   api project(':android:autodispose-android-archcomponents-test')
   androidTestImplementation project(':test-utils')
+  androidTestUtil deps.test.androidOrchestrator
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/android/autodispose-android-archcomponents-test-kotlin/build.gradle
+++ b/android/autodispose-android-archcomponents-test-kotlin/build.gradle
@@ -40,9 +40,8 @@ android {
 }
 
 dependencies {
-  compile deps.kotlin.stdlib
-  compile project(':android:autodispose-android-archcomponents-test')
-  androidTestCompile project(':test-utils')
+  api project(':android:autodispose-android-archcomponents-test')
+  androidTestImplementation project(':test-utils')
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/android/autodispose-android-archcomponents-test/build.gradle
+++ b/android/autodispose-android-archcomponents-test/build.gradle
@@ -37,13 +37,15 @@ android {
 dependencies {
   annotationProcessor deps.build.nullAway
   testAnnotationProcessor deps.build.nullAway
+  androidTestAnnotationProcessor deps.build.nullAway
 
-  compile project(':autodispose')
-  compile deps.support.arch.lifecycle.common
-  compile deps.support.arch.lifecycle.runtime
+  api project(':autodispose')
+  api deps.support.annotations
+  api deps.support.arch.lifecycle.common
+  api deps.support.arch.lifecycle.runtime
 
-  provided deps.misc.errorProneAnnotations
-  provided deps.misc.javaxExtras
+  compileOnly deps.misc.errorProneAnnotations
+  compileOnly deps.misc.javaxExtras
 
   errorprone deps.build.errorProne
 }

--- a/android/autodispose-android-archcomponents/build.gradle
+++ b/android/autodispose-android-archcomponents/build.gradle
@@ -42,20 +42,25 @@ android {
 dependencies {
   annotationProcessor deps.build.nullAway
   testAnnotationProcessor deps.build.nullAway
+  androidTestAnnotationProcessor deps.build.nullAway
   annotationProcessor deps.support.arch.lifecycle.compiler
 
-  compile project(':android:autodispose-android')
-  compile deps.support.arch.lifecycle.runtime
+  api project(':autodispose')
+  api deps.support.annotations
+  api deps.support.arch.lifecycle.runtime
 
-  provided deps.misc.errorProneAnnotations
-  provided deps.misc.javaxExtras
+  implementation project(':android:autodispose-android')
+  implementation deps.rx.android
+
+  compileOnly deps.misc.errorProneAnnotations
+  compileOnly deps.misc.javaxExtras
 
   errorprone deps.build.errorProne
 
-  androidTestCompile project(':android:autodispose-android-archcomponents-test')
-  androidTestCompile project(':test-utils')
-  androidTestCompile deps.test.androidRunner
-  androidTestCompile deps.test.androidRules
+  androidTestImplementation project(':android:autodispose-android-archcomponents-test')
+  androidTestImplementation project(':test-utils')
+  androidTestImplementation deps.test.androidRunner
+  androidTestImplementation deps.test.androidRules
 }
 
 tasks.withType(JavaCompile) {

--- a/android/autodispose-android-archcomponents/build.gradle
+++ b/android/autodispose-android-archcomponents/build.gradle
@@ -37,6 +37,9 @@ android {
   lintOptions {
     lintConfig file('lint.xml')
   }
+  testOptions {
+    execution 'ANDROID_TEST_ORCHESTRATOR'
+  }
 }
 
 dependencies {
@@ -61,6 +64,7 @@ dependencies {
   androidTestImplementation project(':test-utils')
   androidTestImplementation deps.test.androidRunner
   androidTestImplementation deps.test.androidRules
+  androidTestUtil deps.test.androidOrchestrator
 }
 
 tasks.withType(JavaCompile) {

--- a/android/autodispose-android-kotlin/build.gradle
+++ b/android/autodispose-android-kotlin/build.gradle
@@ -37,12 +37,16 @@ android {
   sourceSets {
     main.java.srcDirs += 'src/main/kotlin'
   }
+  testOptions {
+    execution 'ANDROID_TEST_ORCHESTRATOR'
+  }
 }
 
 dependencies {
   api deps.kotlin.stdlib
   implementation project(':android:autodispose-android')
   androidTestImplementation project(':test-utils')
+  androidTestUtil deps.test.androidOrchestrator
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/android/autodispose-android-kotlin/build.gradle
+++ b/android/autodispose-android-kotlin/build.gradle
@@ -40,9 +40,9 @@ android {
 }
 
 dependencies {
-  compile deps.kotlin.stdlib
-  compile project(':android:autodispose-android')
-  androidTestCompile project(':test-utils')
+  api deps.kotlin.stdlib
+  implementation project(':android:autodispose-android')
+  androidTestImplementation project(':test-utils')
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/android/autodispose-android/build.gradle
+++ b/android/autodispose-android/build.gradle
@@ -39,23 +39,23 @@ dependencies {
   annotationProcessor deps.build.nullAway
   testAnnotationProcessor deps.build.nullAway
 
-  compile project(':autodispose')
-  compile deps.rx.java
-  compile deps.rx.android
-  compile deps.support.annotations
+  api project(':autodispose')
+  api deps.rx.java
+  api deps.support.annotations
+  implementation deps.rx.android
 
-  provided deps.misc.errorProneAnnotations
-  provided deps.misc.javaxExtras
+  compileOnly deps.misc.errorProneAnnotations
+  compileOnly deps.misc.javaxExtras
 
   errorprone deps.build.errorProne
 
-  testCompile project(':test-utils')
-  testCompile deps.test.junit
-  testCompile deps.test.truth
-  androidTestCompile project(':test-utils')
-  androidTestCompile deps.support.annotations
-  androidTestCompile deps.test.androidRunner
-  androidTestCompile deps.test.androidRules
+  testImplementation project(':test-utils')
+  testImplementation deps.test.junit
+  testImplementation deps.test.truth
+  androidTestImplementation project(':test-utils')
+  androidTestImplementation deps.support.annotations
+  androidTestImplementation deps.test.androidRunner
+  androidTestImplementation deps.test.androidRules
 }
 
 tasks.withType(JavaCompile) {

--- a/android/autodispose-android/build.gradle
+++ b/android/autodispose-android/build.gradle
@@ -33,6 +33,9 @@ android {
     sourceCompatibility JavaVersion.VERSION_1_7
     targetCompatibility JavaVersion.VERSION_1_7
   }
+  testOptions {
+    execution 'ANDROID_TEST_ORCHESTRATOR'
+  }
 }
 
 dependencies {
@@ -56,6 +59,7 @@ dependencies {
   androidTestImplementation deps.support.annotations
   androidTestImplementation deps.test.androidRunner
   androidTestImplementation deps.test.androidRules
+  androidTestUtil deps.test.androidOrchestrator
 }
 
 tasks.withType(JavaCompile) {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -79,6 +79,7 @@ def support = [
 def test = [
     androidRunner: "com.android.support.test:runner:${versions.androidTest}",
     androidRules: "com.android.support.test:rules:${versions.androidTest}",
+    androidOrchestrator: "com.android.support.test:orchestrator:${versions.androidTest}",
     junit: 'junit:junit:4.12',
     truth: 'com.google.truth:truth:0.39'
 ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -42,7 +42,7 @@ def build = [
     nullAway: 'com.uber.nullaway:nullaway:0.3.2',
 
     gradlePlugins: [
-        android: 'com.android.tools.build:gradle:2.3.0',
+        android: 'com.android.tools.build:gradle:3.1.0',
         dokka: "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
         dokkaAndroid: "org.jetbrains.dokka:dokka-android-gradle-plugin:${versions.dokka}",
         kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -38,12 +38,12 @@ android {
 }
 
 dependencies {
-  provided deps.misc.javaxExtras
-  compile project(':android:autodispose-android')
-  compile project(':android:autodispose-android-archcomponents')
-  compile project(':autodispose')
-  compile project(':autodispose-kotlin')
-  compile 'com.android.support:appcompat-v7:27.0.2'
-  compile 'com.android.support.constraint:constraint-layout:1.1.0-beta4'
-  compile 'com.android.support:design:27.0.2'
+  compileOnly deps.misc.javaxExtras
+  implementation project(':android:autodispose-android')
+  implementation project(':android:autodispose-android-archcomponents')
+  implementation project(':autodispose')
+  implementation project(':autodispose-kotlin')
+  implementation 'com.android.support:appcompat-v7:27.0.2'
+  implementation 'com.android.support.constraint:constraint-layout:1.1.0-beta4'
+  implementation 'com.android.support:design:27.0.2'
 }


### PR DESCRIPTION
This is a long awaited update to AGP 3.x. We had to skip 3.0 because it had gradle classpath issues and we didn't want to pollute the root build.gradle file with a bunch of plugins.

This PR does the following:
* Updates to AGP 3.1.0
* Updates dependencies to respective `api`, `implementation`, and `compileOnly` dependencies
  * Great care was taken to make these done intelligently, but let me know if there's anything that could be further narrowed or looks off.
* Enables the new [test orchestrator](https://developer.android.com/training/testing/junit-runner.html#using-android-test-orchestrator) on instrumentation tests

This also opens the door for us to add a UAST linter artifact alongside the EP checker