### PR TITLE
Parallelize tests in main autodispose artifact

### DIFF
--- a/autodispose/build.gradle
+++ b/autodispose/build.gradle
@@ -41,4 +41,8 @@ tasks.withType(JavaCompile) {
   options.compilerArgs += ["-Xep:NullAway:ERROR", "-XepOpt:NullAway:AnnotatedPackages=com.uber"]
 }
 
+tasks.withType(Test) {
+    setMaxParallelForks(Runtime.runtime.availableProcessors().intdiv(2) ?: 1)
+}
+
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')


### PR DESCRIPTION
Brings down test time from 24sec to 17sec