### PR TITLE
Add recipe for auto disposing ViewModel

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -42,6 +42,9 @@
         android:label="@string/title_activity_arch_component"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
     <activity
+        android:name=".DisposingViewModelActivity"
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
+    <activity
         android:name=".HomeActivity"
         android:label="@string/app_name"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar">

--- a/sample/src/main/kotlin/com/uber/autodispose/recipes/AutoDisposeViewModel.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/recipes/AutoDisposeViewModel.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose.recipes
+
+import android.arch.lifecycle.ViewModel
+import com.uber.autodispose.lifecycle.CorrespondingEventsFunction
+import com.uber.autodispose.lifecycle.LifecycleEndedException
+import com.uber.autodispose.lifecycle.LifecycleScopeProvider
+import com.uber.autodispose.lifecycle.LifecycleScopes
+import com.uber.autodispose.recipes.AutoDisposeViewModel.ViewModelEvent
+import com.uber.autodispose.recipes.AutoDisposeViewModel.ViewModelEvent.CREATED
+import io.reactivex.CompletableSource
+import io.reactivex.Observable
+import io.reactivex.subjects.BehaviorSubject
+
+/**
+ *
+ */
+abstract class AutoDisposeViewModel: ViewModel(), LifecycleScopeProvider<ViewModelEvent> {
+
+  // Subject backing the auto disposing of subscriptions.
+  private val lifecycleEvents = BehaviorSubject.createDefault(CREATED)
+
+  /**
+   * The events that represent the lifecycle of a [ViewModel].
+   *
+   * The [ViewModel] lifecycle is very simple. It is created
+   * and then allows you to clean up any resources in the
+   * [ViewModel.onCleared] method before it is destroyed.
+   */
+  enum class ViewModelEvent {
+    CREATED, CLEARED
+  }
+
+  /**
+   * The observable representing the lifecycle of the [ViewModel].
+   *
+   * @return [Observable] modelling the [ViewModel] lifecycle.
+   */
+  override fun lifecycle(): Observable<ViewModelEvent> {
+    return lifecycleEvents.hide()
+  }
+
+  /**
+   * Returns a [CorrespondingEventsFunction] that maps the
+   * current event -> target disposal event.
+   *
+   * @return function mapping the current event to terminal event.
+   */
+  override fun correspondingEvents(): CorrespondingEventsFunction<ViewModelEvent> {
+    return CORRESPONDING_EVENTS
+  }
+
+  override fun peekLifecycle(): ViewModelEvent? {
+    return lifecycleEvents.value
+  }
+
+  /**
+   * Emit the [ViewModelEvent.CLEARED] event to
+   * dispose off any subscriptions in the ViewModel.
+   */
+  override fun onCleared() {
+    lifecycleEvents.onNext(ViewModelEvent.CLEARED)
+    super.onCleared()
+  }
+
+  override fun requestScope(): CompletableSource {
+    return LifecycleScopes.resolveScopeFromLifecycle(this)
+  }
+
+  companion object {
+    /**
+     * Function of current event -> target disposal event. ViewModel has a very simple lifecycle.
+     * It is created and then later on cleared. So we only have two events and all subscriptions
+     * will only be disposed at [ViewModelEvent.CLEARED].
+     */
+    private val CORRESPONDING_EVENTS = CorrespondingEventsFunction<ViewModelEvent> { event ->
+      when (event) {
+        ViewModelEvent.CREATED -> ViewModelEvent.CLEARED
+        else -> throw LifecycleEndedException(
+            "Cannot bind to ViewModel lifecycle after onCleared.")
+      }
+    }
+  }
+}

--- a/sample/src/main/kotlin/com/uber/autodispose/sample/DisposingViewModel.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/sample/DisposingViewModel.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2018. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose.sample
+
+import android.util.Log
+import com.jakewharton.rxrelay2.BehaviorRelay
+import com.uber.autodispose.autoDisposable
+import com.uber.autodispose.recipes.AutoDisposeViewModel
+import com.uber.autodispose.recipes.subscribeBy
+import io.reactivex.Observable
+import java.util.concurrent.TimeUnit
+
+class DisposingViewModel: AutoDisposeViewModel() {
+
+  /**
+   * The relay to communicate state to the UI.
+   *
+   * This should be subscribed by the UI to get the latest
+   * state updates unaffected by config changes.
+   * This could easily be substituted by a LiveData instance.
+   */
+  private val viewRelay = BehaviorRelay.create<String>()
+
+  /**
+   * Meant to model a long standing operation.
+   *
+   * We first tell the UI that we're loading from network.
+   * We introduce a artificial delay of 10s to load the actual
+   * network. If the config changes, the network will still continue
+   * to fetch the resource, unaffected by disposal of the [viewRelay].
+   * Whenever it's ready, it will pass it along to the [viewRelay].
+   */
+  fun loadNetworkResource() {
+    // Notify UI that we're loading network
+    viewRelay.accept("Loading from network")
+    Observable.just("Network loaded")
+        .delay(10, TimeUnit.SECONDS)
+        .doOnDispose { Log.i(TAG, "Disposing subscription from the ViewModel") }
+        .autoDisposable(this)
+        .subscribe({
+          // Loading done. Pass along to the UI
+          viewRelay.accept(it)
+        }, { _ ->})
+  }
+
+  /**
+   * State representation for our current activity.
+   *
+   * For the purposes of this demo, we'll use a [String]
+   * but you can model your own ViewState with a sealed class
+   * and expose that.
+   */
+  fun viewState(): Observable<String> {
+    return viewRelay.hide()
+  }
+
+  companion object {
+    const val TAG = "DisposingViewModel"
+  }
+}

--- a/sample/src/main/kotlin/com/uber/autodispose/sample/DisposingViewModelActivity.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/sample/DisposingViewModelActivity.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2018. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose.sample
+
+import android.arch.lifecycle.ViewModelProviders
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import android.widget.TextView
+import com.uber.autodispose.ScopeProvider
+import com.uber.autodispose.android.lifecycle.AndroidLifecycleScopeProvider
+import com.uber.autodispose.autoDisposable
+import io.reactivex.android.schedulers.AndroidSchedulers
+
+class DisposingViewModelActivity: AppCompatActivity() {
+
+  private val viewModel: DisposingViewModel by lazy { ViewModelProviders.of(this).get(DisposingViewModel::class.java) }
+
+  private val scope: ScopeProvider by lazy { AndroidLifecycleScopeProvider.from(this) }
+
+  lateinit var textView: TextView
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_disposing_viewmodel)
+
+    textView = findViewById(R.id.textView)
+
+    // If we're coming from a configuration change, no need to
+    // start the stream again.
+    if (savedInstanceState == null) {
+      viewModel.loadNetworkResource()
+    }
+
+    // Get latest value from ViewModel unaffected by any config changes.
+    viewModel.viewState()
+        .observeOn(AndroidSchedulers.mainThread())
+        .autoDisposable(scope)
+        .subscribe({ value ->
+          textView.text = value
+        }, {})
+  }
+}

--- a/sample/src/main/kotlin/com/uber/autodispose/sample/HomeActivity.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/sample/HomeActivity.kt
@@ -53,6 +53,11 @@ class HomeActivity: AppCompatActivity() {
     kotlinActivityButton.setOnClickListener {
       startActivity(KotlinActivity::class.java)
     }
+
+    val disposingActivityButton: Button = findViewById(R.id.disposingActivity)
+    disposingActivityButton.setOnClickListener {
+      startActivity(DisposingViewModelActivity::class.java)
+    }
   }
 
   private fun startActivity(className: Class<*>) {

--- a/sample/src/main/res/layout/activity_disposing_viewmodel.xml
+++ b/sample/src/main/res/layout/activity_disposing_viewmodel.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018. Uber Technologies
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools" xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:padding="16dp">
+
+  <TextView
+      android:id="@+id/textView"
+      tools:text="24"
+      app:layout_constraintTop_toTopOf="parent"
+      app:layout_constraintBottom_toBottomOf="parent"
+      android:textAlignment="center"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/sample/src/main/res/layout/activity_home.xml
+++ b/sample/src/main/res/layout/activity_home.xml
@@ -93,5 +93,11 @@
         android:layout_height="wrap_content"
         android:text="@string/kotlin_demo"/>
 
+    <Button
+        android:id="@+id/disposingActivity"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Disposing Activity"/>
+
   </LinearLayout>
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
**Description**: This is an initial pass at addressing #253 . The meat of the stuff is in `AutoDisposeViewModel` where we automatically dispose any streams in `onCleared`. The behavior is modeling `AndroidLifecycleProvider` and such. The only way to use it meaningfully is to extend this base class. Unfortunately, I don't see a way of using something like `ViewModelLifecyleProvider.from(viewModel)`. Let me know if that implementation looks good. 

The rest of the stuff is around constructing a sample that shows the use of the `AutoDisposeViewModel`. Again, I haven't invested that much time into it, just to see if this would be a good fit for the sample. Right now we just delay the emission of a String to simulate what a long network request would look like. The essence of the concept is that since you're subscribing in the ViewModel and then just passing on the results using a `BehaviorRelay` or `LiveData, even if config changes, your API call still continues (something that wouldn't if you had subscribed to the same observable in your Activity/Fragment since the onDestroy would cancel the call). 

If this looks good to you, we can use mockwebserver from OkHttp to throttle and simulate a network request and make it clearer. 


**Related issue(s)**: #253 