### PR TITLE
Switch to Java 8 everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ There are three artifacts with extra support for Android:
 For each artifact, there is a corresponding kotlin extensions artifact with it. Example:
 `autodispose-android` -> `autodispose-android-ktx`.
 
+Note that the project is compiled against Java 8. If you need support for lower Java versions, you should
+use D8 (Android Gradle Plugin 3.2+) or desugar as needed (depending on the build system).
+
 ##### Kotlin
 
 Kotlin extension artifacts are available for almost every artifact by adding `-ktx` to the ID like 

--- a/android/autodispose-android-archcomponents-ktx/build.gradle
+++ b/android/autodispose-android-archcomponents-ktx/build.gradle
@@ -30,8 +30,8 @@ android {
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
   }
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_7
-    targetCompatibility JavaVersion.VERSION_1_7
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
   }
   sourceSets {
     main.java.srcDirs += 'src/main/kotlin'

--- a/android/autodispose-android-archcomponents-test-ktx/build.gradle
+++ b/android/autodispose-android-archcomponents-test-ktx/build.gradle
@@ -30,8 +30,8 @@ android {
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
   }
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_7
-    targetCompatibility JavaVersion.VERSION_1_7
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
   }
   sourceSets {
     main.java.srcDirs += 'src/main/kotlin'

--- a/android/autodispose-android-archcomponents-test/build.gradle
+++ b/android/autodispose-android-archcomponents-test/build.gradle
@@ -28,8 +28,8 @@ android {
     targetSdkVersion deps.build.targetSdkVersion
   }
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_7
-    targetCompatibility JavaVersion.VERSION_1_7
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
   }
 }
 

--- a/android/autodispose-android-archcomponents/build.gradle
+++ b/android/autodispose-android-archcomponents/build.gradle
@@ -31,8 +31,8 @@ android {
     testApplicationId "com.uber.autodispose.android.lifecycle.androidTest"
   }
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_7
-    targetCompatibility JavaVersion.VERSION_1_7
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
   }
   lintOptions {
     lintConfig file('lint.xml')

--- a/android/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProviderTest.java
+++ b/android/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProviderTest.java
@@ -34,11 +34,8 @@ import static com.google.common.truth.Truth.assertThat;
 @RunWith(AndroidJUnit4.class)
 public final class AndroidLifecycleScopeProviderTest {
 
-  private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
-    @Override public void log(String message) {
-      Log.d(AndroidLifecycleScopeProviderTest.class.getSimpleName(), message);
-    }
-  };
+  private static final RecordingObserver.Logger LOGGER =
+      message -> Log.d(AndroidLifecycleScopeProviderTest.class.getSimpleName(), message);
 
   @Test @UiThreadTest public void observable_beforeCreate() {
     final RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);

--- a/android/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProviderTest.java
+++ b/android/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProviderTest.java
@@ -20,7 +20,6 @@ import android.arch.lifecycle.Lifecycle;
 import android.support.test.annotation.UiThreadTest;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Log;
-import com.uber.autodispose.AutoDispose;
 import com.uber.autodispose.android.lifecycle.test.TestLifecycleOwner;
 import com.uber.autodispose.lifecycle.LifecycleEndedException;
 import com.uber.autodispose.test.RecordingObserver;

--- a/android/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProviderTest.java
+++ b/android/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProviderTest.java
@@ -43,7 +43,7 @@ public final class AndroidLifecycleScopeProviderTest {
 
     // Spin it up
     TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
-    subject.as(AutoDispose.<Integer>autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.as(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
         .subscribe(o);
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     lifecycle.emit(Lifecycle.Event.ON_START);
@@ -73,7 +73,7 @@ public final class AndroidLifecycleScopeProviderTest {
     // Spin it up
     TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
-    subject.as(AutoDispose.<Integer>autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.as(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
         .subscribe(o);
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
@@ -103,7 +103,7 @@ public final class AndroidLifecycleScopeProviderTest {
     TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     lifecycle.emit(Lifecycle.Event.ON_START);
-    subject.as(AutoDispose.<Integer>autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.as(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
         .subscribe(o);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
 
@@ -135,7 +135,7 @@ public final class AndroidLifecycleScopeProviderTest {
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
-    subject.as(AutoDispose.<Integer>autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.as(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -164,7 +164,7 @@ public final class AndroidLifecycleScopeProviderTest {
     TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     subject.as(
-        AutoDispose.<Integer>autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle, Lifecycle.Event.ON_PAUSE)))
+        AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle, Lifecycle.Event.ON_PAUSE)))
         .subscribe(o);
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
@@ -197,7 +197,7 @@ public final class AndroidLifecycleScopeProviderTest {
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
     subject.as(
-        AutoDispose.<Integer>autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle, Lifecycle.Event.ON_DESTROY)))
+        AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle, Lifecycle.Event.ON_DESTROY)))
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -230,7 +230,7 @@ public final class AndroidLifecycleScopeProviderTest {
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
     lifecycle.emit(Lifecycle.Event.ON_PAUSE);
-    subject.as(AutoDispose.<Integer>autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.as(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -262,7 +262,7 @@ public final class AndroidLifecycleScopeProviderTest {
     // In a CREATED state now but the next event will be destroy
     // This simulates subscribing in fragments' onDestroyView, where we want the subscription to
     // still dispose properly in onDestroy.
-    subject.as(AutoDispose.<Integer>autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.as(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -285,7 +285,7 @@ public final class AndroidLifecycleScopeProviderTest {
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
-    subject.as(AutoDispose.<Integer>autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.as(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -307,7 +307,7 @@ public final class AndroidLifecycleScopeProviderTest {
     lifecycle.emit(Lifecycle.Event.ON_PAUSE);
     lifecycle.emit(Lifecycle.Event.ON_STOP);
     lifecycle.emit(Lifecycle.Event.ON_DESTROY);
-    subject.as(AutoDispose.<Integer>autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.as(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();

--- a/android/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProviderTest.java
+++ b/android/autodispose-android-archcomponents/src/androidTest/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProviderTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.uber.autodispose.AutoDispose.autoDisposable;
 
 @RunWith(AndroidJUnit4.class)
 public final class AndroidLifecycleScopeProviderTest {
@@ -43,7 +44,7 @@ public final class AndroidLifecycleScopeProviderTest {
 
     // Spin it up
     TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
-    subject.as(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.as(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
         .subscribe(o);
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     lifecycle.emit(Lifecycle.Event.ON_START);
@@ -73,7 +74,7 @@ public final class AndroidLifecycleScopeProviderTest {
     // Spin it up
     TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
-    subject.as(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.as(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
         .subscribe(o);
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
@@ -103,7 +104,7 @@ public final class AndroidLifecycleScopeProviderTest {
     TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     lifecycle.emit(Lifecycle.Event.ON_START);
-    subject.as(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.as(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
         .subscribe(o);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
 
@@ -135,7 +136,7 @@ public final class AndroidLifecycleScopeProviderTest {
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
-    subject.as(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.as(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -164,7 +165,7 @@ public final class AndroidLifecycleScopeProviderTest {
     TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     subject.as(
-        AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle, Lifecycle.Event.ON_PAUSE)))
+        autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle, Lifecycle.Event.ON_PAUSE)))
         .subscribe(o);
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
@@ -197,7 +198,7 @@ public final class AndroidLifecycleScopeProviderTest {
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
     subject.as(
-        AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle, Lifecycle.Event.ON_DESTROY)))
+        autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle, Lifecycle.Event.ON_DESTROY)))
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -230,7 +231,7 @@ public final class AndroidLifecycleScopeProviderTest {
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
     lifecycle.emit(Lifecycle.Event.ON_PAUSE);
-    subject.as(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.as(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -262,7 +263,7 @@ public final class AndroidLifecycleScopeProviderTest {
     // In a CREATED state now but the next event will be destroy
     // This simulates subscribing in fragments' onDestroyView, where we want the subscription to
     // still dispose properly in onDestroy.
-    subject.as(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.as(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -285,7 +286,7 @@ public final class AndroidLifecycleScopeProviderTest {
     lifecycle.emit(Lifecycle.Event.ON_CREATE);
     lifecycle.emit(Lifecycle.Event.ON_START);
     lifecycle.emit(Lifecycle.Event.ON_RESUME);
-    subject.as(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.as(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -307,7 +308,7 @@ public final class AndroidLifecycleScopeProviderTest {
     lifecycle.emit(Lifecycle.Event.ON_PAUSE);
     lifecycle.emit(Lifecycle.Event.ON_STOP);
     lifecycle.emit(Lifecycle.Event.ON_DESTROY);
-    subject.as(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
+    subject.as(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle)))
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();

--- a/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProvider.java
+++ b/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/AndroidLifecycleScopeProvider.java
@@ -37,22 +37,20 @@ import io.reactivex.Observable;
 public final class AndroidLifecycleScopeProvider implements LifecycleScopeProvider<Lifecycle.Event> {
 
   private static final CorrespondingEventsFunction<Lifecycle.Event> DEFAULT_CORRESPONDING_EVENTS =
-      new CorrespondingEventsFunction<Lifecycle.Event>() {
-        @Override public Lifecycle.Event apply(Lifecycle.Event lastEvent) throws OutsideScopeException {
-          switch (lastEvent) {
-            case ON_CREATE:
-              return Lifecycle.Event.ON_DESTROY;
-            case ON_START:
-              return Lifecycle.Event.ON_STOP;
-            case ON_RESUME:
-              return Lifecycle.Event.ON_PAUSE;
-            case ON_PAUSE:
-              return Lifecycle.Event.ON_STOP;
-            case ON_STOP:
-            case ON_DESTROY:
-            default:
-              throw new LifecycleEndedException("Lifecycle has ended! Last event was " + lastEvent);
-          }
+      lastEvent -> {
+        switch (lastEvent) {
+          case ON_CREATE:
+            return Lifecycle.Event.ON_DESTROY;
+          case ON_START:
+            return Lifecycle.Event.ON_STOP;
+          case ON_RESUME:
+            return Lifecycle.Event.ON_PAUSE;
+          case ON_PAUSE:
+            return Lifecycle.Event.ON_STOP;
+          case ON_STOP:
+          case ON_DESTROY:
+          default:
+            throw new LifecycleEndedException("Lifecycle has ended! Last event was " + lastEvent);
         }
       };
 

--- a/android/autodispose-android-ktx/build.gradle
+++ b/android/autodispose-android-ktx/build.gradle
@@ -30,8 +30,8 @@ android {
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
   }
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_7
-    targetCompatibility JavaVersion.VERSION_1_7
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
   }
   sourceSets {
     main.java.srcDirs += 'src/main/kotlin'

--- a/android/autodispose-android/build.gradle
+++ b/android/autodispose-android/build.gradle
@@ -29,8 +29,8 @@ android {
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
   }
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_7
-    targetCompatibility JavaVersion.VERSION_1_7
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
   }
   testOptions {
     execution 'ANDROID_TEST_ORCHESTRATOR'

--- a/android/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
+++ b/android/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
@@ -38,11 +38,8 @@ import static com.google.common.truth.Truth.assertThat;
 @RunWith(AndroidJUnit4.class)
 public final class ViewScopeProviderTest {
 
-  private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
-    @Override public void log(String message) {
-      Log.d(ViewScopeProviderTest.class.getSimpleName(), message);
-    }
-  };
+  private static final RecordingObserver.Logger LOGGER =
+      message -> Log.d(ViewScopeProviderTest.class.getSimpleName(), message);
 
   @Rule public final ActivityTestRule<AutoDisposeTestActivity> activityRule =
       new ActivityTestRule<>(AutoDisposeTestActivity.class);
@@ -62,17 +59,9 @@ public final class ViewScopeProviderTest {
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     // Attach it
-    instrumentation.runOnMainSync(new Runnable() {
-      @Override public void run() {
-        parent.addView(child);
-      }
-    });
-    instrumentation.runOnMainSync(new Runnable() {
-      @Override public void run() {
-        subject.as(AutoDispose.<Integer>autoDisposable(ViewScopeProvider.from(child)))
-            .subscribe(o);
-      }
-    });
+    instrumentation.runOnMainSync(() -> parent.addView(child));
+    instrumentation.runOnMainSync(() -> subject.as(AutoDispose.<Integer>autoDisposable(ViewScopeProvider.from(child)))
+        .subscribe(o));
 
     Disposable d = o.takeSubscribe();
     o.assertNoMoreEvents(); // No initial value.
@@ -83,11 +72,7 @@ public final class ViewScopeProviderTest {
     subject.onNext(1);
     assertThat(o.takeNext()).isEqualTo(1);
 
-    instrumentation.runOnMainSync(new Runnable() {
-      @Override public void run() {
-        parent.removeView(child);
-      }
-    });
+    instrumentation.runOnMainSync(() -> parent.removeView(child));
 
     subject.onNext(2);
     o.assertNoMoreEvents();
@@ -100,11 +85,7 @@ public final class ViewScopeProviderTest {
     PublishSubject<Integer> subject = PublishSubject.create();
 
     // Attach it
-    instrumentation.runOnMainSync(new Runnable() {
-      @Override public void run() {
-        parent.addView(child);
-      }
-    });
+    instrumentation.runOnMainSync(() -> parent.addView(child));
     subject.as(AutoDispose.<Integer>autoDisposable(ViewScopeProvider.from(child)))
         .subscribe(o);
 
@@ -120,12 +101,8 @@ public final class ViewScopeProviderTest {
     final RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     final PublishSubject<Integer> subject = PublishSubject.create();
 
-    instrumentation.runOnMainSync(new Runnable() {
-      @Override public void run() {
-        subject.as(AutoDispose.<Integer>autoDisposable(ViewScopeProvider.from(child)))
-            .subscribe(o);
-      }
-    });
+    instrumentation.runOnMainSync(() -> subject.as(AutoDispose.<Integer>autoDisposable(ViewScopeProvider.from(child)))
+        .subscribe(o));
 
     Disposable d = o.takeSubscribe();
     Throwable t = o.takeError();
@@ -138,22 +115,10 @@ public final class ViewScopeProviderTest {
     final RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     final PublishSubject<Integer> subject = PublishSubject.create();
 
-    instrumentation.runOnMainSync(new Runnable() {
-      @Override public void run() {
-        parent.addView(child);
-      }
-    });
-    instrumentation.runOnMainSync(new Runnable() {
-      @Override public void run() {
-        parent.removeView(child);
-      }
-    });
-    instrumentation.runOnMainSync(new Runnable() {
-      @Override public void run() {
-        subject.as(AutoDispose.<Integer>autoDisposable(ViewScopeProvider.from(child)))
-            .subscribe(o);
-      }
-    });
+    instrumentation.runOnMainSync(() -> parent.addView(child));
+    instrumentation.runOnMainSync(() -> parent.removeView(child));
+    instrumentation.runOnMainSync(() -> subject.as(AutoDispose.<Integer>autoDisposable(ViewScopeProvider.from(child)))
+        .subscribe(o));
 
     Disposable d = o.takeSubscribe();
     Throwable t = o.takeError();

--- a/android/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
+++ b/android/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.uber.autodispose.AutoDispose.autoDisposable;
 
 @RunWith(AndroidJUnit4.class)
 public final class ViewScopeProviderTest {
@@ -60,7 +61,7 @@ public final class ViewScopeProviderTest {
 
     // Attach it
     instrumentation.runOnMainSync(() -> parent.addView(child));
-    instrumentation.runOnMainSync(() -> subject.as(AutoDispose.autoDisposable(ViewScopeProvider.from(child)))
+    instrumentation.runOnMainSync(() -> subject.as(autoDisposable(ViewScopeProvider.from(child)))
         .subscribe(o));
 
     Disposable d = o.takeSubscribe();
@@ -86,7 +87,7 @@ public final class ViewScopeProviderTest {
 
     // Attach it
     instrumentation.runOnMainSync(() -> parent.addView(child));
-    subject.as(AutoDispose.autoDisposable(ViewScopeProvider.from(child)))
+    subject.as(autoDisposable(ViewScopeProvider.from(child)))
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -101,7 +102,7 @@ public final class ViewScopeProviderTest {
     final RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     final PublishSubject<Integer> subject = PublishSubject.create();
 
-    instrumentation.runOnMainSync(() -> subject.as(AutoDispose.autoDisposable(ViewScopeProvider.from(child)))
+    instrumentation.runOnMainSync(() -> subject.as(autoDisposable(ViewScopeProvider.from(child)))
         .subscribe(o));
 
     Disposable d = o.takeSubscribe();
@@ -117,7 +118,7 @@ public final class ViewScopeProviderTest {
 
     instrumentation.runOnMainSync(() -> parent.addView(child));
     instrumentation.runOnMainSync(() -> parent.removeView(child));
-    instrumentation.runOnMainSync(() -> subject.as(AutoDispose.autoDisposable(ViewScopeProvider.from(child)))
+    instrumentation.runOnMainSync(() -> subject.as(autoDisposable(ViewScopeProvider.from(child)))
         .subscribe(o));
 
     Disposable d = o.takeSubscribe();

--- a/android/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
+++ b/android/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
@@ -23,7 +23,6 @@ import android.support.test.runner.AndroidJUnit4;
 import android.util.Log;
 import android.view.View;
 import android.widget.FrameLayout;
-import com.uber.autodispose.AutoDispose;
 import com.uber.autodispose.OutsideScopeException;
 import com.uber.autodispose.test.RecordingObserver;
 import io.reactivex.disposables.Disposable;
@@ -36,8 +35,7 @@ import org.junit.runner.RunWith;
 import static com.google.common.truth.Truth.assertThat;
 import static com.uber.autodispose.AutoDispose.autoDisposable;
 
-@RunWith(AndroidJUnit4.class)
-public final class ViewScopeProviderTest {
+@RunWith(AndroidJUnit4.class) public final class ViewScopeProviderTest {
 
   private static final RecordingObserver.Logger LOGGER =
       message -> Log.d(ViewScopeProviderTest.class.getSimpleName(), message);

--- a/android/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
+++ b/android/autodispose-android/src/androidTest/java/com/uber/autodispose/android/ViewScopeProviderTest.java
@@ -60,7 +60,7 @@ public final class ViewScopeProviderTest {
 
     // Attach it
     instrumentation.runOnMainSync(() -> parent.addView(child));
-    instrumentation.runOnMainSync(() -> subject.as(AutoDispose.<Integer>autoDisposable(ViewScopeProvider.from(child)))
+    instrumentation.runOnMainSync(() -> subject.as(AutoDispose.autoDisposable(ViewScopeProvider.from(child)))
         .subscribe(o));
 
     Disposable d = o.takeSubscribe();
@@ -86,7 +86,7 @@ public final class ViewScopeProviderTest {
 
     // Attach it
     instrumentation.runOnMainSync(() -> parent.addView(child));
-    subject.as(AutoDispose.<Integer>autoDisposable(ViewScopeProvider.from(child)))
+    subject.as(AutoDispose.autoDisposable(ViewScopeProvider.from(child)))
         .subscribe(o);
 
     Disposable d = o.takeSubscribe();
@@ -101,7 +101,7 @@ public final class ViewScopeProviderTest {
     final RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     final PublishSubject<Integer> subject = PublishSubject.create();
 
-    instrumentation.runOnMainSync(() -> subject.as(AutoDispose.<Integer>autoDisposable(ViewScopeProvider.from(child)))
+    instrumentation.runOnMainSync(() -> subject.as(AutoDispose.autoDisposable(ViewScopeProvider.from(child)))
         .subscribe(o));
 
     Disposable d = o.takeSubscribe();
@@ -117,7 +117,7 @@ public final class ViewScopeProviderTest {
 
     instrumentation.runOnMainSync(() -> parent.addView(child));
     instrumentation.runOnMainSync(() -> parent.removeView(child));
-    instrumentation.runOnMainSync(() -> subject.as(AutoDispose.<Integer>autoDisposable(ViewScopeProvider.from(child)))
+    instrumentation.runOnMainSync(() -> subject.as(AutoDispose.autoDisposable(ViewScopeProvider.from(child)))
         .subscribe(o));
 
     Disposable d = o.takeSubscribe();

--- a/android/autodispose-android/src/main/java/com/uber/autodispose/android/internal/AutoDisposeAndroidUtil.java
+++ b/android/autodispose-android/src/main/java/com/uber/autodispose/android/internal/AutoDisposeAndroidUtil.java
@@ -26,11 +26,8 @@ import static android.support.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 @RestrictTo(LIBRARY_GROUP)
 public class AutoDisposeAndroidUtil {
 
-  private static final BooleanSupplier MAIN_THREAD_CHECK = new BooleanSupplier() {
-    @Override public boolean getAsBoolean() {
-      return Looper.myLooper() == Looper.getMainLooper();
-    }
-  };
+  private static final BooleanSupplier MAIN_THREAD_CHECK =
+      () -> Looper.myLooper() == Looper.getMainLooper();
 
   private AutoDisposeAndroidUtil() { }
 

--- a/android/autodispose-android/src/main/java/com/uber/autodispose/android/internal/MainThreadDisposable.java
+++ b/android/autodispose-android/src/main/java/com/uber/autodispose/android/internal/MainThreadDisposable.java
@@ -43,12 +43,7 @@ public abstract class MainThreadDisposable implements Disposable {
       if (AutoDisposeAndroidUtil.isMainThread()) {
         onDispose();
       } else {
-        AndroidSchedulers.mainThread().scheduleDirect(new Runnable() {
-          @Override
-          public void run() {
-            onDispose();
-          }
-        });
+        AndroidSchedulers.mainThread().scheduleDirect(this::onDispose);
       }
     }
   }

--- a/android/autodispose-android/src/test/java/com/uber/autodispose/android/AutoDisposeAndroidPluginsTest.java
+++ b/android/autodispose-android/src/test/java/com/uber/autodispose/android/AutoDisposeAndroidPluginsTest.java
@@ -34,21 +34,13 @@ public final class AutoDisposeAndroidPluginsTest {
   @Test public void overridingMainThreadCheck_shouldWorkInUnitTests() {
     expectLooperError();
 
-    AutoDisposeAndroidPlugins.setOnCheckMainThread(new BooleanSupplier() {
-      @Override public boolean getAsBoolean() {
-        return true;
-      }
-    });
+    AutoDisposeAndroidPlugins.setOnCheckMainThread(() -> true);
 
     assertThat(AutoDisposeAndroidUtil.isMainThread()).isTrue();
 
     AutoDisposeAndroidPlugins.reset();
 
-    AutoDisposeAndroidPlugins.setOnCheckMainThread(new BooleanSupplier() {
-      @Override public boolean getAsBoolean() {
-        return false;
-      }
-    });
+    AutoDisposeAndroidPlugins.setOnCheckMainThread(() -> false);
 
     assertThat(AutoDisposeAndroidUtil.isMainThread()).isFalse();
 

--- a/android/autodispose-android/src/test/java/com/uber/autodispose/android/AutoDisposeAndroidPluginsTest.java
+++ b/android/autodispose-android/src/test/java/com/uber/autodispose/android/AutoDisposeAndroidPluginsTest.java
@@ -18,7 +18,6 @@ package com.uber.autodispose.android;
 
 import com.uber.autodispose.AutoDisposePlugins;
 import com.uber.autodispose.android.internal.AutoDisposeAndroidUtil;
-import io.reactivex.functions.BooleanSupplier;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/android/autodispose-android/src/test/java/com/uber/autodispose/android/internal/MainThreadDisposableTest.java
+++ b/android/autodispose-android/src/test/java/com/uber/autodispose/android/internal/MainThreadDisposableTest.java
@@ -30,12 +30,7 @@ public final class MainThreadDisposableTest {
   }
 
   @Test public void onDispose_defersToMainThreadHook() {
-    AutoDisposeAndroidPlugins.setOnCheckMainThread(new BooleanSupplier() {
-      @Override
-      public boolean getAsBoolean() {
-        return true;
-      }
-    });
+    AutoDisposeAndroidPlugins.setOnCheckMainThread(() -> true);
 
     final AtomicBoolean called = new AtomicBoolean();
 

--- a/android/autodispose-android/src/test/java/com/uber/autodispose/android/internal/MainThreadDisposableTest.java
+++ b/android/autodispose-android/src/test/java/com/uber/autodispose/android/internal/MainThreadDisposableTest.java
@@ -14,12 +14,10 @@
 package com.uber.autodispose.android.internal;
 
 import com.uber.autodispose.android.AutoDisposeAndroidPlugins;
-import io.reactivex.functions.BooleanSupplier;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -35,8 +33,7 @@ public final class MainThreadDisposableTest {
     final AtomicBoolean called = new AtomicBoolean();
 
     new MainThreadDisposable() {
-      @Override
-      protected void onDispose() {
+      @Override protected void onDispose() {
         called.set(true);
       }
     }.dispose();
@@ -44,12 +41,10 @@ public final class MainThreadDisposableTest {
     assertThat(called.get()).isTrue();
   }
 
-  @Test
-  public void onDisposeFailsWhenMainThreadCheckNotSet() {
+  @Test public void onDisposeFailsWhenMainThreadCheckNotSet() {
     try {
       new MainThreadDisposable() {
-        @Override
-        protected void onDispose() { }
+        @Override protected void onDispose() { }
       }.dispose();
       throw new AssertionError("Expected to fail before this due to Looper not being stubbed!");
     } catch (RuntimeException e) {

--- a/autodispose-rxlifecycle/build.gradle
+++ b/autodispose-rxlifecycle/build.gradle
@@ -19,8 +19,8 @@ plugins {
     id 'net.ltgt.errorprone'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 test {
     testLogging.showStandardStreams = true

--- a/autodispose-rxlifecycle/src/main/java/com/ubercab/autodispose/rxlifecycle/RxLifecycleInterop.java
+++ b/autodispose-rxlifecycle/src/main/java/com/ubercab/autodispose/rxlifecycle/RxLifecycleInterop.java
@@ -19,7 +19,6 @@ package com.ubercab.autodispose.rxlifecycle;
 import com.trello.rxlifecycle2.LifecycleProvider;
 import com.trello.rxlifecycle2.OutsideLifecycleException;
 import com.uber.autodispose.ScopeProvider;
-import io.reactivex.CompletableSource;
 
 /**
  * Interop for RxLifecycle. This provides static factory methods to convert {@link
@@ -49,13 +48,9 @@ public final class RxLifecycleInterop {
    * @return a {@link ScopeProvider}
    */
   public static <E> ScopeProvider from(final LifecycleProvider<E> provider) {
-    return new ScopeProvider() {
-      @Override public CompletableSource requestScope() {
-        return provider.lifecycle()
-            .compose(provider.bindToLifecycle())
-            .ignoreElements();
-      }
-    };
+    return () -> provider.lifecycle()
+        .compose(provider.bindToLifecycle())
+        .ignoreElements();
   }
 
   /**
@@ -74,12 +69,8 @@ public final class RxLifecycleInterop {
    * @return a {@link ScopeProvider}
    */
   public static <E> ScopeProvider from(final LifecycleProvider<E> provider, final E event) {
-    return new ScopeProvider() {
-      @Override public CompletableSource requestScope() {
-        return provider.lifecycle()
-            .compose(provider.bindUntilEvent(event))
-            .ignoreElements();
-      }
-    };
+    return () -> provider.lifecycle()
+        .compose(provider.bindUntilEvent(event))
+        .ignoreElements();
   }
 }

--- a/autodispose-rxlifecycle/src/test/java/com/ubercab/autodispose/rxlifecycle/RxLifecycleInteropTest.java
+++ b/autodispose-rxlifecycle/src/test/java/com/ubercab/autodispose/rxlifecycle/RxLifecycleInteropTest.java
@@ -27,11 +27,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 public class RxLifecycleInteropTest {
 
-  private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
-    @Override public void log(String message) {
-      System.out.println(RxLifecycleInteropTest.class.getSimpleName() + ": " + message);
-    }
-  };
+  private static final RecordingObserver.Logger LOGGER =
+      message -> System.out.println(RxLifecycleInteropTest.class.getSimpleName() + ": " + message);
 
   private TestLifecycleProvider lifecycleProvider = new TestLifecycleProvider();
 

--- a/autodispose-rxlifecycle/src/test/java/com/ubercab/autodispose/rxlifecycle/RxLifecycleInteropTest.java
+++ b/autodispose-rxlifecycle/src/test/java/com/ubercab/autodispose/rxlifecycle/RxLifecycleInteropTest.java
@@ -16,7 +16,6 @@
 
 package com.ubercab.autodispose.rxlifecycle;
 
-import com.uber.autodispose.AutoDispose;
 import com.uber.autodispose.test.RecordingObserver;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.observers.TestObserver;
@@ -24,6 +23,7 @@ import io.reactivex.subjects.PublishSubject;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.uber.autodispose.AutoDispose.autoDisposable;
 
 public class RxLifecycleInteropTest {
 
@@ -36,7 +36,7 @@ public class RxLifecycleInteropTest {
     lifecycleProvider.emitCreate();
     TestObserver<Integer> o = new TestObserver<>();
     PublishSubject<Integer> source = PublishSubject.create();
-    Disposable d = source.as(AutoDispose.autoDisposable(RxLifecycleInterop.from(lifecycleProvider)))
+    Disposable d = source.as(autoDisposable(RxLifecycleInterop.from(lifecycleProvider)))
         .subscribeWith(o);
     o.assertSubscribed();
 
@@ -57,7 +57,7 @@ public class RxLifecycleInteropTest {
     lifecycleProvider.emitCreate();
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     PublishSubject<Integer> source = PublishSubject.create();
-    source.as(AutoDispose.autoDisposable(RxLifecycleInterop.from(lifecycleProvider)))
+    source.as(autoDisposable(RxLifecycleInterop.from(lifecycleProvider)))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -77,7 +77,7 @@ public class RxLifecycleInteropTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     PublishSubject<Integer> source = PublishSubject.create();
     lifecycleProvider.emitDestroy();
-    source.as(AutoDispose.autoDisposable(RxLifecycleInterop.from(lifecycleProvider)))
+    source.as(autoDisposable(RxLifecycleInterop.from(lifecycleProvider)))
         .subscribe(o);
 
     o.takeSubscribe();
@@ -92,7 +92,7 @@ public class RxLifecycleInteropTest {
     lifecycleProvider.emitCreate();
     TestObserver<Integer> o = new TestObserver<>();
     PublishSubject<Integer> source = PublishSubject.create();
-    Disposable d = source.as(AutoDispose.autoDisposable(
+    Disposable d = source.as(autoDisposable(
         RxLifecycleInterop.from(lifecycleProvider, TestLifecycleProvider.Event.DESTROY)))
         .subscribeWith(o);
     o.assertSubscribed();
@@ -114,7 +114,7 @@ public class RxLifecycleInteropTest {
     lifecycleProvider.emitCreate();
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     PublishSubject<Integer> source = PublishSubject.create();
-    source.as(AutoDispose.autoDisposable(
+    source.as(autoDisposable(
         RxLifecycleInterop.from(lifecycleProvider, TestLifecycleProvider.Event.DESTROY)))
         .subscribe(o);
     o.takeSubscribe();

--- a/autodispose-rxlifecycle/src/test/java/com/ubercab/autodispose/rxlifecycle/RxLifecycleInteropTest.java
+++ b/autodispose-rxlifecycle/src/test/java/com/ubercab/autodispose/rxlifecycle/RxLifecycleInteropTest.java
@@ -36,7 +36,7 @@ public class RxLifecycleInteropTest {
     lifecycleProvider.emitCreate();
     TestObserver<Integer> o = new TestObserver<>();
     PublishSubject<Integer> source = PublishSubject.create();
-    Disposable d = source.as(AutoDispose.<Integer>autoDisposable(RxLifecycleInterop.from(lifecycleProvider)))
+    Disposable d = source.as(AutoDispose.autoDisposable(RxLifecycleInterop.from(lifecycleProvider)))
         .subscribeWith(o);
     o.assertSubscribed();
 
@@ -57,7 +57,7 @@ public class RxLifecycleInteropTest {
     lifecycleProvider.emitCreate();
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     PublishSubject<Integer> source = PublishSubject.create();
-    source.as(AutoDispose.<Integer>autoDisposable(RxLifecycleInterop.from(lifecycleProvider)))
+    source.as(AutoDispose.autoDisposable(RxLifecycleInterop.from(lifecycleProvider)))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -77,7 +77,7 @@ public class RxLifecycleInteropTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     PublishSubject<Integer> source = PublishSubject.create();
     lifecycleProvider.emitDestroy();
-    source.as(AutoDispose.<Integer>autoDisposable(RxLifecycleInterop.from(lifecycleProvider)))
+    source.as(AutoDispose.autoDisposable(RxLifecycleInterop.from(lifecycleProvider)))
         .subscribe(o);
 
     o.takeSubscribe();
@@ -92,7 +92,7 @@ public class RxLifecycleInteropTest {
     lifecycleProvider.emitCreate();
     TestObserver<Integer> o = new TestObserver<>();
     PublishSubject<Integer> source = PublishSubject.create();
-    Disposable d = source.as(AutoDispose.<Integer>autoDisposable(
+    Disposable d = source.as(AutoDispose.autoDisposable(
         RxLifecycleInterop.from(lifecycleProvider, TestLifecycleProvider.Event.DESTROY)))
         .subscribeWith(o);
     o.assertSubscribed();
@@ -114,7 +114,7 @@ public class RxLifecycleInteropTest {
     lifecycleProvider.emitCreate();
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     PublishSubject<Integer> source = PublishSubject.create();
-    source.as(AutoDispose.<Integer>autoDisposable(
+    source.as(AutoDispose.autoDisposable(
         RxLifecycleInterop.from(lifecycleProvider, TestLifecycleProvider.Event.DESTROY)))
         .subscribe(o);
     o.takeSubscribe();

--- a/autodispose-rxlifecycle/src/test/java/com/ubercab/autodispose/rxlifecycle/TestLifecycleProvider.java
+++ b/autodispose-rxlifecycle/src/test/java/com/ubercab/autodispose/rxlifecycle/TestLifecycleProvider.java
@@ -26,14 +26,12 @@ import io.reactivex.subjects.BehaviorSubject;
 
 final class TestLifecycleProvider implements LifecycleProvider<TestLifecycleProvider.Event> {
 
-  private static final Function<Event, Event> CORRESPONDING_EVENTS = new Function<Event, Event>() {
-    @Override public Event apply(Event event) {
-      switch (event) {
-        case CREATE:
-          return Event.DESTROY;
-        default:
-          throw new OutsideLifecycleException("Lifecycle ended");
-      }
+  private static final Function<Event, Event> CORRESPONDING_EVENTS = event -> {
+    switch (event) {
+      case CREATE:
+        return Event.DESTROY;
+      default:
+        throw new OutsideLifecycleException("Lifecycle ended");
     }
   };
 

--- a/autodispose/build.gradle
+++ b/autodispose/build.gradle
@@ -19,8 +19,8 @@ plugins {
   id 'net.ltgt.errorprone'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 test {
   testLogging.showStandardStreams = true

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -67,7 +67,7 @@ public final class AutoDispose {
    * Example usage:
    * <pre><code>
    *   Observable.just(1)
-   *        .as(AutoDispose.<Integer>autoDisposable(scope))
+   *        .as(autoDisposable(scope)) // Static import
    *        .subscribe(...)
    * </code></pre>
    *
@@ -99,7 +99,7 @@ public final class AutoDispose {
    * Example usage:
    * <pre><code>
    *   Observable.just(1)
-   *        .as(AutoDispose.<Integer>autoDisposable(scope))
+   *        .as(autoDisposable(scope)) // Static import
    *        .subscribe(...)
    * </code></pre>
    *

--- a/autodispose/src/main/java/com/uber/autodispose/ScopeProvider.java
+++ b/autodispose/src/main/java/com/uber/autodispose/ScopeProvider.java
@@ -31,11 +31,7 @@ public interface ScopeProvider {
    * A new provider that is "unbound", e.g. will emit a completion event to signal that the
    * scope is unbound.
    */
-  ScopeProvider UNBOUND = new ScopeProvider() {
-    @Override public CompletableSource requestScope() {
-      return Completable.never();
-    }
-  };
+  ScopeProvider UNBOUND = Completable::never;
 
   /**
    * @return a {@link CompletableSource} that, upon completion, will trigger disposal.

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -42,11 +42,7 @@ import static com.uber.autodispose.TestUtil.outsideScopeProvider;
 
 public class AutoDisposeCompletableObserverTest {
 
-  private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
-    @Override public void log(String message) {
-      System.out.println(AutoDisposeCompletableObserverTest.class.getSimpleName() + ": " + message);
-    }
-  };
+  private static final RecordingObserver.Logger LOGGER = message -> System.out.println(AutoDisposeCompletableObserverTest.class.getSimpleName() + ": " + message);
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
 
@@ -139,16 +135,14 @@ public class AutoDisposeCompletableObserverTest {
     final AtomicReference<CompletableObserver> atomicObserver = new AtomicReference<>();
     final AtomicReference<CompletableObserver> atomicAutoDisposingObserver = new AtomicReference<>();
     try {
-      RxJavaPlugins.setOnCompletableSubscribe(new BiFunction<Completable, CompletableObserver, CompletableObserver>() {
-        @Override public CompletableObserver apply(Completable source, CompletableObserver observer) {
-          if (atomicObserver.get() == null) {
-            atomicObserver.set(observer);
-          } else if (atomicAutoDisposingObserver.get() == null) {
-            atomicAutoDisposingObserver.set(observer);
-            RxJavaPlugins.setOnObservableSubscribe(null);
-          }
-          return observer;
+      RxJavaPlugins.setOnCompletableSubscribe((source, observer) -> {
+        if (atomicObserver.get() == null) {
+          atomicObserver.set(observer);
+        } else if (atomicAutoDisposingObserver.get() == null) {
+          atomicAutoDisposingObserver.set(observer);
+          RxJavaPlugins.setOnObservableSubscribe(null);
         }
+        return observer;
       });
       Completable.complete()
           .as(autoDisposable(ScopeProvider.UNBOUND))
@@ -167,15 +161,7 @@ public class AutoDisposeCompletableObserverTest {
   @Test public void verifyCancellation() {
     final AtomicInteger i = new AtomicInteger();
     //noinspection unchecked because Java
-    Completable source = Completable.create(new CompletableOnSubscribe() {
-      @Override public void subscribe(CompletableEmitter e) {
-        e.setCancellable(new Cancellable() {
-          @Override public void cancel() {
-            i.incrementAndGet();
-          }
-        });
-      }
-    });
+    Completable source = Completable.create(e -> e.setCancellable(i::incrementAndGet));
     CompletableSubject scope = CompletableSubject.create();
     source.as(autoDisposable(scope))
         .subscribe();
@@ -210,9 +196,7 @@ public class AutoDisposeCompletableObserverTest {
   }
 
   @Test public void autoDispose_outsideScope_withProviderAndNoOpPlugin_shouldFailSilently() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) { }
-    });
+    AutoDisposePlugins.setOutsideScopeHandler(e -> { });
     ScopeProvider provider = outsideScopeProvider();
     CompletableSubject source = CompletableSubject.create();
     TestObserver<Void> o = source.as(autoDisposable(provider))
@@ -224,12 +208,10 @@ public class AutoDisposeCompletableObserverTest {
   }
 
   @Test public void autoDispose_outsideScope_withProviderAndPlugin_shouldFailWithWrappedExp() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) {
-        // Wrap in an IllegalStateException so we can verify this is the exception we see on the
-        // other side
-        throw new IllegalStateException(e);
-      }
+    AutoDisposePlugins.setOutsideScopeHandler(e -> {
+      // Wrap in an IllegalStateException so we can verify this is the exception we see on the
+      // other side
+      throw new IllegalStateException(e);
     });
     ScopeProvider provider = outsideScopeProvider();
     TestObserver<Void> o = CompletableSubject.create()
@@ -237,10 +219,6 @@ public class AutoDisposeCompletableObserverTest {
         .test();
 
     o.assertNoValues();
-    o.assertError(new Predicate<Throwable>() {
-      @Override public boolean test(Throwable throwable) {
-        return throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException;
-      }
-    });
+    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -20,13 +20,7 @@ import com.uber.autodispose.observers.AutoDisposingCompletableObserver;
 import com.uber.autodispose.test.RecordingObserver;
 import com.uber.autodispose.test.RxErrorsRule;
 import io.reactivex.Completable;
-import io.reactivex.CompletableEmitter;
 import io.reactivex.CompletableObserver;
-import io.reactivex.CompletableOnSubscribe;
-import io.reactivex.functions.BiFunction;
-import io.reactivex.functions.Cancellable;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Predicate;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.CompletableSubject;
@@ -42,7 +36,10 @@ import static com.uber.autodispose.TestUtil.outsideScopeProvider;
 
 public class AutoDisposeCompletableObserverTest {
 
-  private static final RecordingObserver.Logger LOGGER = message -> System.out.println(AutoDisposeCompletableObserverTest.class.getSimpleName() + ": " + message);
+  private static final RecordingObserver.Logger LOGGER =
+      message -> System.out.println(AutoDisposeCompletableObserverTest.class.getSimpleName()
+          + ": "
+          + message);
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
 
@@ -133,7 +130,8 @@ public class AutoDisposeCompletableObserverTest {
 
   @Test public void verifyObserverDelegate() {
     final AtomicReference<CompletableObserver> atomicObserver = new AtomicReference<>();
-    final AtomicReference<CompletableObserver> atomicAutoDisposingObserver = new AtomicReference<>();
+    final AtomicReference<CompletableObserver> atomicAutoDisposingObserver =
+        new AtomicReference<>();
     try {
       RxJavaPlugins.setOnCompletableSubscribe((source, observer) -> {
         if (atomicObserver.get() == null) {
@@ -219,6 +217,7 @@ public class AutoDisposeCompletableObserverTest {
         .test();
 
     o.assertNoValues();
-    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
+    o.assertError(throwable -> throwable instanceof IllegalStateException
+        && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -20,13 +20,8 @@ import com.uber.autodispose.observers.AutoDisposingMaybeObserver;
 import com.uber.autodispose.test.RecordingObserver;
 import com.uber.autodispose.test.RxErrorsRule;
 import io.reactivex.Maybe;
-import io.reactivex.MaybeEmitter;
 import io.reactivex.MaybeObserver;
-import io.reactivex.MaybeOnSubscribe;
-import io.reactivex.functions.BiFunction;
-import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Predicate;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.CompletableSubject;
@@ -51,7 +46,7 @@ public class AutoDisposeMaybeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.<Integer>autoDisposable(scope))
+    source.as(AutoDispose.autoDisposable(scope))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -70,7 +65,7 @@ public class AutoDisposeMaybeObserverTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Maybe.just(new BClass())
-        .as(AutoDispose.<BClass>autoDisposable(ScopeProvider.UNBOUND))
+        .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
         .subscribe((Consumer<AClass>) aClass -> {
 
         });
@@ -80,9 +75,9 @@ public class AutoDisposeMaybeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.<Integer>autoDisposable(scope))
+    source.as(AutoDispose.autoDisposable(scope))
         .subscribe(o);
-    source.as(AutoDispose.<Integer>autoDisposable(scope))
+    source.as(AutoDispose.autoDisposable(scope))
         .subscribe(integer -> {
 
         });
@@ -106,7 +101,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     CompletableSubject scope = CompletableSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.as(AutoDispose.<Integer>autoDisposable(provider))
+    source.as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -126,7 +121,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     CompletableSubject scope = CompletableSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.as(AutoDispose.<Integer>autoDisposable(provider))
+    source.as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -146,7 +141,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     CompletableSubject scope = CompletableSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.as(AutoDispose.<Integer>autoDisposable(provider))
+    source.as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -178,7 +173,7 @@ public class AutoDisposeMaybeObserverTest {
         return observer;
       });
       Maybe.just(1)
-          .as(AutoDispose.<Integer>autoDisposable(ScopeProvider.UNBOUND))
+          .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
           .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
@@ -196,7 +191,7 @@ public class AutoDisposeMaybeObserverTest {
     //noinspection unchecked because Java
     Maybe<Integer> source = Maybe.create(e -> e.setCancellable(i::incrementAndGet));
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.<Integer>autoDisposable(scope))
+    source.as(AutoDispose.autoDisposable(scope))
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);
@@ -221,7 +216,7 @@ public class AutoDisposeMaybeObserverTest {
 
   @Test public void unbound_shouldStillPassValues() {
     MaybeSubject<Integer> s = MaybeSubject.create();
-    TestObserver<Integer> o = s.as(AutoDispose.<Integer>autoDisposable(ScopeProvider.UNBOUND))
+    TestObserver<Integer> o = s.as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
         .test();
 
     s.onSuccess(1);
@@ -232,7 +227,7 @@ public class AutoDisposeMaybeObserverTest {
     AutoDisposePlugins.setOutsideScopeHandler(e -> { });
     ScopeProvider provider = outsideScopeProvider();
     MaybeSubject<Integer> source = MaybeSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -247,7 +242,7 @@ public class AutoDisposeMaybeObserverTest {
       throw new IllegalStateException(e);
     });
     ScopeProvider provider = outsideScopeProvider();
-    TestObserver<Integer> o = MaybeSubject.<Integer>create().as(AutoDispose.<Integer>autoDisposable(provider))
+    TestObserver<Integer> o = MaybeSubject.<Integer>create().as(AutoDispose.autoDisposable(provider))
         .test();
 
     o.assertNoValues();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -32,6 +32,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.uber.autodispose.AutoDispose.autoDisposable;
 import static com.uber.autodispose.TestUtil.makeProvider;
 import static com.uber.autodispose.TestUtil.outsideScopeProvider;
 
@@ -46,7 +47,7 @@ public class AutoDisposeMaybeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.autoDisposable(scope))
+    source.as(autoDisposable(scope))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -65,7 +66,7 @@ public class AutoDisposeMaybeObserverTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Maybe.just(new BClass())
-        .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+        .as(autoDisposable(ScopeProvider.UNBOUND))
         .subscribe((Consumer<AClass>) aClass -> {
 
         });
@@ -75,9 +76,9 @@ public class AutoDisposeMaybeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     MaybeSubject<Integer> source = MaybeSubject.create();
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.autoDisposable(scope))
+    source.as(autoDisposable(scope))
         .subscribe(o);
-    source.as(AutoDispose.autoDisposable(scope))
+    source.as(autoDisposable(scope))
         .subscribe(integer -> {
 
         });
@@ -101,7 +102,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     CompletableSubject scope = CompletableSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.as(AutoDispose.autoDisposable(provider))
+    source.as(autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -121,7 +122,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     CompletableSubject scope = CompletableSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.as(AutoDispose.autoDisposable(provider))
+    source.as(autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -141,7 +142,7 @@ public class AutoDisposeMaybeObserverTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     CompletableSubject scope = CompletableSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.as(AutoDispose.autoDisposable(provider))
+    source.as(autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -173,7 +174,7 @@ public class AutoDisposeMaybeObserverTest {
         return observer;
       });
       Maybe.just(1)
-          .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+          .as(autoDisposable(ScopeProvider.UNBOUND))
           .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
@@ -191,7 +192,7 @@ public class AutoDisposeMaybeObserverTest {
     //noinspection unchecked because Java
     Maybe<Integer> source = Maybe.create(e -> e.setCancellable(i::incrementAndGet));
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.autoDisposable(scope))
+    source.as(autoDisposable(scope))
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);
@@ -206,7 +207,7 @@ public class AutoDisposeMaybeObserverTest {
 
   @Test public void autoDispose_withScopeProviderCompleted_shouldNotReportDoubleSubscriptions() {
     TestObserver<Object> o = MaybeSubject.create()
-        .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+        .as(autoDisposable(ScopeProvider.UNBOUND))
         .test();
     o.assertNoValues();
     o.assertNoErrors();
@@ -216,7 +217,7 @@ public class AutoDisposeMaybeObserverTest {
 
   @Test public void unbound_shouldStillPassValues() {
     MaybeSubject<Integer> s = MaybeSubject.create();
-    TestObserver<Integer> o = s.as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+    TestObserver<Integer> o = s.as(autoDisposable(ScopeProvider.UNBOUND))
         .test();
 
     s.onSuccess(1);
@@ -227,7 +228,7 @@ public class AutoDisposeMaybeObserverTest {
     AutoDisposePlugins.setOutsideScopeHandler(e -> { });
     ScopeProvider provider = outsideScopeProvider();
     MaybeSubject<Integer> source = MaybeSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestObserver<Integer> o = source.as(autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -242,7 +243,7 @@ public class AutoDisposeMaybeObserverTest {
       throw new IllegalStateException(e);
     });
     ScopeProvider provider = outsideScopeProvider();
-    TestObserver<Integer> o = MaybeSubject.<Integer>create().as(AutoDispose.autoDisposable(provider))
+    TestObserver<Integer> o = MaybeSubject.<Integer>create().as(autoDisposable(provider))
         .test();
 
     o.assertNoValues();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -39,7 +39,9 @@ import static com.uber.autodispose.TestUtil.outsideScopeProvider;
 public class AutoDisposeMaybeObserverTest {
 
   private static final RecordingObserver.Logger LOGGER =
-      message -> System.out.println(AutoDisposeMaybeObserverTest.class.getSimpleName() + ": " + message);
+      message -> System.out.println(AutoDisposeMaybeObserverTest.class.getSimpleName()
+          + ": "
+          + message);
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
 
@@ -247,6 +249,7 @@ public class AutoDisposeMaybeObserverTest {
         .test();
 
     o.assertNoValues();
-    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
+    o.assertError(throwable -> throwable instanceof IllegalStateException
+        && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -43,11 +43,8 @@ import static com.uber.autodispose.TestUtil.outsideScopeProvider;
 
 public class AutoDisposeObserverTest {
 
-  private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
-    @Override public void log(String message) {
-      System.out.println(AutoDisposeObserverTest.class.getSimpleName() + ": " + message);
-    }
-  };
+  private static final RecordingObserver.Logger LOGGER =
+      message -> System.out.println(AutoDisposeObserverTest.class.getSimpleName() + ": " + message);
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
 
@@ -77,10 +74,8 @@ public class AutoDisposeObserverTest {
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Observable.just(new BClass())
         .as(AutoDispose.<BClass>autoDisposable(ScopeProvider.UNBOUND))
-        .subscribe(new Consumer<AClass>() {
-          @Override public void accept(AClass aClass) {
+        .subscribe((Consumer<AClass>) aClass -> {
 
-          }
         });
   }
 
@@ -138,16 +133,14 @@ public class AutoDisposeObserverTest {
     final AtomicReference<Observer> atomicObserver = new AtomicReference<>();
     final AtomicReference<Observer> atomicAutoDisposingObserver = new AtomicReference<>();
     try {
-      RxJavaPlugins.setOnObservableSubscribe(new BiFunction<Observable, Observer, Observer>() {
-        @Override public Observer apply(Observable source, Observer observer) {
-          if (atomicObserver.get() == null) {
-            atomicObserver.set(observer);
-          } else if (atomicAutoDisposingObserver.get() == null) {
-            atomicAutoDisposingObserver.set(observer);
-            RxJavaPlugins.setOnObservableSubscribe(null);
-          }
-          return observer;
+      RxJavaPlugins.setOnObservableSubscribe((source, observer) -> {
+        if (atomicObserver.get() == null) {
+          atomicObserver.set(observer);
+        } else if (atomicAutoDisposingObserver.get() == null) {
+          atomicAutoDisposingObserver.set(observer);
+          RxJavaPlugins.setOnObservableSubscribe(null);
         }
+        return observer;
       });
       Observable.just(1)
           .as(AutoDispose.<Integer>autoDisposable(ScopeProvider.UNBOUND))
@@ -167,15 +160,9 @@ public class AutoDisposeObserverTest {
     final AtomicInteger i = new AtomicInteger();
     //noinspection unchecked because Java
     final ObservableEmitter<Integer>[] emitter = new ObservableEmitter[1];
-    Observable<Integer> source = Observable.create(new ObservableOnSubscribe<Integer>() {
-      @Override public void subscribe(ObservableEmitter<Integer> e) {
-        e.setCancellable(new Cancellable() {
-          @Override public void cancel() {
-            i.incrementAndGet();
-          }
-        });
-        emitter[0] = e;
-      }
+    Observable<Integer> source = Observable.create(e -> {
+      e.setCancellable(i::incrementAndGet);
+      emitter[0] = e;
     });
     CompletableSubject scope = CompletableSubject.create();
     source.as(AutoDispose.<Integer>autoDisposable(scope))
@@ -215,9 +202,7 @@ public class AutoDisposeObserverTest {
   }
 
   @Test public void autoDispose_outsideScope_withProviderAndNoOpPlugin_shouldFailSilently() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) { }
-    });
+    AutoDisposePlugins.setOutsideScopeHandler(e -> { });
     ScopeProvider provider = outsideScopeProvider();
     PublishSubject<Integer> source = PublishSubject.create();
     TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
@@ -229,22 +214,16 @@ public class AutoDisposeObserverTest {
   }
 
   @Test public void autoDispose_outsideScope_withProviderAndPlugin_shouldFailWithWrappedExp() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) {
-        // Wrap in an IllegalStateException so we can verify this is the exception we see on the
-        // other side
-        throw new IllegalStateException(e);
-      }
+    AutoDisposePlugins.setOutsideScopeHandler(e -> {
+      // Wrap in an IllegalStateException so we can verify this is the exception we see on the
+      // other side
+      throw new IllegalStateException(e);
     });
     ScopeProvider provider = outsideScopeProvider();
     TestObserver<Integer> o = PublishSubject.<Integer>create().as(AutoDispose.<Integer>autoDisposable(provider))
         .test();
 
     o.assertNoValues();
-    o.assertError(new Predicate<Throwable>() {
-      @Override public boolean test(Throwable throwable) {
-        return throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException;
-      }
-    });
+    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -220,6 +220,7 @@ public class AutoDisposeObserverTest {
         .test();
 
     o.assertNoValues();
-    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
+    o.assertError(throwable -> throwable instanceof IllegalStateException
+        && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -21,13 +21,9 @@ import com.uber.autodispose.test.RecordingObserver;
 import com.uber.autodispose.test.RxErrorsRule;
 import io.reactivex.Observable;
 import io.reactivex.ObservableEmitter;
-import io.reactivex.ObservableOnSubscribe;
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.BiFunction;
-import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Predicate;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.CompletableSubject;
@@ -52,7 +48,7 @@ public class AutoDisposeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     PublishSubject<Integer> source = PublishSubject.create();
     CompletableSubject scope = CompletableSubject.create();
-    Disposable d = source.as(AutoDispose.<Integer>autoDisposable(scope))
+    Disposable d = source.as(AutoDispose.autoDisposable(scope))
         .subscribeWith(o);
     o.assertSubscribed();
 
@@ -73,7 +69,7 @@ public class AutoDisposeObserverTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Observable.just(new BClass())
-        .as(AutoDispose.<BClass>autoDisposable(ScopeProvider.UNBOUND))
+        .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
         .subscribe((Consumer<AClass>) aClass -> {
 
         });
@@ -83,7 +79,7 @@ public class AutoDisposeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     PublishSubject<Integer> source = PublishSubject.create();
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.<Integer>autoDisposable(scope))
+    source.as(AutoDispose.autoDisposable(scope))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -105,7 +101,7 @@ public class AutoDisposeObserverTest {
     PublishSubject<Integer> source = PublishSubject.create();
     CompletableSubject scope = CompletableSubject.create();
     ScopeProvider provider = TestUtil.makeProvider(scope);
-    source.as(AutoDispose.<Integer>autoDisposable(provider))
+    source.as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -143,7 +139,7 @@ public class AutoDisposeObserverTest {
         return observer;
       });
       Observable.just(1)
-          .as(AutoDispose.<Integer>autoDisposable(ScopeProvider.UNBOUND))
+          .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
           .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
@@ -165,7 +161,7 @@ public class AutoDisposeObserverTest {
       emitter[0] = e;
     });
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.<Integer>autoDisposable(scope))
+    source.as(AutoDispose.autoDisposable(scope))
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);
@@ -193,7 +189,7 @@ public class AutoDisposeObserverTest {
 
   @Test public void unbound_shouldStillPassValues() {
     PublishSubject<Integer> s = PublishSubject.create();
-    TestObserver<Integer> o = s.as(AutoDispose.<Integer>autoDisposable(ScopeProvider.UNBOUND))
+    TestObserver<Integer> o = s.as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
         .test();
 
     s.onNext(1);
@@ -205,7 +201,7 @@ public class AutoDisposeObserverTest {
     AutoDisposePlugins.setOutsideScopeHandler(e -> { });
     ScopeProvider provider = outsideScopeProvider();
     PublishSubject<Integer> source = PublishSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -220,7 +216,7 @@ public class AutoDisposeObserverTest {
       throw new IllegalStateException(e);
     });
     ScopeProvider provider = outsideScopeProvider();
-    TestObserver<Integer> o = PublishSubject.<Integer>create().as(AutoDispose.<Integer>autoDisposable(provider))
+    TestObserver<Integer> o = PublishSubject.<Integer>create().as(AutoDispose.autoDisposable(provider))
         .test();
 
     o.assertNoValues();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -48,7 +48,7 @@ public class AutoDisposeObserverTest {
     TestObserver<Integer> o = new TestObserver<>();
     PublishSubject<Integer> source = PublishSubject.create();
     CompletableSubject scope = CompletableSubject.create();
-    Disposable d = source.as(AutoDispose.autoDisposable(scope))
+    Disposable d = source.as(autoDisposable(scope))
         .subscribeWith(o);
     o.assertSubscribed();
 
@@ -69,7 +69,7 @@ public class AutoDisposeObserverTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Observable.just(new BClass())
-        .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+        .as(autoDisposable(ScopeProvider.UNBOUND))
         .subscribe((Consumer<AClass>) aClass -> {
 
         });
@@ -79,7 +79,7 @@ public class AutoDisposeObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     PublishSubject<Integer> source = PublishSubject.create();
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.autoDisposable(scope))
+    source.as(autoDisposable(scope))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -101,7 +101,7 @@ public class AutoDisposeObserverTest {
     PublishSubject<Integer> source = PublishSubject.create();
     CompletableSubject scope = CompletableSubject.create();
     ScopeProvider provider = TestUtil.makeProvider(scope);
-    source.as(AutoDispose.autoDisposable(provider))
+    source.as(autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -139,7 +139,7 @@ public class AutoDisposeObserverTest {
         return observer;
       });
       Observable.just(1)
-          .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+          .as(autoDisposable(ScopeProvider.UNBOUND))
           .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
@@ -161,7 +161,7 @@ public class AutoDisposeObserverTest {
       emitter[0] = e;
     });
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.autoDisposable(scope))
+    source.as(autoDisposable(scope))
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);
@@ -189,7 +189,7 @@ public class AutoDisposeObserverTest {
 
   @Test public void unbound_shouldStillPassValues() {
     PublishSubject<Integer> s = PublishSubject.create();
-    TestObserver<Integer> o = s.as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+    TestObserver<Integer> o = s.as(autoDisposable(ScopeProvider.UNBOUND))
         .test();
 
     s.onNext(1);
@@ -201,7 +201,7 @@ public class AutoDisposeObserverTest {
     AutoDisposePlugins.setOutsideScopeHandler(e -> { });
     ScopeProvider provider = outsideScopeProvider();
     PublishSubject<Integer> source = PublishSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestObserver<Integer> o = source.as(autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -216,7 +216,7 @@ public class AutoDisposeObserverTest {
       throw new IllegalStateException(e);
     });
     ScopeProvider provider = outsideScopeProvider();
-    TestObserver<Integer> o = PublishSubject.<Integer>create().as(AutoDispose.autoDisposable(provider))
+    TestObserver<Integer> o = PublishSubject.<Integer>create().as(autoDisposable(provider))
         .test();
 
     o.assertNoValues();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeParallelFlowableTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeParallelFlowableTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.uber.autodispose.AutoDispose.autoDisposable;
 
 public class AutoDisposeParallelFlowableTest {
 
@@ -26,7 +27,7 @@ public class AutoDisposeParallelFlowableTest {
     Subscriber<Integer>[] subscribers = new Subscriber[] { subscriber };
     Flowable.just(1, 2)
         .parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.autoDisposable(scope))
+        .as(autoDisposable(scope))
         .subscribe(subscribers);
 
     List<Throwable> errors = subscriber.errors();
@@ -43,7 +44,7 @@ public class AutoDisposeParallelFlowableTest {
     //noinspection unchecked
     Subscriber<Integer>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
     source.parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.autoDisposable(scope))
+        .as(autoDisposable(scope))
         .subscribe(subscribers);
     firstSubscriber.assertSubscribed();
     secondSubscriber.assertSubscribed();
@@ -76,7 +77,7 @@ public class AutoDisposeParallelFlowableTest {
     Subscriber<Integer>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
 
     source.parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.autoDisposable(scope))
+        .as(autoDisposable(scope))
         .subscribe(subscribers);
 
     firstSubscriber.assertSubscribed();
@@ -107,7 +108,7 @@ public class AutoDisposeParallelFlowableTest {
     Subscriber<Integer>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
 
     source.parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.autoDisposable(provider))
+        .as(autoDisposable(provider))
         .subscribe(subscribers);
     firstSubscriber.assertSubscribed();
     secondSubscriber.assertSubscribed();
@@ -147,7 +148,7 @@ public class AutoDisposeParallelFlowableTest {
     Subscriber<Object>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
     PublishProcessor.create()
         .parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+        .as(autoDisposable(ScopeProvider.UNBOUND))
         .subscribe(subscribers);
     firstSubscriber.assertNoValues();
     firstSubscriber.assertNoErrors();
@@ -164,7 +165,7 @@ public class AutoDisposeParallelFlowableTest {
     Subscriber<Integer>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
 
     source.parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+        .as(autoDisposable(ScopeProvider.UNBOUND))
         .subscribe(subscribers);
 
     source.onNext(1);

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeParallelFlowableTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeParallelFlowableTest.java
@@ -26,7 +26,7 @@ public class AutoDisposeParallelFlowableTest {
     Subscriber<Integer>[] subscribers = new Subscriber[] { subscriber };
     Flowable.just(1, 2)
         .parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.<Integer>autoDisposable(scope))
+        .as(AutoDispose.autoDisposable(scope))
         .subscribe(subscribers);
 
     List<Throwable> errors = subscriber.errors();
@@ -43,7 +43,7 @@ public class AutoDisposeParallelFlowableTest {
     //noinspection unchecked
     Subscriber<Integer>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
     source.parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.<Integer>autoDisposable(scope))
+        .as(AutoDispose.autoDisposable(scope))
         .subscribe(subscribers);
     firstSubscriber.assertSubscribed();
     secondSubscriber.assertSubscribed();
@@ -76,7 +76,7 @@ public class AutoDisposeParallelFlowableTest {
     Subscriber<Integer>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
 
     source.parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.<Integer>autoDisposable(scope))
+        .as(AutoDispose.autoDisposable(scope))
         .subscribe(subscribers);
 
     firstSubscriber.assertSubscribed();
@@ -107,7 +107,7 @@ public class AutoDisposeParallelFlowableTest {
     Subscriber<Integer>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
 
     source.parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.<Integer>autoDisposable(provider))
+        .as(AutoDispose.autoDisposable(provider))
         .subscribe(subscribers);
     firstSubscriber.assertSubscribed();
     secondSubscriber.assertSubscribed();
@@ -164,7 +164,7 @@ public class AutoDisposeParallelFlowableTest {
     Subscriber<Integer>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
 
     source.parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.<Integer>autoDisposable(ScopeProvider.UNBOUND))
+        .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
         .subscribe(subscribers);
 
     source.onNext(1);

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -20,13 +20,8 @@ import com.uber.autodispose.observers.AutoDisposingSingleObserver;
 import com.uber.autodispose.test.RecordingObserver;
 import com.uber.autodispose.test.RxErrorsRule;
 import io.reactivex.Single;
-import io.reactivex.SingleEmitter;
 import io.reactivex.SingleObserver;
-import io.reactivex.SingleOnSubscribe;
-import io.reactivex.functions.BiFunction;
-import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Predicate;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.subjects.CompletableSubject;
@@ -51,7 +46,7 @@ public class AutoDisposeSingleObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.<Integer>autoDisposable(scope))
+    source.as(AutoDispose.autoDisposable(scope))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -70,7 +65,7 @@ public class AutoDisposeSingleObserverTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Single.just(new BClass())
-        .as(AutoDispose.<BClass>autoDisposable(ScopeProvider.UNBOUND))
+        .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
         .subscribe((Consumer<AClass>) aClass -> {
 
         });
@@ -80,7 +75,7 @@ public class AutoDisposeSingleObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.<Integer>autoDisposable(scope))
+    source.as(AutoDispose.autoDisposable(scope))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -102,7 +97,7 @@ public class AutoDisposeSingleObserverTest {
     SingleSubject<Integer> source = SingleSubject.create();
     CompletableSubject scope = CompletableSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.as(AutoDispose.<Integer>autoDisposable(provider))
+    source.as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -123,7 +118,7 @@ public class AutoDisposeSingleObserverTest {
     SingleSubject<Integer> source = SingleSubject.create();
     CompletableSubject scope = CompletableSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.as(AutoDispose.<Integer>autoDisposable(provider))
+    source.as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -154,7 +149,7 @@ public class AutoDisposeSingleObserverTest {
         return observer;
       });
       Single.just(1)
-          .as(AutoDispose.<Integer>autoDisposable(ScopeProvider.UNBOUND))
+          .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
           .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
@@ -172,7 +167,7 @@ public class AutoDisposeSingleObserverTest {
     //noinspection unchecked because Java
     Single<Integer> source = Single.create(e -> e.setCancellable(i::incrementAndGet));
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.<Integer>autoDisposable(scope))
+    source.as(AutoDispose.autoDisposable(scope))
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);
@@ -197,7 +192,7 @@ public class AutoDisposeSingleObserverTest {
 
   @Test public void unbound_shouldStillPassValues() {
     SingleSubject<Integer> s = SingleSubject.create();
-    TestObserver<Integer> o = s.as(AutoDispose.<Integer>autoDisposable(ScopeProvider.UNBOUND))
+    TestObserver<Integer> o = s.as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
         .test();
 
     s.onSuccess(1);
@@ -208,7 +203,7 @@ public class AutoDisposeSingleObserverTest {
     AutoDisposePlugins.setOutsideScopeHandler(e -> { });
     ScopeProvider provider = outsideScopeProvider();
     SingleSubject<Integer> source = SingleSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -223,7 +218,7 @@ public class AutoDisposeSingleObserverTest {
       throw new IllegalStateException(e);
     });
     ScopeProvider provider = outsideScopeProvider();
-    TestObserver<Integer> o = SingleSubject.<Integer>create().as(AutoDispose.<Integer>autoDisposable(provider))
+    TestObserver<Integer> o = SingleSubject.<Integer>create().as(AutoDispose.autoDisposable(provider))
         .test();
 
     o.assertNoValues();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -32,6 +32,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.uber.autodispose.AutoDispose.autoDisposable;
 import static com.uber.autodispose.TestUtil.makeProvider;
 import static com.uber.autodispose.TestUtil.outsideScopeProvider;
 
@@ -46,7 +47,7 @@ public class AutoDisposeSingleObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.autoDisposable(scope))
+    source.as(autoDisposable(scope))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -65,7 +66,7 @@ public class AutoDisposeSingleObserverTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Single.just(new BClass())
-        .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+        .as(autoDisposable(ScopeProvider.UNBOUND))
         .subscribe((Consumer<AClass>) aClass -> {
 
         });
@@ -75,7 +76,7 @@ public class AutoDisposeSingleObserverTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     SingleSubject<Integer> source = SingleSubject.create();
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.autoDisposable(scope))
+    source.as(autoDisposable(scope))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -97,7 +98,7 @@ public class AutoDisposeSingleObserverTest {
     SingleSubject<Integer> source = SingleSubject.create();
     CompletableSubject scope = CompletableSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.as(AutoDispose.autoDisposable(provider))
+    source.as(autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -118,7 +119,7 @@ public class AutoDisposeSingleObserverTest {
     SingleSubject<Integer> source = SingleSubject.create();
     CompletableSubject scope = CompletableSubject.create();
     ScopeProvider provider = makeProvider(scope);
-    source.as(AutoDispose.autoDisposable(provider))
+    source.as(autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -149,7 +150,7 @@ public class AutoDisposeSingleObserverTest {
         return observer;
       });
       Single.just(1)
-          .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+          .as(autoDisposable(ScopeProvider.UNBOUND))
           .subscribe();
 
       assertThat(atomicAutoDisposingObserver.get()).isNotNull();
@@ -167,7 +168,7 @@ public class AutoDisposeSingleObserverTest {
     //noinspection unchecked because Java
     Single<Integer> source = Single.create(e -> e.setCancellable(i::incrementAndGet));
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.autoDisposable(scope))
+    source.as(autoDisposable(scope))
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);
@@ -182,7 +183,7 @@ public class AutoDisposeSingleObserverTest {
 
   @Test public void autoDispose_withScopeProviderCompleted_shouldNotReportDoubleSubscriptions() {
     TestObserver<Object> o = SingleSubject.create()
-        .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+        .as(autoDisposable(ScopeProvider.UNBOUND))
         .test();
     o.assertNoValues();
     o.assertNoErrors();
@@ -192,7 +193,7 @@ public class AutoDisposeSingleObserverTest {
 
   @Test public void unbound_shouldStillPassValues() {
     SingleSubject<Integer> s = SingleSubject.create();
-    TestObserver<Integer> o = s.as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+    TestObserver<Integer> o = s.as(autoDisposable(ScopeProvider.UNBOUND))
         .test();
 
     s.onSuccess(1);
@@ -203,7 +204,7 @@ public class AutoDisposeSingleObserverTest {
     AutoDisposePlugins.setOutsideScopeHandler(e -> { });
     ScopeProvider provider = outsideScopeProvider();
     SingleSubject<Integer> source = SingleSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestObserver<Integer> o = source.as(autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -218,7 +219,7 @@ public class AutoDisposeSingleObserverTest {
       throw new IllegalStateException(e);
     });
     ScopeProvider provider = outsideScopeProvider();
-    TestObserver<Integer> o = SingleSubject.<Integer>create().as(AutoDispose.autoDisposable(provider))
+    TestObserver<Integer> o = SingleSubject.<Integer>create().as(autoDisposable(provider))
         .test();
 
     o.assertNoValues();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -39,7 +39,9 @@ import static com.uber.autodispose.TestUtil.outsideScopeProvider;
 public class AutoDisposeSingleObserverTest {
 
   private static final RecordingObserver.Logger LOGGER =
-      message -> System.out.println(AutoDisposeSingleObserverTest.class.getSimpleName() + ": " + message);
+      message -> System.out.println(AutoDisposeSingleObserverTest.class.getSimpleName()
+          + ": "
+          + message);
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
 
@@ -223,6 +225,7 @@ public class AutoDisposeSingleObserverTest {
         .test();
 
     o.assertNoValues();
-    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
+    o.assertError(throwable -> throwable instanceof IllegalStateException
+        && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -70,10 +70,8 @@ public class AutoDisposeSubscriberTest {
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Flowable.just(new BClass())
         .as(AutoDispose.<BClass>autoDisposable(ScopeProvider.UNBOUND))
-        .subscribe(new Consumer<AClass>() {
-          @Override public void accept(AClass aClass) {
+        .subscribe((Consumer<AClass>) aClass -> {
 
-          }
         });
   }
 
@@ -136,20 +134,18 @@ public class AutoDisposeSubscriberTest {
     final AtomicReference<Subscriber> atomicSubscriber = new AtomicReference<>();
     final AtomicReference<Subscriber> atomicAutoDisposingSubscriber = new AtomicReference<>();
     try {
-      RxJavaPlugins.setOnFlowableSubscribe(new BiFunction<Flowable, Subscriber, Subscriber>() {
-        @Override public Subscriber apply(Flowable source, Subscriber subscriber) {
-          if (atomicSubscriber.get() == null) {
-            System.out.println(subscriber.getClass()
-                .toString());
-            atomicSubscriber.set(subscriber);
-          } else if (atomicAutoDisposingSubscriber.get() == null) {
-            System.out.println(subscriber.getClass()
-                .toString());
-            atomicAutoDisposingSubscriber.set(subscriber);
-            RxJavaPlugins.setOnFlowableSubscribe(null);
-          }
-          return subscriber;
+      RxJavaPlugins.setOnFlowableSubscribe((source, subscriber) -> {
+        if (atomicSubscriber.get() == null) {
+          System.out.println(subscriber.getClass()
+              .toString());
+          atomicSubscriber.set(subscriber);
+        } else if (atomicAutoDisposingSubscriber.get() == null) {
+          System.out.println(subscriber.getClass()
+              .toString());
+          atomicAutoDisposingSubscriber.set(subscriber);
+          RxJavaPlugins.setOnFlowableSubscribe(null);
         }
+        return subscriber;
       });
       Flowable.just(1)
           .as(AutoDispose.<Integer>autoDisposable(ScopeProvider.UNBOUND))
@@ -169,15 +165,9 @@ public class AutoDisposeSubscriberTest {
     final AtomicInteger i = new AtomicInteger();
     //noinspection unchecked because Java
     final FlowableEmitter<Integer>[] emitter = new FlowableEmitter[1];
-    Flowable<Integer> source = Flowable.create(new FlowableOnSubscribe<Integer>() {
-      @Override public void subscribe(FlowableEmitter<Integer> e) {
-        e.setCancellable(new Cancellable() {
-          @Override public void cancel() {
-            i.incrementAndGet();
-          }
-        });
-        emitter[0] = e;
-      }
+    Flowable<Integer> source = Flowable.create(e -> {
+      e.setCancellable(i::incrementAndGet);
+      emitter[0] = e;
     }, BackpressureStrategy.LATEST);
     CompletableSubject scope = CompletableSubject.create();
     source.as(AutoDispose.<Integer>autoDisposable(scope))
@@ -217,9 +207,7 @@ public class AutoDisposeSubscriberTest {
   }
 
   @Test public void autoDispose_outsideScope_withProviderAndNoOpPlugin_shouldFailSilently() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) { }
-    });
+    AutoDisposePlugins.setOutsideScopeHandler(e -> { });
     ScopeProvider provider = outsideScopeProvider();
     PublishProcessor<Integer> source = PublishProcessor.create();
     TestSubscriber<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
@@ -231,22 +219,16 @@ public class AutoDisposeSubscriberTest {
   }
 
   @Test public void autoDispose_outsideScope_withProviderAndPlugin_shouldFailWithWrappedExp() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) {
-        // Wrap in an IllegalStateException so we can verify this is the exception we see on the
-        // other side
-        throw new IllegalStateException(e);
-      }
+    AutoDisposePlugins.setOutsideScopeHandler(e -> {
+      // Wrap in an IllegalStateException so we can verify this is the exception we see on the
+      // other side
+      throw new IllegalStateException(e);
     });
     ScopeProvider provider = outsideScopeProvider();
     TestSubscriber<Integer> o = PublishProcessor.<Integer>create().as(AutoDispose.<Integer>autoDisposable(provider))
         .test();
 
     o.assertNoValues();
-    o.assertError(new Predicate<Throwable>() {
-      @Override public boolean test(Throwable throwable) {
-        return throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException;
-      }
-    });
+    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -226,6 +226,7 @@ public class AutoDisposeSubscriberTest {
         .test();
 
     o.assertNoValues();
-    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
+    o.assertError(throwable -> throwable instanceof IllegalStateException
+        && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.uber.autodispose.AutoDispose.autoDisposable;
 import static com.uber.autodispose.TestUtil.outsideScopeProvider;
 
 public class AutoDisposeSubscriberTest {
@@ -44,7 +45,7 @@ public class AutoDisposeSubscriberTest {
     TestSubscriber<Integer> o = new TestSubscriber<>();
     PublishProcessor<Integer> source = PublishProcessor.create();
     CompletableSubject scope = CompletableSubject.create();
-    Disposable d = source.as(AutoDispose.autoDisposable(scope))
+    Disposable d = source.as(autoDisposable(scope))
         .subscribeWith(o);
     o.assertSubscribed();
 
@@ -65,7 +66,7 @@ public class AutoDisposeSubscriberTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Flowable.just(new BClass())
-        .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+        .as(autoDisposable(ScopeProvider.UNBOUND))
         .subscribe((Consumer<AClass>) aClass -> {
 
         });
@@ -74,7 +75,7 @@ public class AutoDisposeSubscriberTest {
   @Test public void autoDispose_withMaybe_interrupted() {
     PublishProcessor<Integer> source = PublishProcessor.create();
     CompletableSubject scope = CompletableSubject.create();
-    TestSubscriber<Integer> o = source.as(AutoDispose.autoDisposable(scope))
+    TestSubscriber<Integer> o = source.as(autoDisposable(scope))
         .test();
     o.assertSubscribed();
 
@@ -99,7 +100,7 @@ public class AutoDisposeSubscriberTest {
     PublishProcessor<Integer> source = PublishProcessor.create();
     CompletableSubject scope = CompletableSubject.create();
     ScopeProvider provider = TestUtil.makeProvider(scope);
-    TestSubscriber<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestSubscriber<Integer> o = source.as(autoDisposable(provider))
         .test();
     o.assertSubscribed();
 
@@ -144,7 +145,7 @@ public class AutoDisposeSubscriberTest {
         return subscriber;
       });
       Flowable.just(1)
-          .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+          .as(autoDisposable(ScopeProvider.UNBOUND))
           .subscribe();
 
       assertThat(atomicAutoDisposingSubscriber.get()).isNotNull();
@@ -166,7 +167,7 @@ public class AutoDisposeSubscriberTest {
       emitter[0] = e;
     }, BackpressureStrategy.LATEST);
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.autoDisposable(scope))
+    source.as(autoDisposable(scope))
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);
@@ -184,7 +185,7 @@ public class AutoDisposeSubscriberTest {
 
   @Test public void autoDispose_withScopeProviderCompleted_shouldNotReportDoubleSubscriptions() {
     TestSubscriber<Object> o = PublishProcessor.create()
-        .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+        .as(autoDisposable(ScopeProvider.UNBOUND))
         .test();
     o.assertNoValues();
     o.assertNoErrors();
@@ -194,7 +195,7 @@ public class AutoDisposeSubscriberTest {
 
   @Test public void unbound_shouldStillPassValues() {
     PublishProcessor<Integer> s = PublishProcessor.create();
-    TestSubscriber<Integer> o = s.as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
+    TestSubscriber<Integer> o = s.as(autoDisposable(ScopeProvider.UNBOUND))
         .test();
 
     s.onNext(1);
@@ -206,7 +207,7 @@ public class AutoDisposeSubscriberTest {
     AutoDisposePlugins.setOutsideScopeHandler(e -> { });
     ScopeProvider provider = outsideScopeProvider();
     PublishProcessor<Integer> source = PublishProcessor.create();
-    TestSubscriber<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestSubscriber<Integer> o = source.as(autoDisposable(provider))
         .test();
 
     assertThat(source.hasSubscribers()).isFalse();
@@ -221,7 +222,7 @@ public class AutoDisposeSubscriberTest {
       throw new IllegalStateException(e);
     });
     ScopeProvider provider = outsideScopeProvider();
-    TestSubscriber<Integer> o = PublishProcessor.<Integer>create().as(AutoDispose.autoDisposable(provider))
+    TestSubscriber<Integer> o = PublishProcessor.<Integer>create().as(autoDisposable(provider))
         .test();
 
     o.assertNoValues();

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -21,12 +21,8 @@ import com.uber.autodispose.test.RxErrorsRule;
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
 import io.reactivex.FlowableEmitter;
-import io.reactivex.FlowableOnSubscribe;
 import io.reactivex.disposables.Disposable;
-import io.reactivex.functions.BiFunction;
-import io.reactivex.functions.Cancellable;
 import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Predicate;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subjects.CompletableSubject;
@@ -48,7 +44,7 @@ public class AutoDisposeSubscriberTest {
     TestSubscriber<Integer> o = new TestSubscriber<>();
     PublishProcessor<Integer> source = PublishProcessor.create();
     CompletableSubject scope = CompletableSubject.create();
-    Disposable d = source.as(AutoDispose.<Integer>autoDisposable(scope))
+    Disposable d = source.as(AutoDispose.autoDisposable(scope))
         .subscribeWith(o);
     o.assertSubscribed();
 
@@ -69,7 +65,7 @@ public class AutoDisposeSubscriberTest {
 
   @Test public void autoDispose_withSuperClassGenerics_compilesFine() {
     Flowable.just(new BClass())
-        .as(AutoDispose.<BClass>autoDisposable(ScopeProvider.UNBOUND))
+        .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
         .subscribe((Consumer<AClass>) aClass -> {
 
         });
@@ -78,7 +74,7 @@ public class AutoDisposeSubscriberTest {
   @Test public void autoDispose_withMaybe_interrupted() {
     PublishProcessor<Integer> source = PublishProcessor.create();
     CompletableSubject scope = CompletableSubject.create();
-    TestSubscriber<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(scope))
+    TestSubscriber<Integer> o = source.as(AutoDispose.autoDisposable(scope))
         .test();
     o.assertSubscribed();
 
@@ -103,7 +99,7 @@ public class AutoDisposeSubscriberTest {
     PublishProcessor<Integer> source = PublishProcessor.create();
     CompletableSubject scope = CompletableSubject.create();
     ScopeProvider provider = TestUtil.makeProvider(scope);
-    TestSubscriber<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestSubscriber<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
     o.assertSubscribed();
 
@@ -148,7 +144,7 @@ public class AutoDisposeSubscriberTest {
         return subscriber;
       });
       Flowable.just(1)
-          .as(AutoDispose.<Integer>autoDisposable(ScopeProvider.UNBOUND))
+          .as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
           .subscribe();
 
       assertThat(atomicAutoDisposingSubscriber.get()).isNotNull();
@@ -170,7 +166,7 @@ public class AutoDisposeSubscriberTest {
       emitter[0] = e;
     }, BackpressureStrategy.LATEST);
     CompletableSubject scope = CompletableSubject.create();
-    source.as(AutoDispose.<Integer>autoDisposable(scope))
+    source.as(AutoDispose.autoDisposable(scope))
         .subscribe();
 
     assertThat(i.get()).isEqualTo(0);
@@ -198,7 +194,7 @@ public class AutoDisposeSubscriberTest {
 
   @Test public void unbound_shouldStillPassValues() {
     PublishProcessor<Integer> s = PublishProcessor.create();
-    TestSubscriber<Integer> o = s.as(AutoDispose.<Integer>autoDisposable(ScopeProvider.UNBOUND))
+    TestSubscriber<Integer> o = s.as(AutoDispose.autoDisposable(ScopeProvider.UNBOUND))
         .test();
 
     s.onNext(1);
@@ -210,7 +206,7 @@ public class AutoDisposeSubscriberTest {
     AutoDisposePlugins.setOutsideScopeHandler(e -> { });
     ScopeProvider provider = outsideScopeProvider();
     PublishProcessor<Integer> source = PublishProcessor.create();
-    TestSubscriber<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestSubscriber<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
 
     assertThat(source.hasSubscribers()).isFalse();
@@ -225,7 +221,7 @@ public class AutoDisposeSubscriberTest {
       throw new IllegalStateException(e);
     });
     ScopeProvider provider = outsideScopeProvider();
-    TestSubscriber<Integer> o = PublishProcessor.<Integer>create().as(AutoDispose.<Integer>autoDisposable(provider))
+    TestSubscriber<Integer> o = PublishProcessor.<Integer>create().as(AutoDispose.autoDisposable(provider))
         .test();
 
     o.assertNoValues();

--- a/autodispose/src/test/java/com/uber/autodispose/TestUtil.java
+++ b/autodispose/src/test/java/com/uber/autodispose/TestUtil.java
@@ -21,10 +21,8 @@ import io.reactivex.subjects.CompletableSubject;
 
 final class TestUtil {
 
-  private static final ScopeProvider OUTSIDE_SCOPE_PROVIDER = new ScopeProvider() {
-    @Override public CompletableSource requestScope() {
-      throw new OutsideScopeException("Outside scope!");
-    }
+  private static final ScopeProvider OUTSIDE_SCOPE_PROVIDER = () -> {
+    throw new OutsideScopeException("Outside scope!");
   };
 
   private TestUtil() {
@@ -32,11 +30,7 @@ final class TestUtil {
   }
 
   static ScopeProvider makeProvider(final CompletableSubject scope) {
-    return new ScopeProvider() {
-      @Override public CompletableSource requestScope() {
-        return scope;
-      }
-    };
+    return () -> scope;
   }
 
   static ScopeProvider outsideScopeProvider() {

--- a/autodispose/src/test/java/com/uber/autodispose/TestUtil.java
+++ b/autodispose/src/test/java/com/uber/autodispose/TestUtil.java
@@ -16,7 +16,6 @@
 
 package com.uber.autodispose;
 
-import io.reactivex.CompletableSource;
 import io.reactivex.subjects.CompletableSubject;
 
 final class TestUtil {

--- a/lifecycle/autodispose-lifecycle-jdk8/src/test/java/com/uber/autodispose/lifecycle/jdk8/DefaultLifecycleScopeProviderTest.java
+++ b/lifecycle/autodispose-lifecycle-jdk8/src/test/java/com/uber/autodispose/lifecycle/jdk8/DefaultLifecycleScopeProviderTest.java
@@ -16,7 +16,6 @@
 
 package com.uber.autodispose.lifecycle.jdk8;
 
-import com.uber.autodispose.AutoDispose;
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction;
 import com.uber.autodispose.lifecycle.LifecycleEndedException;
 import com.uber.autodispose.test.RecordingObserver;
@@ -26,6 +25,7 @@ import io.reactivex.subjects.PublishSubject;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.uber.autodispose.AutoDispose.autoDisposable;
 
 public final class DefaultLifecycleScopeProviderTest {
 
@@ -67,7 +67,7 @@ public final class DefaultLifecycleScopeProviderTest {
     PublishSubject<Integer> source = PublishSubject.create();
     ThingWithALifecycle provider = new ThingWithALifecycle();
     BehaviorSubject<LifecycleEvent> lifecycle = provider.lifecycle;
-    source.as(AutoDispose.autoDisposable(provider))
+    source.as(autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 

--- a/lifecycle/autodispose-lifecycle/build.gradle
+++ b/lifecycle/autodispose-lifecycle/build.gradle
@@ -19,8 +19,8 @@ plugins {
   id 'net.ltgt.errorprone'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 test {
   testLogging.showStandardStreams = true

--- a/lifecycle/autodispose-lifecycle/src/main/java/com/uber/autodispose/lifecycle/LifecycleScopes.java
+++ b/lifecycle/autodispose-lifecycle/src/main/java/com/uber/autodispose/lifecycle/LifecycleScopes.java
@@ -33,11 +33,7 @@ import java.util.concurrent.Callable;
  */
 public final class LifecycleScopes {
 
-  private static final Comparator<Comparable<Object>> COMPARABLE_COMPARATOR = new Comparator<Comparable<Object>>() {
-    @Override public int compare(Comparable<Object> o1, Comparable<Object> o2) {
-      return o1.compareTo(o2);
-    }
-  };
+  private static final Comparator<Comparable<Object>> COMPARABLE_COMPARATOR = Comparable::compareTo;
 
   private LifecycleScopes() {
     throw new InstantiationError();
@@ -136,17 +132,9 @@ public final class LifecycleScopes {
       @Nullable final Comparator<E> comparator) {
     Predicate<E> equalityPredicate;
     if (comparator != null) {
-      equalityPredicate = new Predicate<E>() {
-        @Override public boolean test(E e) {
-          return comparator.compare(e, endEvent) >= 0;
-        }
-      };
+      equalityPredicate = e -> comparator.compare(e, endEvent) >= 0;
     } else {
-      equalityPredicate = new Predicate<E>() {
-        @Override public boolean test(E e) {
-          return e.equals(endEvent);
-        }
-      };
+      equalityPredicate = e -> e.equals(endEvent);
     }
     return lifecycle.skip(1)
         .takeUntil(equalityPredicate)

--- a/lifecycle/autodispose-lifecycle/src/main/java/com/uber/autodispose/lifecycle/TestLifecycleScopeProvider.java
+++ b/lifecycle/autodispose-lifecycle/src/main/java/com/uber/autodispose/lifecycle/TestLifecycleScopeProvider.java
@@ -63,16 +63,14 @@ public final class TestLifecycleScopeProvider
   }
 
   @Override public CorrespondingEventsFunction<TestLifecycle> correspondingEvents() {
-    return new CorrespondingEventsFunction<TestLifecycle>() {
-      @Override public TestLifecycle apply(TestLifecycle testLifecycle) {
-        switch (testLifecycle) {
-          case STARTED:
-            return TestLifecycle.STOPPED;
-          case STOPPED:
-            throw new LifecycleEndedException();
-          default:
-            throw new IllegalStateException("Unknown lifecycle event.");
-        }
+    return testLifecycle -> {
+      switch (testLifecycle) {
+        case STARTED:
+          return TestLifecycle.STOPPED;
+        case STOPPED:
+          throw new LifecycleEndedException();
+        default:
+          throw new IllegalStateException("Unknown lifecycle event.");
       }
     };
   }

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderCompletableTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderCompletableTest.java
@@ -21,8 +21,6 @@ import com.uber.autodispose.OutsideScopeException;
 import com.uber.autodispose.test.RecordingObserver;
 import com.uber.autodispose.test.RxErrorsRule;
 import io.reactivex.Completable;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Predicate;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.CompletableSubject;
@@ -37,7 +35,10 @@ import static com.uber.autodispose.lifecycle.TestUtil.makeLifecycleProvider;
 
 public class LifecycleScopeProviderCompletableTest {
 
-  private static final RecordingObserver.Logger LOGGER = message -> System.out.println(LifecycleScopeProviderCompletableTest.class.getSimpleName() + ": " + message);
+  private static final RecordingObserver.Logger LOGGER =
+      message -> System.out.println(LifecycleScopeProviderCompletableTest.class.getSimpleName()
+          + ": "
+          + message);
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
 
@@ -171,6 +172,7 @@ public class LifecycleScopeProviderCompletableTest {
         .test();
 
     o.assertNoValues();
-    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
+    o.assertError(throwable -> throwable instanceof IllegalStateException
+        && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderMaybeTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderMaybeTest.java
@@ -37,11 +37,8 @@ import static com.uber.autodispose.lifecycle.TestUtil.makeLifecycleProvider;
 
 public class LifecycleScopeProviderMaybeTest {
 
-  private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
-    @Override public void log(String message) {
-      System.out.println(LifecycleScopeProviderMaybeTest.class.getSimpleName() + ": " + message);
-    }
-  };
+  private static final RecordingObserver.Logger LOGGER =
+      message -> System.out.println(LifecycleScopeProviderMaybeTest.class.getSimpleName() + ": " + message);
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
 
@@ -130,9 +127,7 @@ public class LifecycleScopeProviderMaybeTest {
   }
 
   @Test public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) { }
-    });
+    AutoDisposePlugins.setOutsideScopeHandler(e -> { });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     MaybeSubject<Integer> source = MaybeSubject.create();
@@ -146,10 +141,8 @@ public class LifecycleScopeProviderMaybeTest {
   }
 
   @Test public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) {
-        // Noop
-      }
+    AutoDisposePlugins.setOutsideScopeHandler(e -> {
+      // Noop
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
@@ -167,12 +160,10 @@ public class LifecycleScopeProviderMaybeTest {
   }
 
   @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithWrappedExp() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) {
-        // Wrap in an IllegalStateException so we can verify this is the exception we see on the
-        // other side
-        throw new IllegalStateException(e);
-      }
+    AutoDisposePlugins.setOutsideScopeHandler(e -> {
+      // Wrap in an IllegalStateException so we can verify this is the exception we see on the
+      // other side
+      throw new IllegalStateException(e);
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
@@ -181,10 +172,6 @@ public class LifecycleScopeProviderMaybeTest {
         .test();
 
     o.assertNoValues();
-    o.assertError(new Predicate<Throwable>() {
-      @Override public boolean test(Throwable throwable) {
-        return throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException;
-      }
-    });
+    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderMaybeTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderMaybeTest.java
@@ -22,8 +22,6 @@ import com.uber.autodispose.OutsideScopeException;
 import com.uber.autodispose.test.RecordingObserver;
 import com.uber.autodispose.test.RxErrorsRule;
 import io.reactivex.Maybe;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Predicate;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.MaybeSubject;
@@ -51,7 +49,7 @@ public class LifecycleScopeProviderMaybeTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.as(AutoDispose.<Integer>autoDisposable(provider))
+    source.as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -76,7 +74,7 @@ public class LifecycleScopeProviderMaybeTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.as(AutoDispose.<Integer>autoDisposable(provider))
+    source.as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -104,7 +102,7 @@ public class LifecycleScopeProviderMaybeTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Maybe.just(1)
-        .as(AutoDispose.<Integer>autoDisposable(provider))
+        .as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
 
     o.takeSubscribe();
@@ -119,7 +117,7 @@ public class LifecycleScopeProviderMaybeTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Maybe.just(1)
-        .as(AutoDispose.<Integer>autoDisposable(provider))
+        .as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
 
     o.takeSubscribe();
@@ -131,7 +129,7 @@ public class LifecycleScopeProviderMaybeTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     MaybeSubject<Integer> source = MaybeSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -150,7 +148,7 @@ public class LifecycleScopeProviderMaybeTest {
     lifecycle.onNext(3);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     MaybeSubject<Integer> source = MaybeSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -168,7 +166,7 @@ public class LifecycleScopeProviderMaybeTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     MaybeSubject<Integer> source = MaybeSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
 
     o.assertNoValues();

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderMaybeTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderMaybeTest.java
@@ -36,7 +36,9 @@ import static com.uber.autodispose.lifecycle.TestUtil.makeLifecycleProvider;
 public class LifecycleScopeProviderMaybeTest {
 
   private static final RecordingObserver.Logger LOGGER =
-      message -> System.out.println(LifecycleScopeProviderMaybeTest.class.getSimpleName() + ": " + message);
+      message -> System.out.println(LifecycleScopeProviderMaybeTest.class.getSimpleName()
+          + ": "
+          + message);
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
 
@@ -170,6 +172,7 @@ public class LifecycleScopeProviderMaybeTest {
         .test();
 
     o.assertNoValues();
-    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
+    o.assertError(throwable -> throwable instanceof IllegalStateException
+        && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderMaybeTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderMaybeTest.java
@@ -16,7 +16,6 @@
 
 package com.uber.autodispose.lifecycle;
 
-import com.uber.autodispose.AutoDispose;
 import com.uber.autodispose.AutoDisposePlugins;
 import com.uber.autodispose.OutsideScopeException;
 import com.uber.autodispose.test.RecordingObserver;
@@ -31,6 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.uber.autodispose.AutoDispose.autoDisposable;
 import static com.uber.autodispose.lifecycle.TestUtil.makeLifecycleProvider;
 
 public class LifecycleScopeProviderMaybeTest {
@@ -49,7 +49,7 @@ public class LifecycleScopeProviderMaybeTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.as(AutoDispose.autoDisposable(provider))
+    source.as(autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -74,7 +74,7 @@ public class LifecycleScopeProviderMaybeTest {
     MaybeSubject<Integer> source = MaybeSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.as(AutoDispose.autoDisposable(provider))
+    source.as(autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -102,7 +102,7 @@ public class LifecycleScopeProviderMaybeTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Maybe.just(1)
-        .as(AutoDispose.autoDisposable(provider))
+        .as(autoDisposable(provider))
         .subscribe(o);
 
     o.takeSubscribe();
@@ -117,7 +117,7 @@ public class LifecycleScopeProviderMaybeTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Maybe.just(1)
-        .as(AutoDispose.autoDisposable(provider))
+        .as(autoDisposable(provider))
         .subscribe(o);
 
     o.takeSubscribe();
@@ -129,7 +129,7 @@ public class LifecycleScopeProviderMaybeTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     MaybeSubject<Integer> source = MaybeSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestObserver<Integer> o = source.as(autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -148,7 +148,7 @@ public class LifecycleScopeProviderMaybeTest {
     lifecycle.onNext(3);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     MaybeSubject<Integer> source = MaybeSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestObserver<Integer> o = source.as(autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -166,7 +166,7 @@ public class LifecycleScopeProviderMaybeTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     MaybeSubject<Integer> source = MaybeSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestObserver<Integer> o = source.as(autoDisposable(provider))
         .test();
 
     o.assertNoValues();

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderObservableTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderObservableTest.java
@@ -22,8 +22,6 @@ import com.uber.autodispose.OutsideScopeException;
 import com.uber.autodispose.test.RecordingObserver;
 import com.uber.autodispose.test.RxErrorsRule;
 import io.reactivex.Observable;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Predicate;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.PublishSubject;
@@ -37,11 +35,7 @@ import static com.uber.autodispose.lifecycle.TestUtil.makeLifecycleProvider;
 
 public class LifecycleScopeProviderObservableTest {
 
-  private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
-    @Override public void log(String message) {
-      System.out.println(LifecycleScopeProviderObservableTest.class.getSimpleName() + ": " + message);
-    }
-  };
+  private static final RecordingObserver.Logger LOGGER = message -> System.out.println(LifecycleScopeProviderObservableTest.class.getSimpleName() + ": " + message);
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
 
@@ -107,9 +101,7 @@ public class LifecycleScopeProviderObservableTest {
   }
 
   @Test public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) { }
-    });
+    AutoDisposePlugins.setOutsideScopeHandler(e -> { });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     PublishSubject<Integer> source = PublishSubject.create();
@@ -123,10 +115,8 @@ public class LifecycleScopeProviderObservableTest {
   }
 
   @Test public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) {
-        // Noop
-      }
+    AutoDisposePlugins.setOutsideScopeHandler(e -> {
+      // Noop
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
@@ -144,12 +134,10 @@ public class LifecycleScopeProviderObservableTest {
   }
 
   @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithExp() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) {
-        // Wrap in an IllegalStateException so we can verify this is the exception we see on the
-        // other side
-        throw new IllegalStateException(e);
-      }
+    AutoDisposePlugins.setOutsideScopeHandler(e -> {
+      // Wrap in an IllegalStateException so we can verify this is the exception we see on the
+      // other side
+      throw new IllegalStateException(e);
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
@@ -158,10 +146,6 @@ public class LifecycleScopeProviderObservableTest {
         .test();
 
     o.assertNoValues();
-    o.assertError(new Predicate<Throwable>() {
-      @Override public boolean test(Throwable throwable) {
-        return throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException;
-      }
-    });
+    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderObservableTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderObservableTest.java
@@ -48,7 +48,7 @@ public class LifecycleScopeProviderObservableTest {
     PublishSubject<Integer> source = PublishSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.as(AutoDispose.<Integer>autoDisposable(provider))
+    source.as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -78,7 +78,7 @@ public class LifecycleScopeProviderObservableTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Observable.just(1)
-        .as(AutoDispose.<Integer>autoDisposable(provider))
+        .as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
 
     o.takeSubscribe();
@@ -93,7 +93,7 @@ public class LifecycleScopeProviderObservableTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Observable.just(1)
-        .as(AutoDispose.<Integer>autoDisposable(provider))
+        .as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
 
     o.takeSubscribe();
@@ -105,7 +105,7 @@ public class LifecycleScopeProviderObservableTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     PublishSubject<Integer> source = PublishSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -124,7 +124,7 @@ public class LifecycleScopeProviderObservableTest {
     lifecycle.onNext(3);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     PublishSubject<Integer> source = PublishSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -142,7 +142,7 @@ public class LifecycleScopeProviderObservableTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     PublishSubject<Integer> source = PublishSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
 
     o.assertNoValues();

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderObservableTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderObservableTest.java
@@ -35,7 +35,10 @@ import static com.uber.autodispose.lifecycle.TestUtil.makeLifecycleProvider;
 
 public class LifecycleScopeProviderObservableTest {
 
-  private static final RecordingObserver.Logger LOGGER = message -> System.out.println(LifecycleScopeProviderObservableTest.class.getSimpleName() + ": " + message);
+  private static final RecordingObserver.Logger LOGGER =
+      message -> System.out.println(LifecycleScopeProviderObservableTest.class.getSimpleName()
+          + ": "
+          + message);
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
 
@@ -146,6 +149,7 @@ public class LifecycleScopeProviderObservableTest {
         .test();
 
     o.assertNoValues();
-    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
+    o.assertError(throwable -> throwable instanceof IllegalStateException
+        && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderObservableTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderObservableTest.java
@@ -16,7 +16,6 @@
 
 package com.uber.autodispose.lifecycle;
 
-import com.uber.autodispose.AutoDispose;
 import com.uber.autodispose.AutoDisposePlugins;
 import com.uber.autodispose.OutsideScopeException;
 import com.uber.autodispose.test.RecordingObserver;
@@ -31,6 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.uber.autodispose.AutoDispose.autoDisposable;
 import static com.uber.autodispose.lifecycle.TestUtil.makeLifecycleProvider;
 
 public class LifecycleScopeProviderObservableTest {
@@ -48,7 +48,7 @@ public class LifecycleScopeProviderObservableTest {
     PublishSubject<Integer> source = PublishSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.as(AutoDispose.autoDisposable(provider))
+    source.as(autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -78,7 +78,7 @@ public class LifecycleScopeProviderObservableTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Observable.just(1)
-        .as(AutoDispose.autoDisposable(provider))
+        .as(autoDisposable(provider))
         .subscribe(o);
 
     o.takeSubscribe();
@@ -93,7 +93,7 @@ public class LifecycleScopeProviderObservableTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Observable.just(1)
-        .as(AutoDispose.autoDisposable(provider))
+        .as(autoDisposable(provider))
         .subscribe(o);
 
     o.takeSubscribe();
@@ -105,7 +105,7 @@ public class LifecycleScopeProviderObservableTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     PublishSubject<Integer> source = PublishSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestObserver<Integer> o = source.as(autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -124,7 +124,7 @@ public class LifecycleScopeProviderObservableTest {
     lifecycle.onNext(3);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     PublishSubject<Integer> source = PublishSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestObserver<Integer> o = source.as(autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -142,7 +142,7 @@ public class LifecycleScopeProviderObservableTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     PublishSubject<Integer> source = PublishSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestObserver<Integer> o = source.as(autoDisposable(provider))
         .test();
 
     o.assertNoValues();

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderParallelFlowableTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderParallelFlowableTest.java
@@ -137,9 +137,7 @@ public class LifecycleScopeProviderParallelFlowableTest {
   }
 
   @Test public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) {
-      }
+    AutoDisposePlugins.setOutsideScopeHandler(e -> {
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     TestSubscriber<Integer> firstSubscriber = new TestSubscriber<>();
@@ -163,10 +161,8 @@ public class LifecycleScopeProviderParallelFlowableTest {
   }
 
   @Test public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) {
-        // Noop
-      }
+    AutoDisposePlugins.setOutsideScopeHandler(e -> {
+      // Noop
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
@@ -190,10 +186,8 @@ public class LifecycleScopeProviderParallelFlowableTest {
   }
 
   @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithExp() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) {
-        throw new IllegalStateException(e);
-      }
+    AutoDisposePlugins.setOutsideScopeHandler(e -> {
+      throw new IllegalStateException(e);
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     TestSubscriber<Integer> firstSubscriber = new TestSubscriber<>();
@@ -208,16 +202,8 @@ public class LifecycleScopeProviderParallelFlowableTest {
         .subscribe(subscribers);
 
     firstSubscriber.assertNoValues();
-    firstSubscriber.assertError(new Predicate<Throwable>() {
-      @Override public boolean test(Throwable throwable) {
-        return throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException;
-      }
-    });
+    firstSubscriber.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
     secondSubscriber.assertNoValues();
-    secondSubscriber.assertError(new Predicate<Throwable>() {
-      @Override public boolean test(Throwable throwable) {
-        return throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException;
-      }
-    });
+    secondSubscriber.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderParallelFlowableTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderParallelFlowableTest.java
@@ -200,8 +200,10 @@ public class LifecycleScopeProviderParallelFlowableTest {
         .subscribe(subscribers);
 
     firstSubscriber.assertNoValues();
-    firstSubscriber.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
+    firstSubscriber.assertError(throwable -> throwable instanceof IllegalStateException
+        && throwable.getCause() instanceof OutsideScopeException);
     secondSubscriber.assertNoValues();
-    secondSubscriber.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
+    secondSubscriber.assertError(throwable -> throwable instanceof IllegalStateException
+        && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderParallelFlowableTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderParallelFlowableTest.java
@@ -21,8 +21,6 @@ import com.uber.autodispose.AutoDisposePlugins;
 import com.uber.autodispose.OutsideScopeException;
 import com.uber.autodispose.test.RxErrorsRule;
 import io.reactivex.Flowable;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Predicate;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subscribers.TestSubscriber;
@@ -56,7 +54,7 @@ public class LifecycleScopeProviderParallelFlowableTest {
     Subscriber<Integer>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
 
     source.parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.<Integer>autoDisposable(provider))
+        .as(AutoDispose.autoDisposable(provider))
         .subscribe(subscribers);
     firstSubscriber.assertSubscribed();
     secondSubscriber.assertSubscribed();
@@ -99,7 +97,7 @@ public class LifecycleScopeProviderParallelFlowableTest {
 
     Flowable.just(1, 2)
         .parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.<Integer>autoDisposable(provider))
+        .as(AutoDispose.autoDisposable(provider))
         .subscribe(subscribers);
 
     List<Throwable> errors1 = firstSubscriber.errors();
@@ -124,7 +122,7 @@ public class LifecycleScopeProviderParallelFlowableTest {
 
     Flowable.just(1, 2)
         .parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.<Integer>autoDisposable(provider))
+        .as(AutoDispose.autoDisposable(provider))
         .subscribe(subscribers);
 
     List<Throwable> errors1 = firstSubscriber.errors();
@@ -148,7 +146,7 @@ public class LifecycleScopeProviderParallelFlowableTest {
     Subscriber<Integer>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
 
     source.parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.<Integer>autoDisposable(provider))
+        .as(AutoDispose.autoDisposable(provider))
         .subscribe(subscribers);
 
     assertThat(source.hasSubscribers()).isFalse();
@@ -176,7 +174,7 @@ public class LifecycleScopeProviderParallelFlowableTest {
     Subscriber<Integer>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
 
     source.parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.<Integer>autoDisposable(provider))
+        .as(AutoDispose.autoDisposable(provider))
         .subscribe(subscribers);
 
     assertThat(source.hasSubscribers()).isFalse();
@@ -198,7 +196,7 @@ public class LifecycleScopeProviderParallelFlowableTest {
     Subscriber<Integer>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
 
     source.parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.<Integer>autoDisposable(provider))
+        .as(AutoDispose.autoDisposable(provider))
         .subscribe(subscribers);
 
     firstSubscriber.assertNoValues();

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderParallelFlowableTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderParallelFlowableTest.java
@@ -16,7 +16,6 @@
 
 package com.uber.autodispose.lifecycle;
 
-import com.uber.autodispose.AutoDispose;
 import com.uber.autodispose.AutoDisposePlugins;
 import com.uber.autodispose.OutsideScopeException;
 import com.uber.autodispose.test.RxErrorsRule;
@@ -32,6 +31,7 @@ import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.uber.autodispose.AutoDispose.autoDisposable;
 import static com.uber.autodispose.lifecycle.TestUtil.makeLifecycleProvider;
 
 public class LifecycleScopeProviderParallelFlowableTest {
@@ -54,7 +54,7 @@ public class LifecycleScopeProviderParallelFlowableTest {
     Subscriber<Integer>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
 
     source.parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.autoDisposable(provider))
+        .as(autoDisposable(provider))
         .subscribe(subscribers);
     firstSubscriber.assertSubscribed();
     secondSubscriber.assertSubscribed();
@@ -97,7 +97,7 @@ public class LifecycleScopeProviderParallelFlowableTest {
 
     Flowable.just(1, 2)
         .parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.autoDisposable(provider))
+        .as(autoDisposable(provider))
         .subscribe(subscribers);
 
     List<Throwable> errors1 = firstSubscriber.errors();
@@ -122,7 +122,7 @@ public class LifecycleScopeProviderParallelFlowableTest {
 
     Flowable.just(1, 2)
         .parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.autoDisposable(provider))
+        .as(autoDisposable(provider))
         .subscribe(subscribers);
 
     List<Throwable> errors1 = firstSubscriber.errors();
@@ -146,7 +146,7 @@ public class LifecycleScopeProviderParallelFlowableTest {
     Subscriber<Integer>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
 
     source.parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.autoDisposable(provider))
+        .as(autoDisposable(provider))
         .subscribe(subscribers);
 
     assertThat(source.hasSubscribers()).isFalse();
@@ -174,7 +174,7 @@ public class LifecycleScopeProviderParallelFlowableTest {
     Subscriber<Integer>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
 
     source.parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.autoDisposable(provider))
+        .as(autoDisposable(provider))
         .subscribe(subscribers);
 
     assertThat(source.hasSubscribers()).isFalse();
@@ -196,7 +196,7 @@ public class LifecycleScopeProviderParallelFlowableTest {
     Subscriber<Integer>[] subscribers = new Subscriber[] { firstSubscriber, secondSubscriber };
 
     source.parallel(DEFAULT_PARALLELISM)
-        .as(AutoDispose.autoDisposable(provider))
+        .as(autoDisposable(provider))
         .subscribe(subscribers);
 
     firstSubscriber.assertNoValues();

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderSingleTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderSingleTest.java
@@ -37,11 +37,8 @@ import static com.uber.autodispose.lifecycle.TestUtil.makeLifecycleProvider;
 
 public class LifecycleScopeProviderSingleTest {
 
-  private static final RecordingObserver.Logger LOGGER = new RecordingObserver.Logger() {
-    @Override public void log(String message) {
-      System.out.println(LifecycleScopeProviderSingleTest.class.getSimpleName() + ": " + message);
-    }
-  };
+  private static final RecordingObserver.Logger LOGGER =
+      message -> System.out.println(LifecycleScopeProviderSingleTest.class.getSimpleName() + ": " + message);
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
 
@@ -130,9 +127,7 @@ public class LifecycleScopeProviderSingleTest {
   }
 
   @Test public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) { }
-    });
+    AutoDisposePlugins.setOutsideScopeHandler(e -> { });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     SingleSubject<Integer> source = SingleSubject.create();
@@ -146,10 +141,8 @@ public class LifecycleScopeProviderSingleTest {
   }
 
   @Test public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) {
-        // Noop
-      }
+    AutoDisposePlugins.setOutsideScopeHandler(e -> {
+      // Noop
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
@@ -167,12 +160,10 @@ public class LifecycleScopeProviderSingleTest {
   }
 
   @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithExp() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) {
-        // Wrap in an IllegalStateException so we can verify this is the exception we see on the
-        // other side
-        throw new IllegalStateException(e);
-      }
+    AutoDisposePlugins.setOutsideScopeHandler(e -> {
+      // Wrap in an IllegalStateException so we can verify this is the exception we see on the
+      // other side
+      throw new IllegalStateException(e);
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
@@ -181,10 +172,6 @@ public class LifecycleScopeProviderSingleTest {
         .test();
 
     o.assertNoValues();
-    o.assertError(new Predicate<Throwable>() {
-      @Override public boolean test(Throwable throwable) {
-        return throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException;
-      }
-    });
+    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderSingleTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderSingleTest.java
@@ -22,8 +22,6 @@ import com.uber.autodispose.OutsideScopeException;
 import com.uber.autodispose.test.RecordingObserver;
 import com.uber.autodispose.test.RxErrorsRule;
 import io.reactivex.Single;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Predicate;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.SingleSubject;
@@ -51,7 +49,7 @@ public class LifecycleScopeProviderSingleTest {
     SingleSubject<Integer> source = SingleSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.as(AutoDispose.<Integer>autoDisposable(provider))
+    source.as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -77,7 +75,7 @@ public class LifecycleScopeProviderSingleTest {
     SingleSubject<Integer> source = SingleSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.as(AutoDispose.<Integer>autoDisposable(provider))
+    source.as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -104,7 +102,7 @@ public class LifecycleScopeProviderSingleTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Single.just(1)
-        .as(AutoDispose.<Integer>autoDisposable(provider))
+        .as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
 
     o.takeSubscribe();
@@ -119,7 +117,7 @@ public class LifecycleScopeProviderSingleTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Single.just(1)
-        .as(AutoDispose.<Integer>autoDisposable(provider))
+        .as(AutoDispose.autoDisposable(provider))
         .subscribe(o);
 
     o.takeSubscribe();
@@ -131,7 +129,7 @@ public class LifecycleScopeProviderSingleTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     SingleSubject<Integer> source = SingleSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -150,7 +148,7 @@ public class LifecycleScopeProviderSingleTest {
     lifecycle.onNext(3);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     SingleSubject<Integer> source = SingleSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -168,7 +166,7 @@ public class LifecycleScopeProviderSingleTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     SingleSubject<Integer> source = SingleSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
 
     o.assertNoValues();

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderSingleTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderSingleTest.java
@@ -16,7 +16,6 @@
 
 package com.uber.autodispose.lifecycle;
 
-import com.uber.autodispose.AutoDispose;
 import com.uber.autodispose.AutoDisposePlugins;
 import com.uber.autodispose.OutsideScopeException;
 import com.uber.autodispose.test.RecordingObserver;
@@ -31,6 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.uber.autodispose.AutoDispose.autoDisposable;
 import static com.uber.autodispose.lifecycle.TestUtil.makeLifecycleProvider;
 
 public class LifecycleScopeProviderSingleTest {
@@ -49,7 +49,7 @@ public class LifecycleScopeProviderSingleTest {
     SingleSubject<Integer> source = SingleSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.as(AutoDispose.autoDisposable(provider))
+    source.as(autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -75,7 +75,7 @@ public class LifecycleScopeProviderSingleTest {
     SingleSubject<Integer> source = SingleSubject.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    source.as(AutoDispose.autoDisposable(provider))
+    source.as(autoDisposable(provider))
         .subscribe(o);
     o.takeSubscribe();
 
@@ -102,7 +102,7 @@ public class LifecycleScopeProviderSingleTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Single.just(1)
-        .as(AutoDispose.autoDisposable(provider))
+        .as(autoDisposable(provider))
         .subscribe(o);
 
     o.takeSubscribe();
@@ -117,7 +117,7 @@ public class LifecycleScopeProviderSingleTest {
     RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     Single.just(1)
-        .as(AutoDispose.autoDisposable(provider))
+        .as(autoDisposable(provider))
         .subscribe(o);
 
     o.takeSubscribe();
@@ -129,7 +129,7 @@ public class LifecycleScopeProviderSingleTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     SingleSubject<Integer> source = SingleSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestObserver<Integer> o = source.as(autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -148,7 +148,7 @@ public class LifecycleScopeProviderSingleTest {
     lifecycle.onNext(3);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     SingleSubject<Integer> source = SingleSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestObserver<Integer> o = source.as(autoDisposable(provider))
         .test();
 
     assertThat(source.hasObservers()).isFalse();
@@ -166,7 +166,7 @@ public class LifecycleScopeProviderSingleTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     SingleSubject<Integer> source = SingleSubject.create();
-    TestObserver<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestObserver<Integer> o = source.as(autoDisposable(provider))
         .test();
 
     o.assertNoValues();

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderSingleTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderSingleTest.java
@@ -36,7 +36,9 @@ import static com.uber.autodispose.lifecycle.TestUtil.makeLifecycleProvider;
 public class LifecycleScopeProviderSingleTest {
 
   private static final RecordingObserver.Logger LOGGER =
-      message -> System.out.println(LifecycleScopeProviderSingleTest.class.getSimpleName() + ": " + message);
+      message -> System.out.println(LifecycleScopeProviderSingleTest.class.getSimpleName()
+          + ": "
+          + message);
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
 
@@ -170,6 +172,7 @@ public class LifecycleScopeProviderSingleTest {
         .test();
 
     o.assertNoValues();
-    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
+    o.assertError(throwable -> throwable instanceof IllegalStateException
+        && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderSubscriberTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderSubscriberTest.java
@@ -103,9 +103,7 @@ public class LifecycleScopeProviderSubscriberTest {
   }
 
   @Test public void autoDispose_withProviderAndNoOpPlugin_withoutStarting_shouldFailSilently() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) { }
-    });
+    AutoDisposePlugins.setOutsideScopeHandler(e -> { });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     PublishProcessor<Integer> source = PublishProcessor.create();
@@ -119,10 +117,8 @@ public class LifecycleScopeProviderSubscriberTest {
   }
 
   @Test public void autoDispose_withProviderAndNoOpPlugin_afterEnding_shouldFailSilently() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) {
-        // Noop
-      }
+    AutoDisposePlugins.setOutsideScopeHandler(e -> {
+      // Noop
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     lifecycle.onNext(1);
@@ -140,12 +136,10 @@ public class LifecycleScopeProviderSubscriberTest {
   }
 
   @Test public void autoDispose_withProviderAndPlugin_withoutStarting_shouldFailWithExp() {
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) {
-        // Wrap in an IllegalStateException so we can verify this is the exception we see on the
-        // other side
-        throw new IllegalStateException(e);
-      }
+    AutoDisposePlugins.setOutsideScopeHandler(e -> {
+      // Wrap in an IllegalStateException so we can verify this is the exception we see on the
+      // other side
+      throw new IllegalStateException(e);
     });
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
@@ -154,10 +148,6 @@ public class LifecycleScopeProviderSubscriberTest {
         .test();
 
     o.assertNoValues();
-    o.assertError(new Predicate<Throwable>() {
-      @Override public boolean test(Throwable throwable) {
-        return throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException;
-      }
-    });
+    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderSubscriberTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderSubscriberTest.java
@@ -146,6 +146,7 @@ public class LifecycleScopeProviderSubscriberTest {
         .test();
 
     o.assertNoValues();
-    o.assertError(throwable -> throwable instanceof IllegalStateException && throwable.getCause() instanceof OutsideScopeException);
+    o.assertError(throwable -> throwable instanceof IllegalStateException
+        && throwable.getCause() instanceof OutsideScopeException);
   }
 }

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderSubscriberTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderSubscriberTest.java
@@ -21,8 +21,6 @@ import com.uber.autodispose.AutoDisposePlugins;
 import com.uber.autodispose.OutsideScopeException;
 import com.uber.autodispose.test.RxErrorsRule;
 import io.reactivex.Flowable;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Predicate;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subscribers.TestSubscriber;
@@ -47,7 +45,7 @@ public class LifecycleScopeProviderSubscriberTest {
     PublishProcessor<Integer> source = PublishProcessor.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    TestSubscriber<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestSubscriber<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
     o.assertSubscribed();
 
@@ -79,7 +77,7 @@ public class LifecycleScopeProviderSubscriberTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     TestSubscriber<Integer> o = Flowable.just(1)
-        .as(AutoDispose.<Integer>autoDisposable(provider))
+        .as(AutoDispose.autoDisposable(provider))
         .test();
 
     List<Throwable> errors = o.errors();
@@ -94,7 +92,7 @@ public class LifecycleScopeProviderSubscriberTest {
     lifecycle.onNext(3);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     TestSubscriber<Integer> o = Flowable.just(1)
-        .as(AutoDispose.<Integer>autoDisposable(provider))
+        .as(AutoDispose.autoDisposable(provider))
         .test();
 
     List<Throwable> errors = o.errors();
@@ -107,7 +105,7 @@ public class LifecycleScopeProviderSubscriberTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     PublishProcessor<Integer> source = PublishProcessor.create();
-    TestSubscriber<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestSubscriber<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
 
     assertThat(source.hasSubscribers()).isFalse();
@@ -126,7 +124,7 @@ public class LifecycleScopeProviderSubscriberTest {
     lifecycle.onNext(3);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     PublishProcessor<Integer> source = PublishProcessor.create();
-    TestSubscriber<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestSubscriber<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
 
     assertThat(source.hasSubscribers()).isFalse();
@@ -144,7 +142,7 @@ public class LifecycleScopeProviderSubscriberTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     PublishProcessor<Integer> source = PublishProcessor.create();
-    TestSubscriber<Integer> o = source.as(AutoDispose.<Integer>autoDisposable(provider))
+    TestSubscriber<Integer> o = source.as(AutoDispose.autoDisposable(provider))
         .test();
 
     o.assertNoValues();

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderSubscriberTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopeProviderSubscriberTest.java
@@ -16,7 +16,6 @@
 
 package com.uber.autodispose.lifecycle;
 
-import com.uber.autodispose.AutoDispose;
 import com.uber.autodispose.AutoDisposePlugins;
 import com.uber.autodispose.OutsideScopeException;
 import com.uber.autodispose.test.RxErrorsRule;
@@ -31,6 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.uber.autodispose.AutoDispose.autoDisposable;
 import static com.uber.autodispose.lifecycle.TestUtil.makeLifecycleProvider;
 
 public class LifecycleScopeProviderSubscriberTest {
@@ -45,7 +45,7 @@ public class LifecycleScopeProviderSubscriberTest {
     PublishProcessor<Integer> source = PublishProcessor.create();
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.createDefault(0);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
-    TestSubscriber<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestSubscriber<Integer> o = source.as(autoDisposable(provider))
         .test();
     o.assertSubscribed();
 
@@ -77,7 +77,7 @@ public class LifecycleScopeProviderSubscriberTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     TestSubscriber<Integer> o = Flowable.just(1)
-        .as(AutoDispose.autoDisposable(provider))
+        .as(autoDisposable(provider))
         .test();
 
     List<Throwable> errors = o.errors();
@@ -92,7 +92,7 @@ public class LifecycleScopeProviderSubscriberTest {
     lifecycle.onNext(3);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     TestSubscriber<Integer> o = Flowable.just(1)
-        .as(AutoDispose.autoDisposable(provider))
+        .as(autoDisposable(provider))
         .test();
 
     List<Throwable> errors = o.errors();
@@ -105,7 +105,7 @@ public class LifecycleScopeProviderSubscriberTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     PublishProcessor<Integer> source = PublishProcessor.create();
-    TestSubscriber<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestSubscriber<Integer> o = source.as(autoDisposable(provider))
         .test();
 
     assertThat(source.hasSubscribers()).isFalse();
@@ -124,7 +124,7 @@ public class LifecycleScopeProviderSubscriberTest {
     lifecycle.onNext(3);
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     PublishProcessor<Integer> source = PublishProcessor.create();
-    TestSubscriber<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestSubscriber<Integer> o = source.as(autoDisposable(provider))
         .test();
 
     assertThat(source.hasSubscribers()).isFalse();
@@ -142,7 +142,7 @@ public class LifecycleScopeProviderSubscriberTest {
     BehaviorSubject<Integer> lifecycle = BehaviorSubject.create();
     LifecycleScopeProvider<Integer> provider = makeLifecycleProvider(lifecycle);
     PublishProcessor<Integer> source = PublishProcessor.create();
-    TestSubscriber<Integer> o = source.as(AutoDispose.autoDisposable(provider))
+    TestSubscriber<Integer> o = source.as(autoDisposable(provider))
         .test();
 
     o.assertNoValues();

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopesTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopesTest.java
@@ -72,10 +72,8 @@ public final class LifecycleScopesTest {
   @Test public void lifecycleCheckEnd_shouldFailIfEndedWithHandler() {
     TestLifecycleScopeProvider lifecycle = TestLifecycleScopeProvider.createInitial(STOPPED);
 
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) {
-        // Swallow the exception.
-      }
+    AutoDisposePlugins.setOutsideScopeHandler(e -> {
+      // Swallow the exception.
     });
 
     testSource(resolveScopeFromLifecycle(lifecycle, true)).assertComplete();
@@ -85,11 +83,9 @@ public final class LifecycleScopesTest {
     TestLifecycleScopeProvider lifecycle = TestLifecycleScopeProvider.createInitial(STOPPED);
 
     final RuntimeException expected = new RuntimeException("Expected");
-    AutoDisposePlugins.setOutsideScopeHandler(new Consumer<OutsideScopeException>() {
-      @Override public void accept(OutsideScopeException e) {
-        // Throw it back
-        throw expected;
-      }
+    AutoDisposePlugins.setOutsideScopeHandler(e -> {
+      // Throw it back
+      throw expected;
     });
 
     testSource(resolveScopeFromLifecycle(lifecycle, true)).assertError(expected);
@@ -196,11 +192,7 @@ public final class LifecycleScopesTest {
   @Test public void resolveScopeFromLifecycle_normal_comparator() {
     PublishSubject<Integer> lifecycle = PublishSubject.create();
 
-    Comparator<Integer> comparator = new Comparator<Integer>() {
-      @Override public int compare(Integer o1, Integer o2) {
-        return Integer.compare(-o1, o2);
-      }
-    };
+    Comparator<Integer> comparator = (o1, o2) -> Integer.compare(-o1, o2);
 
     TestObserver<?> o = testSource(resolveScopeFromLifecycle(lifecycle, 3, comparator));
 

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopesTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopesTest.java
@@ -17,9 +17,7 @@
 package com.uber.autodispose.lifecycle;
 
 import com.uber.autodispose.AutoDisposePlugins;
-import com.uber.autodispose.OutsideScopeException;
 import io.reactivex.CompletableSource;
-import io.reactivex.functions.Consumer;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.PublishSubject;
 import java.util.Comparator;
@@ -41,7 +39,8 @@ public final class LifecycleScopesTest {
 
     try {
       testSource(resolveScopeFromLifecycle(lifecycle));
-      throw new AssertionError("Lifecycle resolution should have failed due to missing start event");
+      throw new AssertionError("Lifecycle resolution should have failed due to missing start "
+          + "event");
     } catch (LifecycleNotStartedException ignored) {
 
     }
@@ -94,7 +93,8 @@ public final class LifecycleScopesTest {
   @Test public void lifecycleCheckEndDisabled_shouldRouteThroughOnError() {
     TestLifecycleScopeProvider lifecycle = TestLifecycleScopeProvider.createInitial(STOPPED);
 
-    testSource(resolveScopeFromLifecycle(lifecycle, false)).assertError(LifecycleEndedException.class);
+    testSource(resolveScopeFromLifecycle(lifecycle,
+        false)).assertError(LifecycleEndedException.class);
   }
 
   @Test public void resolveScopeFromLifecycle_normal() {
@@ -175,7 +175,8 @@ public final class LifecycleScopesTest {
   @Test public void resolveScopeFromLifecycle_normal_comparable() {
     PublishSubject<NegativeComparableInteger> lifecycle = PublishSubject.create();
 
-    TestObserver<?> o = testSource(resolveScopeFromLifecycle(lifecycle, new NegativeComparableInteger(3)));
+    TestObserver<?> o =
+        testSource(resolveScopeFromLifecycle(lifecycle, new NegativeComparableInteger(3)));
 
     lifecycle.onNext(new NegativeComparableInteger(-1));
     o.assertNotTerminated();

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/TestLifecycleScopeProviderTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/TestLifecycleScopeProviderTest.java
@@ -25,7 +25,8 @@ import static com.uber.autodispose.lifecycle.TestLifecycleScopeProvider.TestLife
 
 public class TestLifecycleScopeProviderTest {
 
-  private final TestLifecycleScopeProvider testLifecycleScopeProvider = TestLifecycleScopeProvider.create();
+  private final TestLifecycleScopeProvider testLifecycleScopeProvider =
+      TestLifecycleScopeProvider.create();
 
   @Test public void create_noArgs_shouldHaveNoState() {
     assertThat(testLifecycleScopeProvider.peekLifecycle()).isNull();
@@ -44,7 +45,8 @@ public class TestLifecycleScopeProviderTest {
         .apply(testLifecycleScopeProvider.peekLifecycle())).isEqualTo(STOPPED);
   }
 
-  @Test(expected = LifecycleEndedException.class) public void stop_afterStart_shouldTriggerStopEvent() {
+  @Test(expected = LifecycleEndedException.class)
+  public void stop_afterStart_shouldTriggerStopEvent() {
     testLifecycleScopeProvider.start();
     testLifecycleScopeProvider.stop();
 
@@ -53,7 +55,8 @@ public class TestLifecycleScopeProviderTest {
         .apply(testLifecycleScopeProvider.peekLifecycle());
   }
 
-  @Test(expected = IllegalStateException.class) public void stop_beforeStart_shouldThrowException() {
+  @Test(expected = IllegalStateException.class)
+  public void stop_beforeStart_shouldThrowException() {
     testLifecycleScopeProvider.stop();
   }
 

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/TestUtil.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/TestUtil.java
@@ -21,19 +21,16 @@ import io.reactivex.Observable;
 import io.reactivex.subjects.BehaviorSubject;
 
 final class TestUtil {
-  private static final CorrespondingEventsFunction<Integer> CORRESPONDING_EVENTS =
-      new CorrespondingEventsFunction<Integer>() {
-        @Override public Integer apply(Integer lastEvent) {
-          switch (lastEvent) {
-            case 0:
-              return 3;
-            case 1:
-              return 2;
-            default:
-              throw new LifecycleEndedException();
-          }
-        }
-      };
+  private static final CorrespondingEventsFunction<Integer> CORRESPONDING_EVENTS = lastEvent -> {
+    switch (lastEvent) {
+      case 0:
+        return 3;
+      case 1:
+        return 2;
+      default:
+        throw new LifecycleEndedException();
+    }
+  };
 
   private TestUtil() {
     throw new InstantiationError();

--- a/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/error/prone/checker/UseAutoDisposeNegativeCases.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/error/prone/checker/UseAutoDisposeNegativeCases.java
@@ -33,6 +33,8 @@ import io.reactivex.annotations.Nullable;
 import io.reactivex.subjects.BehaviorSubject;
 import org.reactivestreams.Subscriber;
 
+import static com.uber.autodispose.AutoDispose.autoDisposable;
+
 /**
  * Cases that use {@link AutoDispose} and should not fail the {@link UseAutoDispose} check.
  */
@@ -80,31 +82,31 @@ public class UseAutoDisposeNegativeCases implements LifecycleScopeProvider<TestL
 
   public void observable_subscribeWithAutoDispose() {
     Observable.just(1)
-        .as(AutoDispose.<Integer>autoDisposable(this))
+        .as(autoDisposable(this))
         .subscribe();
   }
 
   public void single_subscribeWithAutoDispose() {
     Single.just(true)
-        .as(AutoDispose.<Boolean>autoDisposable(this))
+        .as(autoDisposable(this))
         .subscribe();
   }
 
   public void completable_subscribeWithAutoDispose() {
     Completable.complete()
-        .as(AutoDispose.autoDisposable(this))
+        .as(autoDisposable(this))
         .subscribe();
   }
 
   public void maybe_subscribeWithAutoDispose() {
     Maybe.just(1)
-        .as(AutoDispose.<Integer>autoDisposable(this))
+        .as(autoDisposable(this))
         .subscribe();
   }
 
   public void flowable_subscribeWithAutoDispose() {
     Flowable.just(1)
-        .as(AutoDispose.<Integer>autoDisposable(this))
+        .as(autoDisposable(this))
         .subscribe();
   }
 
@@ -112,7 +114,7 @@ public class UseAutoDisposeNegativeCases implements LifecycleScopeProvider<TestL
     Subscriber<Integer>[] subscribers = new Subscriber[] {};
     Flowable.just(1, 2)
         .parallel(2)
-        .as(AutoDispose.<Integer>autoDisposable(this))
+        .as(autoDisposable(this))
         .subscribe(subscribers);
   }
 }

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -19,8 +19,8 @@ plugins {
   id 'net.ltgt.errorprone'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
   annotationProcessor deps.build.nullAway

--- a/test-utils/src/main/java/com/uber/autodispose/test/RxErrorsRule.java
+++ b/test-utils/src/main/java/com/uber/autodispose/test/RxErrorsRule.java
@@ -18,7 +18,6 @@ package com.uber.autodispose.test;
 
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.exceptions.UndeliverableException;
-import io.reactivex.functions.Consumer;
 import io.reactivex.plugins.RxJavaPlugins;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,11 +39,7 @@ public class RxErrorsRule extends TestWatcher {
   private BlockingDeque<Throwable> errors = new LinkedBlockingDeque<>();
 
   @Override protected void starting(Description description) {
-    RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
-      @Override public void accept(Throwable t) {
-        errors.add(t);
-      }
-    });
+    RxJavaPlugins.setErrorHandler(t -> errors.add(t));
   }
 
   @Override protected void finished(Description description) {


### PR DESCRIPTION
This switches the project to fully embrace Java 8 with lambdas, method refs, and better type inference. With AGP 3.2+, there's no reason not to do this now and let desugar do its thing