### PR TITLE
Clean up annotations

### DIFF
--- a/android/autodispose-android-archcomponents-kotlin/consumer-proguard-rules.txt
+++ b/android/autodispose-android-archcomponents-kotlin/consumer-proguard-rules.txt
@@ -1,0 +1,1 @@
+-dontwarn org.jetbrains.annotations.**

--- a/android/autodispose-android-archcomponents-kotlin/consumer-proguard-rules.txt
+++ b/android/autodispose-android-archcomponents-kotlin/consumer-proguard-rules.txt
@@ -1,2 +1,0 @@
--dontwarn com.uber.javaxextras.**
--dontwarn com.google.errorprone.annotations.**

--- a/android/autodispose-android-archcomponents-test-kotlin/consumer-proguard-rules.txt
+++ b/android/autodispose-android-archcomponents-test-kotlin/consumer-proguard-rules.txt
@@ -1,0 +1,1 @@
+-dontwarn org.jetbrains.annotations.**

--- a/android/autodispose-android-archcomponents-test-kotlin/consumer-proguard-rules.txt
+++ b/android/autodispose-android-archcomponents-test-kotlin/consumer-proguard-rules.txt
@@ -1,2 +1,0 @@
--dontwarn com.uber.javaxextras.**
--dontwarn com.google.errorprone.annotations.**

--- a/android/autodispose-android-archcomponents-test/build.gradle
+++ b/android/autodispose-android-archcomponents-test/build.gradle
@@ -44,9 +44,6 @@ dependencies {
   api deps.support.arch.lifecycle.common
   api deps.support.arch.lifecycle.runtime
 
-  compileOnly deps.misc.errorProneAnnotations
-  compileOnly deps.misc.javaxExtras
-
   errorprone deps.build.errorProne
 }
 

--- a/android/autodispose-android-archcomponents-test/consumer-proguard-rules.txt
+++ b/android/autodispose-android-archcomponents-test/consumer-proguard-rules.txt
@@ -1,0 +1,1 @@
+-dontwarn org.jetbrains.annotations.**

--- a/android/autodispose-android-archcomponents-test/consumer-proguard-rules.txt
+++ b/android/autodispose-android-archcomponents-test/consumer-proguard-rules.txt
@@ -1,2 +1,0 @@
--dontwarn com.uber.javaxextras.**
--dontwarn com.google.errorprone.annotations.**

--- a/android/autodispose-android-archcomponents/build.gradle
+++ b/android/autodispose-android-archcomponents/build.gradle
@@ -55,9 +55,6 @@ dependencies {
   implementation project(':android:autodispose-android')
   implementation deps.rx.android
 
-  compileOnly deps.misc.errorProneAnnotations
-  compileOnly deps.misc.javaxExtras
-
   errorprone deps.build.errorProne
 
   androidTestImplementation project(':android:autodispose-android-archcomponents-test')

--- a/android/autodispose-android-archcomponents/consumer-proguard-rules.txt
+++ b/android/autodispose-android-archcomponents/consumer-proguard-rules.txt
@@ -1,1 +1,2 @@
+-dontwarn org.jetbrains.annotations.**
 -keep class * implements android.arch.lifecycle.GeneratedAdapter {<init>(...);}

--- a/android/autodispose-android-archcomponents/consumer-proguard-rules.txt
+++ b/android/autodispose-android-archcomponents/consumer-proguard-rules.txt
@@ -1,3 +1,1 @@
--dontwarn com.uber.javaxextras.**
--dontwarn com.google.errorprone.annotations.**
 -keep class * implements android.arch.lifecycle.GeneratedAdapter {<init>(...);}

--- a/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/package-info.java
+++ b/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/package-info.java
@@ -17,6 +17,5 @@
 /**
  * Android Architecture Components extensions for AutoDispose.
  */
-@com.uber.javaxextras.FieldsMethodsAndParametersAreNonNullByDefault
 package com.uber.autodispose.android.lifecycle;
 

--- a/android/autodispose-android-kotlin/consumer-proguard-rules.txt
+++ b/android/autodispose-android-kotlin/consumer-proguard-rules.txt
@@ -1,0 +1,1 @@
+-dontwarn org.jetbrains.annotations.**

--- a/android/autodispose-android-kotlin/consumer-proguard-rules.txt
+++ b/android/autodispose-android-kotlin/consumer-proguard-rules.txt
@@ -1,2 +1,0 @@
--dontwarn com.uber.javaxextras.**
--dontwarn com.google.errorprone.annotations.**

--- a/android/autodispose-android/build.gradle
+++ b/android/autodispose-android/build.gradle
@@ -48,9 +48,6 @@ dependencies {
   api deps.support.annotations
   implementation deps.rx.android
 
-  compileOnly deps.misc.errorProneAnnotations
-  compileOnly deps.misc.javaxExtras
-
   errorprone deps.build.errorProne
 
   testImplementation project(':test-utils')

--- a/android/autodispose-android/consumer-proguard-rules.txt
+++ b/android/autodispose-android/consumer-proguard-rules.txt
@@ -1,0 +1,1 @@
+-dontwarn org.jetbrains.annotations.**

--- a/android/autodispose-android/consumer-proguard-rules.txt
+++ b/android/autodispose-android/consumer-proguard-rules.txt
@@ -1,2 +1,0 @@
--dontwarn com.uber.javaxextras.**
--dontwarn com.google.errorprone.annotations.**

--- a/android/autodispose-android/src/main/java/com/uber/autodispose/android/package-info.java
+++ b/android/autodispose-android/src/main/java/com/uber/autodispose/android/package-info.java
@@ -17,6 +17,5 @@
 /**
  * Android components for AutoDispose.
  */
-@com.uber.javaxextras.FieldsMethodsAndParametersAreNonNullByDefault
 package com.uber.autodispose.android;
 

--- a/autodispose-rxlifecycle/build.gradle
+++ b/autodispose-rxlifecycle/build.gradle
@@ -32,8 +32,6 @@ dependencies {
 
     api project(':autodispose')
     api deps.misc.rxlifecycle
-    compileOnly deps.misc.errorProneAnnotations
-    compileOnly deps.misc.javaxExtras
 
     errorprone deps.build.errorProne
 

--- a/autodispose-rxlifecycle/src/main/java/com/ubercab/autodispose/rxlifecycle/package-info.java
+++ b/autodispose-rxlifecycle/src/main/java/com/ubercab/autodispose/rxlifecycle/package-info.java
@@ -18,6 +18,5 @@
  * AutoDispose extensions for interop with RxLifecycle. This namely supports
  * {@link com.trello.rxlifecycle2.LifecycleProvider}.
  */
-@com.uber.javaxextras.FieldsMethodsAndParametersAreNonNullByDefault
 package com.ubercab.autodispose.rxlifecycle;
 

--- a/autodispose/build.gradle
+++ b/autodispose/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 
   api deps.rx.java
 
+  compileOnly deps.misc.jetbrainsAnnotations
+
   errorprone deps.build.errorProne
 
   testCompile project(':test-utils')

--- a/autodispose/build.gradle
+++ b/autodispose/build.gradle
@@ -31,8 +31,6 @@ dependencies {
   testAnnotationProcessor deps.build.nullAway
 
   api deps.rx.java
-  compileOnly deps.misc.errorProneAnnotations
-  compileOnly deps.misc.javaxExtras
 
   errorprone deps.build.errorProne
 

--- a/autodispose/src/main/java/com/uber/autodispose/AtomicThrowable.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AtomicThrowable.java
@@ -18,7 +18,7 @@
 package com.uber.autodispose;
 
 import java.util.concurrent.atomic.AtomicReference;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Atomic container for Throwables including combining and having a

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
@@ -17,7 +17,7 @@
 package com.uber.autodispose;
 
 import io.reactivex.functions.Consumer;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Utility class to inject handlers to certain standard AutoDispose operations.

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposeUtil.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposeUtil.java
@@ -16,7 +16,7 @@
 
 package com.uber.autodispose;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 final class AutoDisposeUtil {
 

--- a/autodispose/src/main/java/com/uber/autodispose/AutoSubscriptionHelper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoSubscriptionHelper.java
@@ -19,7 +19,7 @@ package com.uber.autodispose;
 import io.reactivex.plugins.RxJavaPlugins;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import org.reactivestreams.Subscription;
 
 /**

--- a/autodispose/src/main/java/com/uber/autodispose/DoNotMock.java
+++ b/autodispose/src/main/java/com/uber/autodispose/DoNotMock.java
@@ -1,0 +1,27 @@
+package com.uber.autodispose;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation indicates that a given type should not be mocked. This is a copy of what was in
+ * Error-Prone's annotations artifact before it was removed, but left for documentation purposes.
+ * <p>
+ * This has been modified to have CLASS retention and is only applicable to TYPE targets.
+ */
+@Inherited
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+@interface DoNotMock {
+  /**
+   * The reason why the annotated type should not be mocked.
+   *
+   * <p>This should suggest alternative APIs to use for testing objects of this type.
+   */
+  String value() default "Create a real instance instead";
+}

--- a/autodispose/src/main/java/com/uber/autodispose/ExceptionHelper.java
+++ b/autodispose/src/main/java/com/uber/autodispose/ExceptionHelper.java
@@ -19,7 +19,7 @@ package com.uber.autodispose;
 
 import io.reactivex.exceptions.CompositeException;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Terminal atomics for Throwable containers.

--- a/autodispose/src/main/java/com/uber/autodispose/LifecycleScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/LifecycleScopeProvider.java
@@ -16,7 +16,6 @@
 
 package com.uber.autodispose;
 
-import com.google.errorprone.annotations.DoNotMock;
 import io.reactivex.Observable;
 import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.functions.Function;

--- a/autodispose/src/main/java/com/uber/autodispose/LifecycleScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/LifecycleScopeProvider.java
@@ -19,7 +19,7 @@ package com.uber.autodispose;
 import io.reactivex.Observable;
 import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.functions.Function;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * An interface that, when implemented, provides information to AutoDispose to allow it to resolve

--- a/autodispose/src/main/java/com/uber/autodispose/ScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/ScopeProvider.java
@@ -16,7 +16,6 @@
 
 package com.uber.autodispose;
 
-import com.google.errorprone.annotations.DoNotMock;
 import io.reactivex.Maybe;
 import io.reactivex.annotations.CheckReturnValue;
 

--- a/autodispose/src/main/java/com/uber/autodispose/TestLifecycleScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/TestLifecycleScopeProvider.java
@@ -19,7 +19,7 @@ package com.uber.autodispose;
 import io.reactivex.Observable;
 import io.reactivex.functions.Function;
 import io.reactivex.subjects.BehaviorSubject;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Test utility to create {@link LifecycleScopeProvider} instances for tests.

--- a/autodispose/src/main/java/com/uber/autodispose/observers/package-info.java
+++ b/autodispose/src/main/java/com/uber/autodispose/observers/package-info.java
@@ -18,6 +18,5 @@
  * These are Observers AutoDispose uses when scoping an observable. They are exposed as a public API
  *  to allow for consumers to watch for them if they want, such as in RxJava plugins.
  */
-@com.uber.javaxextras.FieldsMethodsAndParametersAreNonNullByDefault
 package com.uber.autodispose.observers;
 

--- a/autodispose/src/main/java/com/uber/autodispose/package-info.java
+++ b/autodispose/src/main/java/com/uber/autodispose/package-info.java
@@ -17,7 +17,22 @@
 /**
  * AutoDispose is an RxJava 2 tool for automatically binding the execution of RxJava 2 streams to a
  * provided scope via disposal/cancellation.
+ * <p>
+ * The idea is simple: construct your chain like any other, and then at subscription you simply
+ * drop in the relevant factory call + method for that type as a converter. In everyday use, it
+ * usually looks like this:
+ * <p>
+ * <code><pre>
+ *   myObservable
+ *     .doStuff()
+ *     .as(autoDisposable(this))   // <-- AutoDispose
+ *     .subscribe(s -> ...);
+ * </pre></code>
+ * <p>
+ * By doing this, you will automatically unsubscribe from myObservable as indicated by your scope
+ * - this helps prevent many classes of errors when an observable emits and item, but the actions
+ * taken in the subscription are no longer valid. For instance, if a network request comes back
+ * after a UI has already been torn down, the UI can't be updated - this pattern prevents this type
+ * of bug.
  */
-@com.uber.javaxextras.FieldsMethodsAndParametersAreNonNullByDefault
 package com.uber.autodispose;
-

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -93,9 +93,6 @@
     <module name="LineLength">
       <property name="max" value="100"/>
     </module>
-    <module name="MethodLength">
-      <property name="max" value="180"/>
-    </module>
 
     <!-- Indentation -->
     <module name="Indentation">

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -54,9 +54,6 @@ def kotlin = [
 ]
 
 def misc = [
-    errorProneAnnotations: "com.google.errorprone:error_prone_annotations:${versions.errorProne}",
-    javaxExtras: "com.uber.javaxextras:javax-extras:0.1.0",
-    jsr305: 'com.google.code.findbugs:jsr305:3.0.2',
     rxlifecycle: 'com.trello.rxlifecycle2:rxlifecycle:2.2.1'
 ]
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -54,6 +54,7 @@ def kotlin = [
 ]
 
 def misc = [
+    jetbrainsAnnotations: 'org.jetbrains:annotations:13.0',
     rxlifecycle: 'com.trello.rxlifecycle2:rxlifecycle:2.2.1'
 ]
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -38,7 +38,6 @@ android {
 }
 
 dependencies {
-  compileOnly deps.misc.javaxExtras
   implementation project(':android:autodispose-android')
   implementation project(':android:autodispose-android-archcomponents')
   implementation project(':autodispose')

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -38,6 +38,8 @@ android {
 }
 
 dependencies {
+  compileOnly deps.misc.jetbrainsAnnotations
+
   implementation project(':android:autodispose-android')
   implementation project(':android:autodispose-android-archcomponents')
   implementation project(':autodispose')

--- a/sample/src/main/java/com/uber/autodispose/recipes/AutoDisposeViewHolder.java
+++ b/sample/src/main/java/com/uber/autodispose/recipes/AutoDisposeViewHolder.java
@@ -22,7 +22,7 @@ import android.view.View;
 import com.uber.autodispose.LifecycleEndedException;
 import com.uber.autodispose.LifecycleScopeProvider;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import io.reactivex.Observable;
 import io.reactivex.functions.Function;

--- a/sample/src/main/java/com/uber/autodispose/recipes/package-info.java
+++ b/sample/src/main/java/com/uber/autodispose/recipes/package-info.java
@@ -17,6 +17,9 @@
 /**
  * Android recipes for AutoDispose.
  */
-@com.uber.javaxextras.FieldsMethodsAndParametersAreNonNullByDefault
+
+/**
+ * Recipes for AutoDispose.
+ */
 package com.uber.autodispose.recipes;
 

--- a/sample/src/main/java/com/uber/autodispose/sample/package-info.java
+++ b/sample/src/main/java/com/uber/autodispose/sample/package-info.java
@@ -17,6 +17,9 @@
 /**
  * Android recipes for AutoDispose.
  */
-@com.uber.javaxextras.FieldsMethodsAndParametersAreNonNullByDefault
+
+/**
+ * Sample app for AutoDispose.
+ */
 package com.uber.autodispose.sample;
 

--- a/static-analysis/autodispose-error-prone-checker/build.gradle
+++ b/static-analysis/autodispose-error-prone-checker/build.gradle
@@ -30,6 +30,7 @@ dependencies {
   compileOnly deps.apt.autoService
   compileOnly deps.build.errorProneCheckApi
 
+  testImplementation deps.misc.jetbrainsAnnotations
   testImplementation(deps.build.errorProneTestHelpers) {
     exclude group: "junit", module: "junit"
   }

--- a/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/error/prone/checker/UseAutoDisposeDefaultClassPositiveCases.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/error/prone/checker/UseAutoDisposeDefaultClassPositiveCases.java
@@ -28,7 +28,7 @@ import io.reactivex.Single;
 import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.functions.Function;
 import io.reactivex.subjects.BehaviorSubject;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 /**

--- a/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/error/prone/checker/UseAutoDisposeNegativeCases.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/error/prone/checker/UseAutoDisposeNegativeCases.java
@@ -29,7 +29,7 @@ import io.reactivex.Single;
 import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.functions.Function;
 import io.reactivex.subjects.BehaviorSubject;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 /**

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -23,7 +23,6 @@ sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
-  compileOnly deps.misc.errorProneAnnotations
   errorprone deps.build.errorProne
   api deps.rx.java
   api deps.test.junit


### PR DESCRIPTION
This cleans up a few annotations areas for a few reasons.

- Switch to internal `DoNotMock` annotation, as error-prone removed theirs. We're leaving in our own annotation for documentation purposes and any custom error prone checks that still look for annotations with this name.
- Remove javaxextras for compatibility with the Java 9 module system, which unfortunately JSR 305 is not compatible with.
- Remove stale jsr305 dependency.