### PR TITLE
Migrate FlowableScoper to delegate to as()

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposeFlowable.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposeFlowable.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose;
+
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+
+final class AutoDisposeFlowable<T> extends Flowable<T> {
+  private final Publisher<T> source;
+  private final Maybe<?> scope;
+
+  AutoDisposeFlowable(Publisher<T> source, Maybe<?> scope) {
+    this.source = source;
+    this.scope = scope;
+  }
+
+  @Override protected void subscribeActual(Subscriber<? super T> observer) {
+    source.subscribe(new AutoDisposingSubscriberImpl<>(scope, observer));
+  }
+}

--- a/autodispose/src/main/java/com/uber/autodispose/FlowableScoper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/FlowableScoper.java
@@ -24,7 +24,6 @@ import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
 import io.reactivex.subscribers.TestSubscriber;
 
-import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -121,20 +120,6 @@ public class FlowableScoper<T> extends BaseAutoDisposeConverter
         return subscriber;
       }
     };
-  }
-
-  static final class AutoDisposeFlowable<T> extends Flowable<T> {
-    private final Publisher<T> source;
-    private final Maybe<?> scope;
-
-    AutoDisposeFlowable(Publisher<T> source, Maybe<?> scope) {
-      this.source = source;
-      this.scope = scope;
-    }
-
-    @Override protected void subscribeActual(Subscriber<? super T> observer) {
-      source.subscribe(new AutoDisposingSubscriberImpl<>(scope, observer));
-    }
   }
 }
 

--- a/autodispose/src/main/java/com/uber/autodispose/FlowableScoper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/FlowableScoper.java
@@ -18,14 +18,7 @@ package com.uber.autodispose;
 
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.Action;
-import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
-import io.reactivex.subscribers.TestSubscriber;
-
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 
 /**
  * Entry point for auto-disposing {@link Flowable}s.
@@ -64,62 +57,9 @@ public class FlowableScoper<T> extends BaseAutoDisposeConverter
 
   @Override public FlowableSubscribeProxy<T> apply(final Flowable<? extends T> source)
       throws Exception {
-    return new FlowableSubscribeProxy<T>() {
-      @Override public Disposable subscribe() {
-        return new AutoDisposeFlowable<>(source, scope()).subscribe();
-      }
-
-      @Override public Disposable subscribe(Consumer<? super T> onNext) {
-        return new AutoDisposeFlowable<>(source, scope()).subscribe(onNext);
-      }
-
-      @Override
-      public Disposable subscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError) {
-        return new AutoDisposeFlowable<>(source, scope()).subscribe(onNext, onError);
-      }
-
-      @Override
-      public Disposable subscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
-          Action onComplete) {
-        return new AutoDisposeFlowable<>(source, scope()).subscribe(onNext, onError, onComplete);
-      }
-
-      @Override
-      public Disposable subscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
-          Action onComplete, Consumer<? super Subscription> onSubscribe) {
-        return new AutoDisposeFlowable<>(source, scope()).subscribe(onNext, onError, onComplete,
-            onSubscribe);
-      }
-
-      @Override public void subscribe(Subscriber<T> observer) {
-        new AutoDisposeFlowable<>(source, scope()).subscribe(observer);
-      }
-
-      @Override public <E extends Subscriber<? super T>> E subscribeWith(E observer) {
-        return new AutoDisposeFlowable<>(source, scope()).subscribeWith(observer);
-      }
-
-      @Override public TestSubscriber<T> test() {
-        TestSubscriber<T> subscriber = new TestSubscriber<>();
-        subscribe(subscriber);
-        return subscriber;
-      }
-
-      @Override public TestSubscriber<T> test(long initialRequest) {
-        TestSubscriber<T> subscriber = new TestSubscriber<>(initialRequest);
-        subscribe(subscriber);
-        return subscriber;
-      }
-
-      @Override public TestSubscriber<T> test(long initialRequest, boolean cancel) {
-        TestSubscriber<T> subscriber = new TestSubscriber<>(initialRequest);
-        if (cancel) {
-            subscriber.cancel();
-        }
-        subscribe(subscriber);
-        return subscriber;
-      }
-    };
+    return source
+        .map(BaseAutoDisposeConverter.<T>identityFunctionForGenerics())
+        .as(AutoDispose.<T>autoDisposable(scope()));
   }
 }
 


### PR DESCRIPTION
Part of #188, this migrates FlowableScoper to delegate to the `as()` based API and makes the top level `autoDisposable()` API free of using scoper under the hood