### PR TITLE
Make Android lifecycle extensions return ScopeProvider

### DIFF
--- a/android/autodispose-android-archcomponents-ktx/src/main/kotlin/com/uber/autodispose/android/lifecycle/AutoDisposeAndroidLifecycle.kt
+++ b/android/autodispose-android-archcomponents-ktx/src/main/kotlin/com/uber/autodispose/android/lifecycle/AutoDisposeAndroidLifecycle.kt
@@ -21,59 +21,59 @@ package com.uber.autodispose.android.lifecycle
 import android.arch.lifecycle.Lifecycle
 import android.arch.lifecycle.Lifecycle.Event
 import android.arch.lifecycle.LifecycleOwner
+import com.uber.autodispose.ScopeProvider
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction
-import com.uber.autodispose.lifecycle.LifecycleScopeProvider
 import io.reactivex.annotations.CheckReturnValue
 
 /**
- * Extension that returns a [LifecycleScopeProvider] for this [LifecycleOwner].
+ * Extension that returns a [ScopeProvider] for this [LifecycleOwner].
  */
 @CheckReturnValue
-inline fun LifecycleOwner.scope(): LifecycleScopeProvider<*> = AndroidLifecycleScopeProvider.from(
+inline fun LifecycleOwner.scope(): ScopeProvider = AndroidLifecycleScopeProvider.from(
     this)
 
 /**
- * Extension that returns a [LifecycleScopeProvider] for this [LifecycleOwner].
+ * Extension that returns a [ScopeProvider] for this [LifecycleOwner].
  *
  * @param untilEvent the event until the scope is valid.
  */
 @CheckReturnValue
 inline fun LifecycleOwner.scope(
-    untilEvent: Lifecycle.Event): LifecycleScopeProvider<*> = AndroidLifecycleScopeProvider.from(
+    untilEvent: Lifecycle.Event): ScopeProvider = AndroidLifecycleScopeProvider.from(
     this, untilEvent)
 
 /**
- * Extension that returns a [LifecycleScopeProvider] for this [LifecycleOwner].
+ * Extension that returns a [ScopeProvider] for this [LifecycleOwner].
  *
  * @param boundaryResolver function that resolves the event boundary.
  */
 @CheckReturnValue
 inline fun LifecycleOwner.scope(
-    boundaryResolver: CorrespondingEventsFunction<Event>): LifecycleScopeProvider<*> = AndroidLifecycleScopeProvider.from(
+    boundaryResolver: CorrespondingEventsFunction<Event>): ScopeProvider = AndroidLifecycleScopeProvider.from(
     this, boundaryResolver)
 
 /**
- * Extension that returns a [LifecycleScopeProvider] for this [Lifecycle].
+ * Extension that returns a [ScopeProvider] for this [Lifecycle].
  */
 @CheckReturnValue
-inline fun Lifecycle.scope(): LifecycleScopeProvider<*> = AndroidLifecycleScopeProvider.from(this)
+inline fun Lifecycle.scope(): ScopeProvider = AndroidLifecycleScopeProvider.from(this)
 
 /**
- * Extension that returns a [LifecycleScopeProvider] for this [Lifecycle].
+ * Extension that returns a [ScopeProvider] for this [Lifecycle].
  *
  * @param untilEvent the event until the scope is valid.
  */
 @CheckReturnValue
 inline fun Lifecycle.scope(
-    untilEvent: Lifecycle.Event): LifecycleScopeProvider<*> = AndroidLifecycleScopeProvider.from(
+    untilEvent: Lifecycle.Event): ScopeProvider = AndroidLifecycleScopeProvider.from(
     this, untilEvent)
 
 /**
- * Extension that returns a [LifecycleScopeProvider] for this [Lifecycle].
+ * Extension that returns a [ScopeProvider] for this [Lifecycle].
  *
  * @param boundaryResolver function that resolves the event boundary.
  */
 @CheckReturnValue
 inline fun Lifecycle.scope(
-    boundaryResolver: CorrespondingEventsFunction<Event>): LifecycleScopeProvider<*> = AndroidLifecycleScopeProvider.from(
+    boundaryResolver: CorrespondingEventsFunction<Event>): ScopeProvider = AndroidLifecycleScopeProvider.from(
     this, boundaryResolver)


### PR DESCRIPTION
<!--
Thank you for contributing to AutoDispose. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**: Make Android Lifecycle Extensions return `ScopeProvider`. 

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**: #239 

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
