### PR TITLE
Apply autoservice processing to error prone checker

### DIFF
--- a/static-analysis/autodispose-error-prone-checker/build.gradle
+++ b/static-analysis/autodispose-error-prone-checker/build.gradle
@@ -28,6 +28,7 @@ targetCompatibility = 1.8
 
 dependencies {
   annotationProcessor deps.build.nullAway
+  annotationProcessor deps.apt.autoService
   testAnnotationProcessor deps.build.nullAway
 
   compileOnly deps.apt.autoService


### PR DESCRIPTION
**Description**: This adds the missing service file to the error-prone JAR.

**Related issue(s)**: #287 

What do you think about integrating this into the sample project, so that we can easily test newer/existing checks? 