### PR TITLE
Skip android setup and just rely on sdkmanager for more incremental CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,12 @@
 language: android
 
-android:
-  components:
-  # Update tools and then platform-tools explicitly so lint gets an updated database. Can be removed once 3.0 is out.
-  - tools
-  - platform-tools
-
 jdk:
 - oraclejdk8
 
 before_install:
 # Install SDK license so Android Gradle plugin can install deps.
 - mkdir "$ANDROID_HOME/licenses" || true
-- echo "$LICENSES_HASH" > "$ANDROID_HOME/licenses/android-sdk-license"
-- echo "$LICENSES_HASH_TWO" >> "$ANDROID_HOME/licenses/android-sdk-license"
+- echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
 # Install the rest of tools (e.g., avdmanager)
 - sdkmanager tools
 # Install the system image


### PR DESCRIPTION
Borrowing from https://github.com/JakeWharton/RxBinding/blob/master/.travis.yml#L7-L9 and discussion here: https://github.com/square/leakcanary/pull/1090#discussion_r212045519

Maybe helps with #220
