### PR TITLE
Add MainThreadDisposable to allow disposing on the JVM

### DIFF
--- a/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/LifecycleEventsObservable.java
+++ b/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/LifecycleEventsObservable.java
@@ -23,9 +23,9 @@ import android.arch.lifecycle.LifecycleOwner;
 import android.arch.lifecycle.OnLifecycleEvent;
 import android.support.annotation.Nullable;
 import android.support.annotation.RestrictTo;
+import com.uber.autodispose.android.internal.MainThreadDisposable;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
-import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.subjects.BehaviorSubject;
 
 import static android.arch.lifecycle.Lifecycle.Event.ON_CREATE;

--- a/android/autodispose-android/src/main/java/com/uber/autodispose/android/internal/MainThreadDisposable.java
+++ b/android/autodispose-android/src/main/java/com/uber/autodispose/android/internal/MainThreadDisposable.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose.android.internal;
+
+import android.support.annotation.RestrictTo;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.Disposable;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
+
+/**
+ * Copy of the MainThreadDisposable from RxAndroid which makes use of the
+ * {@link AutoDisposeAndroidUtil} to check for main thread. This allows
+ * disposing on the JVM crashing due to the looper check.
+ */
+@RestrictTo(LIBRARY_GROUP)
+public abstract class MainThreadDisposable implements Disposable {
+  private final AtomicBoolean unsubscribed = new AtomicBoolean();
+
+  @Override
+  public final boolean isDisposed() {
+    return unsubscribed.get();
+  }
+
+  @Override
+  public final void dispose() {
+    if (unsubscribed.compareAndSet(false, true)) {
+      if (AutoDisposeAndroidUtil.isMainThread()) {
+        onDispose();
+      } else {
+        AndroidSchedulers.mainThread().scheduleDirect(new Runnable() {
+          @Override
+          public void run() {
+            onDispose();
+          }
+        });
+      }
+    }
+  }
+
+  protected abstract void onDispose();
+}

--- a/android/autodispose-android/src/test/java/com/uber/autodispose/android/internal/MainThreadDisposableTest.java
+++ b/android/autodispose-android/src/test/java/com/uber/autodispose/android/internal/MainThreadDisposableTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.autodispose.android.internal;
+
+import com.uber.autodispose.android.AutoDisposeAndroidPlugins;
+import io.reactivex.functions.BooleanSupplier;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertTrue;
+
+public final class MainThreadDisposableTest {
+
+  @Test public void onDisposeRunsSyncWhenMainThreadSkipped() {
+    AutoDisposeAndroidPlugins.setOnCheckMainThread(new BooleanSupplier() {
+      @Override
+      public boolean getAsBoolean() {
+        return true;
+      }
+    });
+
+    final AtomicBoolean called = new AtomicBoolean();
+
+    new MainThreadDisposable() {
+      @Override
+      protected void onDispose() {
+        called.set(true);
+      }
+    }.dispose();
+
+    assertTrue(called.get());
+    AutoDisposeAndroidPlugins.setOnCheckMainThread(null);
+  }
+
+  @Test
+  public void onDisposeFailsWhenMainThreadCheckNotSet() {
+    try {
+      new MainThreadDisposable() {
+        @Override
+        protected void onDispose() { }
+      }.dispose();
+      throw new AssertionError("Expected to fail before this due to Looper not being stubbed!");
+    } catch (RuntimeException e) {
+      // "Method myLooper in android.os.Looper not mocked..."
+      // Not testing this exact message as it's an implementation detail of the test framework.
+    }
+  }
+}


### PR DESCRIPTION
**Description**:
Due to `LifecycleEventsObservable` extending the `MainThreadDisposable` from `RxAndroid` it was not possible to test disposing of a subscription on the JVM. 

`io.reactivex.android.MainThreadObservable` also contains a check `Looper.myLooper() == Looper.getMainLooper()` which will throw an exception in JVM tests.

Using a local copy of `MainThreadObservable` which utilizes the `AutoDisposeAndroidUtil.isMainThread()` you will get more consistent "main thread check" behavior.

The unit tests that are now included only test new behavior and not the rest of the behavior of `MainThreadObservable`. First wanted to copy over tests from rxandroid, but then saw that those are robolectric, which is not a dependency in this project.
