### PR TITLE
Switch to errorprone-javacplugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ android:
     - platform-tools
 
 jdk:
-  - oraclejdk9
+  - oraclejdk10
 
 before_install:
   # Install SDK license so Android Gradle plugin can install deps.

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ android:
     - platform-tools
 
 jdk:
-  - oraclejdk8
+  - oraclejdk9
 
 before_install:
   # Install SDK license so Android Gradle plugin can install deps.

--- a/android/autodispose-android-archcomponents-test/build.gradle
+++ b/android/autodispose-android-archcomponents-test/build.gradle
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import net.ltgt.gradle.errorprone.javacplugin.CheckSeverity
+
 plugins {
   id 'com.android.library'
-  id 'net.ltgt.errorprone'
+  id 'net.ltgt.errorprone-javacplugin'
 }
 
 android {
@@ -47,10 +49,14 @@ dependencies {
   errorprone deps.build.errorProne
 }
 
-tasks.withType(JavaCompile) {
-  options.compilerArgs += ["-Xep:NullAway:ERROR",
-                           "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                           "-Xep:RestrictTo:OFF"]
+afterEvaluate {
+  tasks.withType(JavaCompile) {
+    options.errorprone {
+      option("NullAway:AnnotatedPackages", "com.uber")
+      check("NullAway", CheckSeverity.ERROR)
+      check("RestrictTo", CheckSeverity.OFF)
+    }
+  }
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/android/autodispose-android-archcomponents/build.gradle
+++ b/android/autodispose-android-archcomponents/build.gradle
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import net.ltgt.gradle.errorprone.javacplugin.CheckSeverity
+
 plugins {
   id 'com.android.library'
-  id 'net.ltgt.errorprone'
+  id 'net.ltgt.errorprone-javacplugin'
 }
 
 android {
@@ -64,10 +66,15 @@ dependencies {
   androidTestUtil deps.test.androidOrchestrator
 }
 
-tasks.withType(JavaCompile) {
-  options.compilerArgs += ["-Xep:NullAway:ERROR",
-                           "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                           "-Xep:RestrictTo:OFF"]
+afterEvaluate {
+  tasks.withType(JavaCompile) {
+    options.errorprone {
+      disableWarningsInGeneratedCode = true
+      option("NullAway:AnnotatedPackages", "com.uber")
+      check("NullAway", CheckSeverity.ERROR)
+      check("RestrictTo", CheckSeverity.OFF)
+    }
+  }
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/android/autodispose-android/build.gradle
+++ b/android/autodispose-android/build.gradle
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import net.ltgt.gradle.errorprone.javacplugin.CheckSeverity
+
 plugins {
   id 'com.android.library'
-  id 'net.ltgt.errorprone'
+  id 'net.ltgt.errorprone-javacplugin'
 }
 
 android {
@@ -60,10 +62,14 @@ dependencies {
   androidTestUtil deps.test.androidOrchestrator
 }
 
-tasks.withType(JavaCompile) {
-  options.compilerArgs += ["-Xep:NullAway:ERROR",
-                           "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                           "-Xep:RestrictTo:OFF"]
+afterEvaluate {
+  tasks.withType(JavaCompile) {
+    options.errorprone {
+      option("NullAway:AnnotatedPackages", "com.uber")
+      check("NullAway", CheckSeverity.ERROR)
+      check("RestrictTo", CheckSeverity.OFF)
+    }
+  }
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/autodispose-rxlifecycle/build.gradle
+++ b/autodispose-rxlifecycle/build.gradle
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import net.ltgt.gradle.errorprone.javacplugin.CheckSeverity
+
 plugins {
     id 'java-library'
-    id 'net.ltgt.errorprone'
+    id 'net.ltgt.errorprone-javacplugin'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_7
@@ -39,7 +41,10 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs += ["-Xep:NullAway:ERROR", "-XepOpt:NullAway:AnnotatedPackages=com.uber"]
+    options.errorprone {
+        option("NullAway:AnnotatedPackages", "com.uber")
+        check("NullAway", CheckSeverity.ERROR)
+    }
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/autodispose/build.gradle
+++ b/autodispose/build.gradle
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import net.ltgt.gradle.errorprone.javacplugin.CheckSeverity
+
 plugins {
   id 'java-library'
-  id 'net.ltgt.errorprone'
+  id 'net.ltgt.errorprone-javacplugin'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_7
@@ -40,7 +42,10 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-  options.compilerArgs += ["-Xep:NullAway:ERROR", "-XepOpt:NullAway:AnnotatedPackages=com.uber"]
+  options.errorprone {
+    option("NullAway:AnnotatedPackages", "com.uber")
+    check("NullAway", CheckSeverity.ERROR)
+  }
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,8 +19,8 @@ def versions = [
     archComponents: '1.1.0',
     archRuntime: '1.0.3',
     dokka: '0.9.17',
-    errorProne: '2.2.0',
-    errorPronePlugin: '0.0.13',
+    errorProne: '2.3.1',
+    errorPronePlugin: '0.2',
     kotlin: '1.2.21',
     support: '27.0.2'
 ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -39,7 +39,7 @@ def build = [
     errorProne: "com.google.errorprone:error_prone_core:${versions.errorProne}",
     errorProneCheckApi: "com.google.errorprone:error_prone_check_api:${versions.errorProne}",
     errorProneTestHelpers: "com.google.errorprone:error_prone_test_helpers:${versions.errorProne}",
-    nullAway: 'com.uber.nullaway:nullaway:0.3.2',
+    nullAway: 'com.uber.nullaway:nullaway:0.4.7',
 
     gradlePlugins: [
         android: 'com.android.tools.build:gradle:3.1.3',

--- a/settings.gradle
+++ b/settings.gradle
@@ -37,7 +37,7 @@ pluginManagement {
         case 'org.jetbrains.kotlin.android':
           useModule(deps.build.gradlePlugins.kotlin)
           break
-        case 'net.ltgt.errorprone':
+        case 'net.ltgt.errorprone-javacplugin':
           useVersion(deps.versions.errorPronePlugin)
           break
       }

--- a/static-analysis/autodispose-error-prone-checker/build.gradle
+++ b/static-analysis/autodispose-error-prone-checker/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import net.ltgt.gradle.errorprone.javacplugin.CheckSeverity
+
 plugins {
   id 'java-library'
   id 'net.ltgt.errorprone-javacplugin'
@@ -39,6 +41,13 @@ dependencies {
   testImplementation project(':autodispose')
 
   epJavac deps.build.errorProneCheckApi
+}
+
+tasks.withType(JavaCompile) {
+  options.errorprone {
+    option("NullAway:AnnotatedPackages", "com.uber")
+    check("NullAway", CheckSeverity.ERROR)
+  }
 }
 
 test {

--- a/static-analysis/autodispose-error-prone-checker/build.gradle
+++ b/static-analysis/autodispose-error-prone-checker/build.gradle
@@ -16,7 +16,7 @@
 
 plugins {
   id 'java-library'
-  id 'net.ltgt.errorprone'
+  id 'net.ltgt.errorprone-javacplugin'
 }
 
 // we use this config to get the path of the JDK 9 javac jar, to

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import net.ltgt.gradle.errorprone.javacplugin.CheckSeverity
+
 plugins {
   id 'java-library'
-  id 'net.ltgt.errorprone'
+  id 'net.ltgt.errorprone-javacplugin'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_7
@@ -27,4 +29,11 @@ dependencies {
   api deps.rx.java
   api deps.test.junit
   api deps.test.truth
+}
+
+tasks.withType(JavaCompile) {
+  options.errorprone {
+    option("NullAway:AnnotatedPackages", "com.uber")
+    check("NullAway", CheckSeverity.ERROR)
+  }
 }


### PR DESCRIPTION
Also opportunistically updates ErrorProne and NullAway to latest, as well as enabling nullaway on the static analysis artifact

Resolves #218