### PR TITLE
Match >= for compareTo if lifecycle events are Comparable

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/ScopeUtil.java
+++ b/autodispose/src/main/java/com/uber/autodispose/ScopeUtil.java
@@ -118,13 +118,11 @@ public final class ScopeUtil {
       Observable<E> lifecycle,
       final E endEvent) {
     Function<E, Boolean> equalityFunction;
-    if (endEvent instanceof Enum) {
-      // Match on enum ordinal in case we skip an event
-      final int targetOrdinal = ((Enum) endEvent).ordinal();
+    if (endEvent instanceof Comparable) {
       //noinspection unchecked
-      equalityFunction = (Function<E, Boolean>) new Function<Enum, Boolean>() {
-        @Override public Boolean apply(Enum e) {
-          return e.ordinal() >= targetOrdinal;
+      equalityFunction = (Function<E, Boolean>) new Function<Comparable<E>, Boolean>() {
+        @Override public Boolean apply(Comparable<E> e) {
+          return e.compareTo(endEvent) >= 0;
         }
       };
     } else {

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -93,9 +93,6 @@
     <module name="LineLength">
       <property name="max" value="100"/>
     </module>
-    <module name="MethodLength">
-      <property name="max" value="180"/>
-    </module>
 
     <!-- Indentation -->
     <module name="Indentation">


### PR DESCRIPTION
Resolves #192, this checks if the lifecycle even type is comparable and uses it in comparison checking. This works for enums as a convention, I can't think of any examples that don't abide by this, but also allows for overriding the behavior if necessary. The idea here is that if we target end event "B" from start event "A", any events after "B" should also be counted as stop points.

CC @jinatonic