### PR TITLE
Add missing root project buildDir clean

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,10 @@ subprojects {
   }
 }
 
+task clean(type: Delete) {
+  delete rootProject.buildDir
+}
+
 task wrapper(type: Wrapper) {
   gradleVersion = '4.8.1'
   distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"


### PR DESCRIPTION
This is usually automatically added because root projects don't have clean tasks, but seems ours went missing. This is especially apparent when using the new doc publishing task, which hasn't been getting cleaned up
