### PR TITLE
Lower AGP plugin update back to 3.1.1 to unbreak android builds

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -42,7 +42,7 @@ def build = [
     nullAway: 'com.uber.nullaway:nullaway:0.3.2',
 
     gradlePlugins: [
-        android: 'com.android.tools.build:gradle:3.1.2',
+        android: 'com.android.tools.build:gradle:3.1.1',
         dokka: "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
         dokkaAndroid: "org.jetbrains.dokka:dokka-android-gradle-plugin:${versions.dokka}",
         kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"


### PR DESCRIPTION
Due to the really descriptive

> Configuration on demand is not supported by the current version of the Android Gradle plugin since you are using Gradle version 4.6 or above. Suggestion: disable configuration on demand by setting org.gradle.configureondemand=false in your gradle.properties file or use a Gradle version less than 4.6.

error message. These landed independently on CI, and thus why we didn't catch it.
