### PR TITLE
Migrate MaybeScoper to delegate to as()

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposeMaybe.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposeMaybe.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.uber.autodispose;
+
+import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
+import io.reactivex.MaybeSource;
+
+final class AutoDisposeMaybe<T> extends Maybe<T> {
+  private final MaybeSource<T> source;
+  private final Maybe<?> scope;
+
+  AutoDisposeMaybe(MaybeSource<T> source, Maybe<?> scope) {
+    this.source = source;
+    this.scope = scope;
+  }
+
+  @Override protected void subscribeActual(MaybeObserver<? super T> observer) {
+    source.subscribe(new AutoDisposingMaybeObserverImpl<>(scope, observer));
+  }
+}
+

--- a/autodispose/src/main/java/com/uber/autodispose/MaybeScoper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/MaybeScoper.java
@@ -17,12 +17,7 @@
 package com.uber.autodispose;
 
 import io.reactivex.Maybe;
-import io.reactivex.MaybeObserver;
-import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.Action;
-import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
-import io.reactivex.observers.TestObserver;
 
 /**
  * Entry point for auto-disposing {@link Maybe}s.
@@ -61,50 +56,9 @@ public class MaybeScoper<T> extends BaseAutoDisposeConverter
 
   @Override public MaybeSubscribeProxy<T> apply(final Maybe<? extends T> maybeSource)
       throws Exception {
-    return new MaybeSubscribeProxy<T>() {
-      @Override public Disposable subscribe() {
-        return new AutoDisposeMaybe<>(maybeSource, scope()).subscribe();
-      }
-
-      @Override public Disposable subscribe(Consumer<? super T> onNext) {
-        return new AutoDisposeMaybe<>(maybeSource, scope()).subscribe(onNext);
-      }
-
-      @Override
-      public Disposable subscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError) {
-        return new AutoDisposeMaybe<>(maybeSource, scope()).subscribe(onNext, onError);
-      }
-
-      @Override
-      public Disposable subscribe(Consumer<? super T> onNext, Consumer<? super Throwable> onError,
-          Action onComplete) {
-        return new AutoDisposeMaybe<>(maybeSource, scope()).subscribe(onNext, onError, onComplete);
-      }
-
-      @Override public void subscribe(MaybeObserver<T> observer) {
-        new AutoDisposeMaybe<>(maybeSource, scope()).subscribe(observer);
-      }
-
-      @Override public <E extends MaybeObserver<? super T>> E subscribeWith(E observer) {
-        return new AutoDisposeMaybe<>(maybeSource, scope()).subscribeWith(observer);
-      }
-
-      @Override public TestObserver<T> test() {
-        TestObserver<T> observer = new TestObserver<>();
-        subscribe(observer);
-        return observer;
-      }
-
-      @Override public TestObserver<T> test(boolean cancel) {
-        TestObserver<T> observer = new TestObserver<>();
-
-        if (cancel) {
-            observer.cancel();
-        }
-        subscribe(observer);
-        return observer;
-      }
-    };
+    return maybeSource
+        .map(BaseAutoDisposeConverter.<T>identityFunctionForGenerics())
+        .as(AutoDispose.<T>autoDisposable(scope()));
   }
 }
 

--- a/autodispose/src/main/java/com/uber/autodispose/MaybeScoper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/MaybeScoper.java
@@ -18,7 +18,6 @@ package com.uber.autodispose;
 
 import io.reactivex.Maybe;
 import io.reactivex.MaybeObserver;
-import io.reactivex.MaybeSource;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Action;
 import io.reactivex.functions.Consumer;
@@ -106,20 +105,6 @@ public class MaybeScoper<T> extends BaseAutoDisposeConverter
         return observer;
       }
     };
-  }
-
-  static final class AutoDisposeMaybe<T> extends Maybe<T> {
-    private final MaybeSource<T> source;
-    private final Maybe<?> scope;
-
-    AutoDisposeMaybe(MaybeSource<T> source, Maybe<?> scope) {
-      this.source = source;
-      this.scope = scope;
-    }
-
-    @Override protected void subscribeActual(MaybeObserver<? super T> observer) {
-      source.subscribe(new AutoDisposingMaybeObserverImpl<>(scope, observer));
-    }
   }
 }
 


### PR DESCRIPTION
Part of #188, this migrates MaybeScoper to delegate to the `as()` based API and makes the top level `autoDisposable()` API free of using scoper under the hood