### PR TITLE
Add requestScope() to samples

### DIFF
--- a/sample/src/main/java/com/uber/autodispose/recipes/AutoDisposeActivity.java
+++ b/sample/src/main/java/com/uber/autodispose/recipes/AutoDisposeActivity.java
@@ -22,6 +22,8 @@ import android.support.annotation.Nullable;
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction;
 import com.uber.autodispose.lifecycle.LifecycleEndedException;
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider;
+import com.uber.autodispose.lifecycle.LifecycleScopes;
+import io.reactivex.CompletableSource;
 import io.reactivex.Observable;
 import io.reactivex.subjects.BehaviorSubject;
 
@@ -72,6 +74,10 @@ public abstract class AutoDisposeActivity extends Activity
 
   @Nullable @Override public ActivityEvent peekLifecycle() {
     return lifecycleEvents.getValue();
+  }
+
+  @Override public CompletableSource requestScope() {
+    return LifecycleScopes.resolveScopeFromLifecycle(this);
   }
 
   @Override protected void onCreate(@Nullable Bundle savedInstanceState) {

--- a/sample/src/main/java/com/uber/autodispose/recipes/AutoDisposeFragment.java
+++ b/sample/src/main/java/com/uber/autodispose/recipes/AutoDisposeFragment.java
@@ -24,6 +24,8 @@ import android.view.View;
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction;
 import com.uber.autodispose.lifecycle.LifecycleEndedException;
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider;
+import com.uber.autodispose.lifecycle.LifecycleScopes;
+import io.reactivex.CompletableSource;
 import io.reactivex.Observable;
 import io.reactivex.subjects.BehaviorSubject;
 
@@ -82,6 +84,10 @@ public abstract class AutoDisposeFragment extends Fragment
 
   @Nullable @Override public FragmentEvent peekLifecycle() {
     return lifecycleEvents.getValue();
+  }
+
+  @Override public CompletableSource requestScope() {
+    return LifecycleScopes.resolveScopeFromLifecycle(this);
   }
 
   @Override public void onAttach(Context context) {

--- a/sample/src/main/java/com/uber/autodispose/recipes/AutoDisposeView.java
+++ b/sample/src/main/java/com/uber/autodispose/recipes/AutoDisposeView.java
@@ -26,6 +26,8 @@ import com.uber.autodispose.android.ViewScopeProvider;
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction;
 import com.uber.autodispose.lifecycle.LifecycleEndedException;
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider;
+import com.uber.autodispose.lifecycle.LifecycleScopes;
+import io.reactivex.CompletableSource;
 import io.reactivex.Observable;
 import io.reactivex.subjects.BehaviorSubject;
 
@@ -108,5 +110,9 @@ public abstract class AutoDisposeView extends View implements LifecycleScopeProv
   @Nullable @Override public ViewEvent peekLifecycle() {
     //noinspection ConstantConditions only in layoutlib
     return lifecycleEvents.getValue();
+  }
+
+  @Override public CompletableSource requestScope() {
+    return LifecycleScopes.resolveScopeFromLifecycle(this);
   }
 }

--- a/sample/src/main/java/com/uber/autodispose/recipes/AutoDisposeViewHolder.java
+++ b/sample/src/main/java/com/uber/autodispose/recipes/AutoDisposeViewHolder.java
@@ -21,6 +21,8 @@ import android.view.View;
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction;
 import com.uber.autodispose.lifecycle.LifecycleEndedException;
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider;
+import com.uber.autodispose.lifecycle.LifecycleScopes;
+import io.reactivex.CompletableSource;
 import io.reactivex.Observable;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.subjects.BehaviorSubject;
@@ -63,6 +65,10 @@ public abstract class AutoDisposeViewHolder extends BindAwareViewHolder
 
   @Nullable @Override public ViewHolderEvent peekLifecycle() {
     return lifecycleEvents.getValue();
+  }
+
+  @Override public CompletableSource requestScope() {
+    return LifecycleScopes.resolveScopeFromLifecycle(this);
   }
 
   @Override protected void onBind() {

--- a/sample/src/main/kotlin/com/uber/autodispose/recipes/AutoDisposeActivityKotlin.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/recipes/AutoDisposeActivityKotlin.kt
@@ -21,6 +21,7 @@ import android.os.Bundle
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction
 import com.uber.autodispose.lifecycle.LifecycleEndedException
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider
+import com.uber.autodispose.lifecycle.LifecycleScopes
 import com.uber.autodispose.recipes.AutoDisposeActivityKotlin.ActivityEvent
 import com.uber.autodispose.recipes.AutoDisposeActivityKotlin.ActivityEvent.CREATE
 import com.uber.autodispose.recipes.AutoDisposeActivityKotlin.ActivityEvent.DESTROY
@@ -28,6 +29,7 @@ import com.uber.autodispose.recipes.AutoDisposeActivityKotlin.ActivityEvent.PAUS
 import com.uber.autodispose.recipes.AutoDisposeActivityKotlin.ActivityEvent.RESUME
 import com.uber.autodispose.recipes.AutoDisposeActivityKotlin.ActivityEvent.START
 import com.uber.autodispose.recipes.AutoDisposeActivityKotlin.ActivityEvent.STOP
+import io.reactivex.CompletableSource
 import io.reactivex.Observable
 import io.reactivex.subjects.BehaviorSubject
 
@@ -55,7 +57,7 @@ abstract class AutoDisposeActivityKotlin : Activity(), LifecycleScopeProvider<Ac
     return lifecycleEvents.value
   }
 
-  override fun onCreate(savedInstanceState: Bundle) {
+  override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     lifecycleEvents.onNext(ActivityEvent.CREATE)
   }
@@ -78,6 +80,10 @@ abstract class AutoDisposeActivityKotlin : Activity(), LifecycleScopeProvider<Ac
   override fun onStop() {
     lifecycleEvents.onNext(ActivityEvent.STOP)
     super.onStop()
+  }
+
+  override fun requestScope(): CompletableSource {
+    return LifecycleScopes.resolveScopeFromLifecycle(this)
   }
 
   override fun onDestroy() {

--- a/sample/src/main/kotlin/com/uber/autodispose/recipes/AutoDisposeFragmentKotlin.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/recipes/AutoDisposeFragmentKotlin.kt
@@ -23,6 +23,7 @@ import android.view.View
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction
 import com.uber.autodispose.lifecycle.LifecycleEndedException
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider
+import com.uber.autodispose.lifecycle.LifecycleScopes
 import com.uber.autodispose.recipes.AutoDisposeFragmentKotlin.FragmentEvent
 import com.uber.autodispose.recipes.AutoDisposeFragmentKotlin.FragmentEvent.ATTACH
 import com.uber.autodispose.recipes.AutoDisposeFragmentKotlin.FragmentEvent.CREATE
@@ -34,6 +35,7 @@ import com.uber.autodispose.recipes.AutoDisposeFragmentKotlin.FragmentEvent.PAUS
 import com.uber.autodispose.recipes.AutoDisposeFragmentKotlin.FragmentEvent.RESUME
 import com.uber.autodispose.recipes.AutoDisposeFragmentKotlin.FragmentEvent.START
 import com.uber.autodispose.recipes.AutoDisposeFragmentKotlin.FragmentEvent.STOP
+import io.reactivex.CompletableSource
 import io.reactivex.Observable
 import io.reactivex.subjects.BehaviorSubject
 
@@ -59,6 +61,10 @@ abstract class AutoDisposeFragmentKotlin : Fragment(), LifecycleScopeProvider<Fr
 
   override fun peekLifecycle(): FragmentEvent? {
     return lifecycleEvents.value
+  }
+
+  override fun requestScope(): CompletableSource {
+    return LifecycleScopes.resolveScopeFromLifecycle(this)
   }
 
   override fun onAttach(context: Context) {

--- a/sample/src/main/kotlin/com/uber/autodispose/recipes/AutoDisposeViewHolderKotlin.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/recipes/AutoDisposeViewHolderKotlin.kt
@@ -21,9 +21,11 @@ import android.view.View
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction
 import com.uber.autodispose.lifecycle.LifecycleEndedException
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider
+import com.uber.autodispose.lifecycle.LifecycleScopes
 import com.uber.autodispose.recipes.AutoDisposeViewHolderKotlin.ViewHolderEvent
 import com.uber.autodispose.recipes.AutoDisposeViewHolderKotlin.ViewHolderEvent.BIND
 import com.uber.autodispose.recipes.AutoDisposeViewHolderKotlin.ViewHolderEvent.UNBIND
+import io.reactivex.CompletableSource
 import io.reactivex.Observable
 import io.reactivex.subjects.BehaviorSubject
 
@@ -50,6 +52,10 @@ abstract class AutoDisposeViewHolderKotlin(itemView: View)
   override fun correspondingEvents(): CorrespondingEventsFunction<ViewHolderEvent> = CORRESPONDING_EVENTS
 
   override fun peekLifecycle(): ViewHolderEvent? = lifecycleEvents.value
+
+  override fun requestScope(): CompletableSource {
+    return LifecycleScopes.resolveScopeFromLifecycle(this)
+  }
 
   companion object {
 

--- a/sample/src/main/kotlin/com/uber/autodispose/recipes/AutoDisposeViewKotlin.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/recipes/AutoDisposeViewKotlin.kt
@@ -25,9 +25,11 @@ import com.uber.autodispose.android.ViewScopeProvider
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction
 import com.uber.autodispose.lifecycle.LifecycleEndedException
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider
+import com.uber.autodispose.lifecycle.LifecycleScopes
 import com.uber.autodispose.recipes.AutoDisposeViewKotlin.ViewEvent
 import com.uber.autodispose.recipes.AutoDisposeViewKotlin.ViewEvent.ATTACH
 import com.uber.autodispose.recipes.AutoDisposeViewKotlin.ViewEvent.DETACH
+import io.reactivex.CompletableSource
 import io.reactivex.Observable
 import io.reactivex.subjects.BehaviorSubject
 
@@ -72,6 +74,10 @@ abstract class AutoDisposeViewKotlin : View, LifecycleScopeProvider<ViewEvent> {
 
   override fun peekLifecycle(): ViewEvent? {
     return lifecycleEvents.value
+  }
+
+  override fun requestScope(): CompletableSource {
+    return LifecycleScopes.resolveScopeFromLifecycle(this)
   }
 
   companion object {


### PR DESCRIPTION
<!--
Thank you for contributing to AutoDispose. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**: With the move to 1.0.0-RC*, LifecycleScopeProvider extends ScopeProvider and thus needs to implement `requestScope()`. Since these are abstract classes, this wasn't caught. This fixes it. 
