### PR TITLE
Migrate SingleScoper to delegate to as()

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -25,9 +25,11 @@ import io.reactivex.Observable;
 import io.reactivex.ObservableConverter;
 import io.reactivex.Observer;
 import io.reactivex.Single;
+import io.reactivex.SingleObserver;
 import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Action;
+import io.reactivex.functions.BiConsumer;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
 import io.reactivex.observers.TestObserver;
@@ -446,8 +448,49 @@ public final class AutoDispose {
         };
       }
 
-      @Override public SingleSubscribeProxy<T> apply(Single<T> upstream) {
-        return upstream.to(new SingleScoper<T>(scope));
+      @Override public SingleSubscribeProxy<T> apply(final Single<T> upstream) {
+        return new SingleSubscribeProxy<T>() {
+          @Override public Disposable subscribe() {
+            return new AutoDisposeSingle<>(upstream, scope).subscribe();
+          }
+
+          @Override public Disposable subscribe(Consumer<? super T> onSuccess) {
+            return new AutoDisposeSingle<>(upstream, scope).subscribe(onSuccess);
+          }
+
+          @Override
+          public Disposable subscribe(BiConsumer<? super T, ? super Throwable> biConsumer) {
+            return new AutoDisposeSingle<>(upstream, scope).subscribe(biConsumer);
+          }
+
+          @Override public Disposable subscribe(Consumer<? super T> onSuccess,
+              Consumer<? super Throwable> onError) {
+            return new AutoDisposeSingle<>(upstream, scope).subscribe(onSuccess, onError);
+          }
+
+          @Override public void subscribe(SingleObserver<T> observer) {
+            new AutoDisposeSingle<>(upstream, scope).subscribe();
+          }
+
+          @Override public <E extends SingleObserver<? super T>> E subscribeWith(E observer) {
+            return new AutoDisposeSingle<>(upstream, scope).subscribeWith(observer);
+          }
+
+          @Override public TestObserver<T> test() {
+            TestObserver<T> observer = new TestObserver<>();
+            subscribe(observer);
+            return observer;
+          }
+
+          @Override public TestObserver<T> test(boolean dispose) {
+            TestObserver<T> observer = new TestObserver<>();
+            if (dispose) {
+              observer.dispose();
+            }
+            subscribe(observer);
+            return observer;
+          }
+        };
       }
     };
   }

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -469,7 +469,7 @@ public final class AutoDispose {
           }
 
           @Override public void subscribe(SingleObserver<T> observer) {
-            new AutoDisposeSingle<>(upstream, scope).subscribe();
+            new AutoDisposeSingle<>(upstream, scope).subscribe(observer);
           }
 
           @Override public <E extends SingleObserver<? super T>> E subscribeWith(E observer) {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposeSingle.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposeSingle.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose;
+
+import io.reactivex.Maybe;
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
+import io.reactivex.SingleSource;
+
+final class AutoDisposeSingle<T> extends Single<T> {
+  private final SingleSource<T> source;
+  private final Maybe<?> scope;
+
+  AutoDisposeSingle(SingleSource<T> source, Maybe<?> scope) {
+    this.source = source;
+    this.scope = scope;
+  }
+
+  @Override protected void subscribeActual(SingleObserver<? super T> observer) {
+    source.subscribe(new AutoDisposingSingleObserverImpl<>(scope, observer));
+  }
+}

--- a/autodispose/src/main/java/com/uber/autodispose/SingleScoper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/SingleScoper.java
@@ -18,12 +18,7 @@ package com.uber.autodispose;
 
 import io.reactivex.Maybe;
 import io.reactivex.Single;
-import io.reactivex.SingleObserver;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.BiConsumer;
-import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
-import io.reactivex.observers.TestObserver;
 
 /**
  * Entry point for auto-disposing {@link Single}s.
@@ -62,48 +57,9 @@ public class SingleScoper<T> extends BaseAutoDisposeConverter
 
   @Override public SingleSubscribeProxy<T> apply(final Single<? extends T> singleSource)
       throws Exception {
-    return new SingleSubscribeProxy<T>() {
-      @Override public Disposable subscribe() {
-        return new AutoDisposeSingle<>(singleSource, scope()).subscribe();
-      }
-
-      @Override public Disposable subscribe(Consumer<? super T> onNext) {
-        return new AutoDisposeSingle<>(singleSource, scope()).subscribe(onNext);
-      }
-
-      @Override public Disposable subscribe(BiConsumer<? super T, ? super Throwable> biConsumer) {
-        return new AutoDisposeSingle<>(singleSource, scope()).subscribe(biConsumer);
-      }
-
-      @Override
-      public Disposable subscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError) {
-        return new AutoDisposeSingle<>(singleSource, scope()).subscribe(onNext, onError);
-      }
-
-      @Override public void subscribe(SingleObserver<T> observer) {
-        new AutoDisposeSingle<>(singleSource, scope()).subscribe(observer);
-      }
-
-      @Override public <E extends SingleObserver<? super T>> E subscribeWith(E observer) {
-        return new AutoDisposeSingle<>(singleSource, scope()).subscribeWith(observer);
-      }
-
-      @Override public TestObserver<T> test() {
-        TestObserver<T> observer = new TestObserver<>();
-        subscribe(observer);
-        return observer;
-      }
-
-      @Override public TestObserver<T> test(boolean cancel) {
-        TestObserver<T> observer = new TestObserver<>();
-
-        if (cancel) {
-            observer.cancel();
-        }
-        subscribe(observer);
-        return observer;
-      }
-    };
+    return singleSource
+        .map(BaseAutoDisposeConverter.<T>identityFunctionForGenerics())
+        .as(AutoDispose.<T>autoDisposable(scope()));
   }
 }
 

--- a/autodispose/src/main/java/com/uber/autodispose/SingleScoper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/SingleScoper.java
@@ -19,7 +19,6 @@ package com.uber.autodispose;
 import io.reactivex.Maybe;
 import io.reactivex.Single;
 import io.reactivex.SingleObserver;
-import io.reactivex.SingleSource;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.BiConsumer;
 import io.reactivex.functions.Consumer;
@@ -105,20 +104,6 @@ public class SingleScoper<T> extends BaseAutoDisposeConverter
         return observer;
       }
     };
-  }
-
-  static final class AutoDisposeSingle<T> extends Single<T> {
-    private final SingleSource<T> source;
-    private final Maybe<?> scope;
-
-    AutoDisposeSingle(SingleSource<T> source, Maybe<?> scope) {
-      this.source = source;
-      this.scope = scope;
-    }
-
-    @Override protected void subscribeActual(SingleObserver<? super T> observer) {
-      source.subscribe(new AutoDisposingSingleObserverImpl<>(scope, observer));
-    }
   }
 }
 


### PR DESCRIPTION
Part of #188, this migrates SingleScoper to delegate to the `as()` based API and makes the top level `autoDisposable()` API free of using scoper under the hood