### PR TITLE
Add automatic-module-name to relevant modules

### DIFF
--- a/android/autodispose-android-archcomponents-test/gradle.properties
+++ b/android/autodispose-android-archcomponents-test/gradle.properties
@@ -17,3 +17,4 @@
 POM_NAME=AutoDispose (Android Architecture Components Test Extensions)
 POM_ARTIFACT_ID=autodispose-android-archcomponents-test
 POM_PACKAGING=aar
+AUTOMATIC_MODULE_NAME=com.uber.autodispose.android.lifecycle.test

--- a/android/autodispose-android-archcomponents/gradle.properties
+++ b/android/autodispose-android-archcomponents/gradle.properties
@@ -17,3 +17,4 @@
 POM_NAME=AutoDispose (Android Architecture Components Extensions)
 POM_ARTIFACT_ID=autodispose-android-archcomponents
 POM_PACKAGING=aar
+AUTOMATIC_MODULE_NAME=com.uber.autodispose.android.lifecycle

--- a/android/autodispose-android/gradle.properties
+++ b/android/autodispose-android/gradle.properties
@@ -17,3 +17,4 @@
 POM_NAME=AutoDispose (Android Extensions)
 POM_ARTIFACT_ID=autodispose-android
 POM_PACKAGING=aar
+AUTOMATIC_MODULE_NAME=com.uber.autodispose.android

--- a/autodispose-rxlifecycle/gradle.properties
+++ b/autodispose-rxlifecycle/gradle.properties
@@ -17,3 +17,4 @@
 POM_NAME=AutoDispose (RxLifecycle Interop)
 POM_ARTIFACT_ID=autodispose-rxlifecycle
 POM_PACKAGING=jar
+AUTOMATIC_MODULE_NAME=com.uber.autodispose.rxlifecycle

--- a/autodispose/gradle.properties
+++ b/autodispose/gradle.properties
@@ -17,3 +17,4 @@
 POM_NAME=AutoDispose
 POM_ARTIFACT_ID=autodispose
 POM_PACKAGING=jar
+AUTOMATIC_MODULE_NAME=com.uber.autodispose

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -193,6 +193,14 @@ afterEvaluate { project ->
     sign configurations.archives
   }
 
+  if (hasProperty("AUTOMATIC_MODULE_NAME")) {
+    jar {
+      manifest {
+        attributes('Automatic-Module-Name': properties.get("AUTOMATIC_MODULE_NAME"))
+      }
+    }
+  }
+
   if (project.getPlugins().hasPlugin('com.android.application') || project.getPlugins().
       hasPlugin('com.android.library')) {
     task install(type: Upload, dependsOn: assemble) {

--- a/lifecycle/autodispose-lifecycle-jdk8/gradle.properties
+++ b/lifecycle/autodispose-lifecycle-jdk8/gradle.properties
@@ -17,3 +17,4 @@
 POM_NAME=AutoDispose (Lifecycle JDK8 Extensions)
 POM_ARTIFACT_ID=autodispose-lifecycle-jdk8
 POM_PACKAGING=jar
+AUTOMATIC_MODULE_NAME=com.uber.autodispose.lifecycle.jdk8

--- a/lifecycle/autodispose-lifecycle/gradle.properties
+++ b/lifecycle/autodispose-lifecycle/gradle.properties
@@ -17,3 +17,4 @@
 POM_NAME=AutoDispose (Lifecycle)
 POM_ARTIFACT_ID=autodispose-lifecycle
 POM_PACKAGING=jar
+AUTOMATIC_MODULE_NAME=com.uber.autodispose.lifecycle

--- a/static-analysis/autodispose-error-prone-checker/gradle.properties
+++ b/static-analysis/autodispose-error-prone-checker/gradle.properties
@@ -17,3 +17,4 @@
 POM_NAME=AutoDispose Error-Prone Checker
 POM_ARTIFACT_ID=autodispose-error-prone-checker
 POM_PACKAGING=jar
+AUTOMATIC_MODULE_NAME=com.uber.autodispose.errorprone

--- a/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
+++ b/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.uber.autodispose.error.prone.checker;
+package com.uber.autodispose.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;

--- a/static-analysis/autodispose-error-prone-checker/src/test/java/com/uber/autodispose/errorprone/ComponentWithLifecycle.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/java/com/uber/autodispose/errorprone/ComponentWithLifecycle.java
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-package com.uber.autodispose.error.prone.checker;
+package com.uber.autodispose.errorprone;
 
-public class ComponentWithLifeCycle {}
+public class ComponentWithLifecycle {}

--- a/static-analysis/autodispose-error-prone-checker/src/test/java/com/uber/autodispose/errorprone/UseAutoDisposeTest.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/java/com/uber/autodispose/errorprone/UseAutoDisposeTest.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package com.uber.autodispose.error.prone.checker;
+package com.uber.autodispose.errorprone;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.CompilationTestHelper;
-import java.util.Collections;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,8 +42,8 @@ public class UseAutoDisposeTest {
   }
 
   @Test public void test_autodisposePositiveCaseswithCustomClass() {
-    compilationHelper.setArgs(Collections.singletonList(
-        "-XepOpt:ClassesWithScope" + "=com.uber.autodispose.error.prone.checker.ComponentWithLifeCycle"));
+    compilationHelper.setArgs(ImmutableList.of("-XepOpt:ClassesWithScope"
+        + "=com.uber.autodispose.errorprone.ComponentWithLifecycle"));
     compilationHelper.addSourceFile("UseAutoDisposeCustomClassPositiveCases.java")
         .doTest();
   }

--- a/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeCustomClassPositiveCases.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeCustomClassPositiveCases.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package com.uber.autodispose.error.prone.checker;
+package com.uber.autodispose.errorprone;
 
+import com.uber.autodispose.errorprone.ComponentWithLifecycle;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
@@ -23,7 +24,7 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import org.reactivestreams.Subscriber;
 
-public class UseAutoDisposeCustomClassPositiveCases extends ComponentWithLifeCycle {
+public class UseAutoDisposeCustomClassPositiveCases extends ComponentWithLifecycle {
   public void observable_subscribeWithoutAutoDispose() {
     Observable.empty()
         // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.

--- a/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeDefaultClassPositiveCases.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeDefaultClassPositiveCases.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.uber.autodispose.error.prone.checker;
+package com.uber.autodispose.errorprone;
 
-import com.uber.autodispose.AutoDispose;
+import com.uber.autodispose.errorprone.UseAutoDispose;
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction;
 import com.uber.autodispose.lifecycle.LifecycleEndedException;
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider;
@@ -33,12 +33,11 @@ import io.reactivex.annotations.Nullable;
 import io.reactivex.subjects.BehaviorSubject;
 import org.reactivestreams.Subscriber;
 
-import static com.uber.autodispose.AutoDispose.autoDisposable;
-
 /**
- * Cases that use {@link AutoDispose} and should not fail the {@link UseAutoDispose} check.
+ * Cases that don't use autodispose and should fail the {@link UseAutoDispose} check.
  */
-public class UseAutoDisposeNegativeCases implements LifecycleScopeProvider<TestLifecycleScopeProvider.TestLifecycle> {
+public class UseAutoDisposeDefaultClassPositiveCases
+    implements LifecycleScopeProvider<TestLifecycleScopeProvider.TestLifecycle> {
 
   private final BehaviorSubject<TestLifecycleScopeProvider.TestLifecycle> lifecycleSubject = BehaviorSubject.create();
 
@@ -80,41 +79,41 @@ public class UseAutoDisposeNegativeCases implements LifecycleScopeProvider<TestL
     return LifecycleScopes.resolveScopeFromLifecycle(this);
   }
 
-  public void observable_subscribeWithAutoDispose() {
-    Observable.just(1)
-        .as(autoDisposable(this))
+  public void observable_subscribeWithoutAutoDispose() {
+    Observable.empty()
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
         .subscribe();
   }
 
-  public void single_subscribeWithAutoDispose() {
+  public void single_subscribeWithoutAutoDispose() {
     Single.just(true)
-        .as(autoDisposable(this))
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
         .subscribe();
   }
 
-  public void completable_subscribeWithAutoDispose() {
+  public void completable_subscribeWithoutAutoDispose() {
     Completable.complete()
-        .as(autoDisposable(this))
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
         .subscribe();
   }
 
-  public void maybe_subscribeWithAutoDispose() {
-    Maybe.just(1)
-        .as(autoDisposable(this))
+  public void maybe_subscribeWithoutAutoDispose() {
+    Maybe.empty()
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
         .subscribe();
   }
 
-  public void flowable_subscribeWithAutoDispose() {
-    Flowable.just(1)
-        .as(autoDisposable(this))
+  public void flowable_subscribeWithoutAutoDispose() {
+    Flowable.empty()
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
         .subscribe();
   }
 
-  public void parallelFlowable_subscribeWithAutoDispose() {
+  public void parallelFlowable_subscribeWithoutAutoDispose() {
     Subscriber<Integer>[] subscribers = new Subscriber[] {};
     Flowable.just(1, 2)
         .parallel(2)
-        .as(autoDisposable(this))
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
         .subscribe(subscribers);
   }
 }

--- a/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeNegativeCases.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeNegativeCases.java
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-package com.uber.autodispose.error.prone.checker;
+package com.uber.autodispose.errorprone;
 
+import com.uber.autodispose.AutoDispose;
+import com.uber.autodispose.errorprone.UseAutoDispose;
 import com.uber.autodispose.lifecycle.CorrespondingEventsFunction;
 import com.uber.autodispose.lifecycle.LifecycleEndedException;
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider;
@@ -32,11 +34,12 @@ import io.reactivex.annotations.Nullable;
 import io.reactivex.subjects.BehaviorSubject;
 import org.reactivestreams.Subscriber;
 
+import static com.uber.autodispose.AutoDispose.autoDisposable;
+
 /**
- * Cases that don't use autodispose and should fail the {@link UseAutoDispose} check.
+ * Cases that use {@link AutoDispose} and should not fail the {@link UseAutoDispose} check.
  */
-public class UseAutoDisposeDefaultClassPositiveCases
-    implements LifecycleScopeProvider<TestLifecycleScopeProvider.TestLifecycle> {
+public class UseAutoDisposeNegativeCases implements LifecycleScopeProvider<TestLifecycleScopeProvider.TestLifecycle> {
 
   private final BehaviorSubject<TestLifecycleScopeProvider.TestLifecycle> lifecycleSubject = BehaviorSubject.create();
 
@@ -78,41 +81,41 @@ public class UseAutoDisposeDefaultClassPositiveCases
     return LifecycleScopes.resolveScopeFromLifecycle(this);
   }
 
-  public void observable_subscribeWithoutAutoDispose() {
-    Observable.empty()
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+  public void observable_subscribeWithAutoDispose() {
+    Observable.just(1)
+        .as(autoDisposable(this))
         .subscribe();
   }
 
-  public void single_subscribeWithoutAutoDispose() {
+  public void single_subscribeWithAutoDispose() {
     Single.just(true)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        .as(autoDisposable(this))
         .subscribe();
   }
 
-  public void completable_subscribeWithoutAutoDispose() {
+  public void completable_subscribeWithAutoDispose() {
     Completable.complete()
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        .as(autoDisposable(this))
         .subscribe();
   }
 
-  public void maybe_subscribeWithoutAutoDispose() {
-    Maybe.empty()
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+  public void maybe_subscribeWithAutoDispose() {
+    Maybe.just(1)
+        .as(autoDisposable(this))
         .subscribe();
   }
 
-  public void flowable_subscribeWithoutAutoDispose() {
-    Flowable.empty()
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+  public void flowable_subscribeWithAutoDispose() {
+    Flowable.just(1)
+        .as(autoDisposable(this))
         .subscribe();
   }
 
-  public void parallelFlowable_subscribeWithoutAutoDispose() {
+  public void parallelFlowable_subscribeWithAutoDispose() {
     Subscriber<Integer>[] subscribers = new Subscriber[] {};
     Flowable.just(1, 2)
         .parallel(2)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        .as(autoDisposable(this))
         .subscribe(subscribers);
   }
 }


### PR DESCRIPTION
As described in http://branchandbound.net/blog/java/2017/12/automatic-module-name/

I'm not totally sure what to do with the ktx artifacts, as they're all purely extension functions but technically don't have different root packages. Open to suggestions. The android artifacts also have this applied, though more fore completeness since Android doesn't support java 9 anyway.

Also opportunistically fixed the error prone checker package from `error.prone.checker` to just `errorprone`. Previous name was unnecessarily pedantic and should be ok as far as semver goes since it's not supposed to be a dependency or manually wired anywhere