### PR TITLE
Strawman implementation of custom overloads for different RxJava types

### DIFF
--- a/autodispose/src/test/java/com/uber/autodispose/OverloadsTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/OverloadsTest.java
@@ -1,0 +1,319 @@
+package com.uber.autodispose;
+
+import io.reactivex.functions.Predicate;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.processors.PublishProcessor;
+import io.reactivex.subjects.MaybeSubject;
+import io.reactivex.subjects.PublishSubject;
+import io.reactivex.subjects.SingleSubject;
+import io.reactivex.subscribers.TestSubscriber;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public final class OverloadsTest {
+
+  @Test
+  public void publisher_takeFirst() {
+    PublishProcessor<Integer> source = PublishProcessor.create();
+    PublishProcessor<Integer> scope = PublishProcessor.create();
+    TestSubscriber<Integer> o = source.as(AutoDispose.<Integer, Integer>autoDisposable(scope, true))
+        .test();
+    o.assertSubscribed();
+
+    assertThat(source.hasSubscribers()).isTrue();
+    assertThat(scope.hasSubscribers()).isTrue();
+
+    source.onNext(1);
+    o.assertValue(1);
+
+    scope.onNext(1);
+    source.onNext(2);
+
+    // No more events
+    o.assertValue(1);
+
+    // Unsubscribed
+    assertThat(source.hasSubscribers()).isFalse();
+    assertThat(scope.hasSubscribers()).isFalse();
+  }
+
+  @Test
+  public void publisher_predicate() {
+    PublishProcessor<Integer> source = PublishProcessor.create();
+    PublishProcessor<Integer> scope = PublishProcessor.create();
+    TestSubscriber<Integer> o = source.as(AutoDispose.<Integer, Integer>autoDisposable(scope,
+        new Predicate<Integer>() {
+          @Override public boolean test(Integer i) {
+            // Dispose when this emits 1
+            return i == 1;
+          }
+        }))
+        .test();
+    o.assertSubscribed();
+
+    assertThat(source.hasSubscribers()).isTrue();
+    assertThat(scope.hasSubscribers()).isTrue();
+
+    source.onNext(1);
+    o.assertValue(1);
+
+    scope.onNext(0);
+    source.onNext(2);
+    o.assertValues(1, 2);
+
+    scope.onNext(1);
+    source.onNext(3);
+
+    // No more events
+    o.assertValues(1, 2);
+
+    // Unsubscribed
+    assertThat(source.hasSubscribers()).isFalse();
+    assertThat(scope.hasSubscribers()).isFalse();
+  }
+
+  @Test
+  public void publisher_takeFirst_complete() {
+    PublishProcessor<Integer> source = PublishProcessor.create();
+    PublishProcessor<Integer> scope = PublishProcessor.create();
+    TestSubscriber<Integer> o = source.as(AutoDispose.<Integer, Integer>autoDisposable(scope, true))
+        .test();
+    o.assertSubscribed();
+
+    assertThat(source.hasSubscribers()).isTrue();
+    assertThat(scope.hasSubscribers()).isTrue();
+
+    source.onNext(1);
+    o.assertValue(1);
+
+    scope.onComplete();
+    source.onNext(2);
+
+    // No more events
+    o.assertValue(1);
+
+    // Unsubscribed
+    assertThat(source.hasSubscribers()).isFalse();
+    assertThat(scope.hasSubscribers()).isFalse();
+  }
+
+  @Test
+  public void publisher_predicate_complete() {
+    PublishProcessor<Integer> source = PublishProcessor.create();
+    PublishProcessor<Integer> scope = PublishProcessor.create();
+    TestSubscriber<Integer> o = source.as(AutoDispose.<Integer, Integer>autoDisposable(scope,
+        new Predicate<Integer>() {
+          @Override public boolean test(Integer i) {
+            // Dispose when this emits 1
+            return i == 1;
+          }
+        }))
+        .test();
+    o.assertSubscribed();
+
+    assertThat(source.hasSubscribers()).isTrue();
+    assertThat(scope.hasSubscribers()).isTrue();
+
+    source.onNext(1);
+    o.assertValue(1);
+
+    scope.onNext(0);
+    source.onNext(2);
+    o.assertValues(1, 2);
+
+    scope.onComplete();
+    source.onNext(3);
+
+    // No more events
+    o.assertValues(1, 2);
+
+    // Unsubscribed
+    assertThat(source.hasSubscribers()).isFalse();
+    assertThat(scope.hasSubscribers()).isFalse();
+  }
+
+  @Test
+  public void observable_takeFirst() {
+    PublishSubject<Integer> source = PublishSubject.create();
+    PublishSubject<Integer> scope = PublishSubject.create();
+    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(scope, true))
+        .test();
+    o.assertSubscribed();
+
+    assertThat(source.hasObservers()).isTrue();
+    assertThat(scope.hasObservers()).isTrue();
+
+    source.onNext(1);
+    o.assertValue(1);
+
+    scope.onNext(1);
+    source.onNext(2);
+
+    // No more events
+    o.assertValue(1);
+
+    // Unsubscribed
+    assertThat(source.hasObservers()).isFalse();
+    assertThat(scope.hasObservers()).isFalse();
+  }
+
+  @Test
+  public void observable_predicate() {
+    PublishSubject<Integer> source = PublishSubject.create();
+    PublishSubject<Integer> scope = PublishSubject.create();
+    TestObserver<Integer> o = source.as(AutoDispose.<Integer, Integer>autoDisposable(scope,
+        new Predicate<Integer>() {
+          @Override public boolean test(Integer i) {
+            // Dispose when this emits 1
+            return i == 1;
+          }
+        }))
+        .test();
+    o.assertSubscribed();
+
+    assertThat(source.hasObservers()).isTrue();
+    assertThat(scope.hasObservers()).isTrue();
+
+    source.onNext(1);
+    o.assertValue(1);
+
+    scope.onNext(0);
+    source.onNext(2);
+    o.assertValues(1, 2);
+
+    scope.onNext(1);
+    source.onNext(3);
+
+    // No more events
+    o.assertValues(1, 2);
+
+    // Unsubscribed
+    assertThat(source.hasObservers()).isFalse();
+    assertThat(scope.hasObservers()).isFalse();
+  }
+
+  @Test
+  public void observable_takeFirst_complete() {
+    PublishSubject<Integer> source = PublishSubject.create();
+    PublishSubject<Integer> scope = PublishSubject.create();
+    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(scope, true))
+        .test();
+    o.assertSubscribed();
+
+    assertThat(source.hasObservers()).isTrue();
+    assertThat(scope.hasObservers()).isTrue();
+
+    source.onNext(1);
+    o.assertValue(1);
+
+    scope.onComplete();
+    source.onNext(2);
+
+    // No more events
+    o.assertValue(1);
+
+    // Unsubscribed
+    assertThat(source.hasObservers()).isFalse();
+    assertThat(scope.hasObservers()).isFalse();
+  }
+
+  @Test
+  public void observable_predicate_complete() {
+    PublishSubject<Integer> source = PublishSubject.create();
+    PublishSubject<Integer> scope = PublishSubject.create();
+    TestObserver<Integer> o = source.as(AutoDispose.<Integer, Integer>autoDisposable(scope,
+        new Predicate<Integer>() {
+          @Override public boolean test(Integer i) {
+            // Dispose when this emits 1
+            return i == 1;
+          }
+        }))
+        .test();
+    o.assertSubscribed();
+
+    assertThat(source.hasObservers()).isTrue();
+    assertThat(scope.hasObservers()).isTrue();
+
+    source.onNext(1);
+    o.assertValue(1);
+
+    scope.onNext(0);
+    source.onNext(2);
+    o.assertValues(1, 2);
+
+    scope.onComplete();
+    source.onNext(3);
+
+    // No more events
+    o.assertValues(1, 2);
+
+    // Unsubscribed
+    assertThat(source.hasObservers()).isFalse();
+    assertThat(scope.hasObservers()).isFalse();
+  }
+
+  @Test
+  public void single() {
+    SingleSubject<Integer> source = SingleSubject.create();
+    SingleSubject<Integer> scope = SingleSubject.create();
+    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(scope))
+        .test();
+    o.assertSubscribed();
+
+    assertThat(source.hasObservers()).isTrue();
+    assertThat(scope.hasObservers()).isTrue();
+
+    scope.onSuccess(1);
+
+    // No more events
+    o.assertNoValues();
+
+    // Unsubscribed
+    assertThat(source.hasObservers()).isFalse();
+    assertThat(scope.hasObservers()).isFalse();
+  }
+
+  @Test
+  public void maybe() {
+    MaybeSubject<Integer> source = MaybeSubject.create();
+    MaybeSubject<Integer> scope = MaybeSubject.create();
+    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(scope))
+        .test();
+    o.assertSubscribed();
+
+    assertThat(source.hasObservers()).isTrue();
+    assertThat(scope.hasObservers()).isTrue();
+
+    scope.onSuccess(1);
+
+    // No more events
+    o.assertNoValues();
+
+    // Unsubscribed
+    assertThat(source.hasObservers()).isFalse();
+    assertThat(scope.hasObservers()).isFalse();
+  }
+
+  @Test
+  public void maybe_complete() {
+    MaybeSubject<Integer> source = MaybeSubject.create();
+    MaybeSubject<Integer> scope = MaybeSubject.create();
+    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(scope))
+        .test();
+    o.assertSubscribed();
+
+    assertThat(source.hasObservers()).isTrue();
+    assertThat(scope.hasObservers()).isTrue();
+
+    scope.onComplete();
+
+    // No more events
+    o.assertNoValues();
+
+    // Unsubscribed
+    assertThat(source.hasObservers()).isFalse();
+    assertThat(scope.hasObservers()).isFalse();
+  }
+
+}


### PR DESCRIPTION
This demos overloads for accepting RxJava's other types and funneling them to the usual `Completable` factory. There's a few considerations to take here from an API design perspective:

- `Single` and `Maybe` are straight forward, basically shortcut to `ignoreElement()`.
- `Observable` and `Flowable/Publisher` get a bit weirder. There are three overloads for each:
  - Single source argument, basically a shorthand to `ignoreElements()`
  - Source + `takeFirst` boolean, basically shortcut to `take(1).ignoreElements()`
    - There are two variants of this, one that actually calls `take(1)` and has a single type argument, and the other passes through to the `takeUntil` overload but requires a second type argument for the source (more verbose).
  - Source + `takeUntil` `Predicate`, basically shortcut to `takeUntil(predicate)`
    - Requires a second type argument for the source (more verbose).
  - Should the extra parameter overloads be in the public API at all? If so, should we use `take(1)` for the `takeFirst` overload to simplify type arguments in that case?
- Should these be in the top level API at all? Should they maybe be in a `Scopes` factory utility class with better names, like `maybeScope`/`singleScope`/etc?

Not sure about this as a 1.0 goal, but could consider it. This is meant to be a discussion/proposal PR for now.