### PR TITLE
Big error-prone refresh

### DIFF
--- a/static-analysis/autodispose-error-prone-checker/build.gradle
+++ b/static-analysis/autodispose-error-prone-checker/build.gradle
@@ -24,6 +24,8 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
+  annotationProcessor deps.apt.autoService
+
   compileOnly deps.apt.autoService
   compileOnly deps.build.errorProneCheckApi
 

--- a/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/AbstractReturnValueIgnored.java
+++ b/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/AbstractReturnValueIgnored.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2012 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.autodispose.errorprone;
+
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.enclosingNode;
+import static com.google.errorprone.matchers.Matchers.expressionStatement;
+import static com.google.errorprone.matchers.Matchers.isLastStatementInBlock;
+import static com.google.errorprone.matchers.Matchers.kindIs;
+import static com.google.errorprone.matchers.Matchers.methodSelect;
+import static com.google.errorprone.matchers.Matchers.nextStatement;
+import static com.google.errorprone.matchers.Matchers.not;
+import static com.google.errorprone.matchers.Matchers.parentNode;
+import static com.google.errorprone.matchers.Matchers.previousStatement;
+import static com.google.errorprone.matchers.Matchers.toType;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MemberReferenceTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.Fix;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MemberReferenceTree;
+import com.sun.source.tree.MemberReferenceTree.ReferenceMode;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.StatementTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
+import com.sun.tools.javac.tree.JCTree.JCIdent;
+import com.sun.tools.javac.tree.JCTree.JCLambda;
+import com.sun.tools.javac.tree.JCTree.JCMemberReference;
+import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
+import javax.lang.model.type.TypeKind;
+
+/**
+ * An abstract base class to match method invocations in which the return value is not used.
+ * <p>
+ * Adapted from https://github
+ * .com/google/error-prone/blob/976ab7c62771d54dfe11bde9b01dc301d364957b/core/src/main/java/com
+ * /google/errorprone/bugpatterns/AbstractReturnValueIgnored.java
+ *
+ * @author eaftan@google.com (Eddie Aftandilian)
+ */
+abstract class AbstractReturnValueIgnored extends BugChecker
+    implements MethodInvocationTreeMatcher, MemberReferenceTreeMatcher {
+
+  @Override public Description matchMethodInvocation(MethodInvocationTree methodInvocationTree,
+      VisitorState state) {
+    if (allOf(parentNode(anyOf(AbstractReturnValueIgnored::isVoidReturningLambdaExpression,
+        Matchers.kindIs(Kind.EXPRESSION_STATEMENT))),
+        not(methodSelect(toType(IdentifierTree.class, identifierHasName("super")))),
+        // NOTE left for ref, but we have to allow void types for subscribeWith() methods
+        //not((t, s) -> ASTHelpers.isVoidType(ASTHelpers.getType(t), s)),
+        specializedMatcher(),
+        not(AbstractReturnValueIgnored::expectedExceptionTest)).matches(methodInvocationTree,
+        state)) {
+      return describe(methodInvocationTree, state);
+    }
+    return Description.NO_MATCH;
+  }
+
+  @Override public Description matchMemberReference(MemberReferenceTree tree, VisitorState state) {
+    if (allOf((t, s) -> t.getMode() == ReferenceMode.INVOKE,
+        AbstractReturnValueIgnored::isVoidReturningMethodReferenceExpression,
+        // Skip cases where the method we're referencing really does return void. We're only
+        // looking for cases where the referenced method does not return void, but it's being
+        // used on a void-returning functional interface.
+        // NOTE left for ref, but we have to allow void types for subscribeWith() methods
+        //not((t, s) -> ASTHelpers.isVoidType(ASTHelpers.getSymbol(tree).getReturnType(), s)),
+        not((t, s) -> isThrowingFunctionalInterface(s, ((JCMemberReference) t).type)),
+        specializedMatcher()).matches(tree, state)) {
+      return describeMatch(tree);
+    }
+
+    return Description.NO_MATCH;
+  }
+
+  private static boolean isVoidReturningMethodReferenceExpression(MemberReferenceTree tree,
+      VisitorState state) {
+    return functionalInterfaceReturnsExactlyVoid(((JCMemberReference) tree).type, state);
+  }
+
+  private static boolean isVoidReturningLambdaExpression(Tree tree, VisitorState state) {
+    if (!(tree instanceof LambdaExpressionTree)) {
+      return false;
+    }
+
+    return functionalInterfaceReturnsExactlyVoid(((JCLambda) tree).type, state);
+  }
+
+  /**
+   * Checks that the return value of a functional interface is void. Note, we do not use
+   * ASTHelpers.isVoidType here, return values of Void are actually type-checked. Only
+   * void-returning functions silently ignore return values of any type.
+   */
+  private static boolean functionalInterfaceReturnsExactlyVoid(Type interfaceType,
+      VisitorState state) {
+    return state.getTypes()
+        .findDescriptorType(interfaceType)
+        .getReturnType()
+        .getKind() == TypeKind.VOID;
+  }
+
+  private static boolean methodCallInDeclarationOfThrowingRunnable(VisitorState state) {
+    // Find the nearest definitional context for this method invocation
+    // (i.e.: the nearest surrounding class or lambda)
+    Tree tree = null;
+    out:
+    for (Tree t : state.getPath()) {
+      switch (t.getKind()) {
+        case LAMBDA_EXPRESSION:
+        case CLASS:
+          tree = t;
+          break out;
+        default: // fall out, to loop again
+      }
+    }
+
+    if (tree == null) {
+      // Huh. Shouldn't happen.
+      return false;
+    }
+    return isThrowingFunctionalInterface(state, ASTHelpers.getType(tree));
+  }
+
+  private static boolean isThrowingFunctionalInterface(VisitorState state, Type clazzType) {
+    return CLASSES_CONSIDERED_THROWING.stream()
+        .anyMatch(t -> ASTHelpers.isSubtype(clazzType, state.getTypeFromString(t), state));
+  }
+
+  /**
+   * {@code @FunctionalInterface}'s that are generally used as a lambda expression for 'a block of
+   * code that's going to fail', e.g.:
+   *
+   * <p>{@code assertThrows(FooException.class, () -> myCodeThatThrowsAnException());
+   * errorCollector.checkThrows(FooException.class, () -> myCodeThatThrowsAnException()); }
+   *
+   * <p>// TODO(glorioso): Consider a meta-annotation like @LikelyToThrow instead/in addition?
+   */
+  private static final ImmutableSet<String> CLASSES_CONSIDERED_THROWING = ImmutableSet.of(
+      "org.junit.function.ThrowingRunnable",
+      "org.junit.jupiter.api.function.Executable",
+      "org.assertj.core.api.ThrowableAssert$ThrowingCallable",
+      "com.google.truth.ExpectFailure.AssertionCallback",
+      "com.google.truth.ExpectFailure.DelegatedAssertionCallback",
+      "com.google.truth.ExpectFailure.StandardSubjectBuilderCallback",
+      "com.google.truth.ExpectFailure.SimpleSubjectBuilderCallback");
+
+  /**
+   * Match whatever additional conditions concrete subclasses want to match (a list of known
+   * side-effect-free methods, has a @OptionalCheckReturnValue annotation, etc.).
+   */
+  public abstract Matcher<? super ExpressionTree> specializedMatcher();
+
+  private static Matcher<IdentifierTree> identifierHasName(final String name) {
+    return (item, state) -> item.getName()
+        .contentEquals(name);
+  }
+
+  /**
+   * Fixes the error by assigning the result of the call to the receiver reference, or deleting the
+   * method call.
+   */
+  private Description describe(MethodInvocationTree methodInvocationTree, VisitorState state) {
+    // Find the root of the field access chain, i.e. a.intern().trim() ==> a.
+    ExpressionTree identifierExpr = ASTHelpers.getRootAssignable(methodInvocationTree);
+    String identifierStr = null;
+    Type identifierType = null;
+    if (identifierExpr != null) {
+      identifierStr = identifierExpr.toString();
+      if (identifierExpr instanceof JCIdent) {
+        identifierType = ((JCIdent) identifierExpr).sym.type;
+      } else if (identifierExpr instanceof JCFieldAccess) {
+        identifierType = ((JCFieldAccess) identifierExpr).sym.type;
+      } else {
+        throw new IllegalStateException("Expected a JCIdent or a JCFieldAccess");
+      }
+    }
+
+    Type returnType =
+        ASTHelpers.getReturnType(((JCMethodInvocation) methodInvocationTree).getMethodSelect());
+
+    Fix fix;
+    if (identifierStr != null
+        && !"this".equals(identifierStr)
+        && returnType != null
+        && state.getTypes()
+        .isAssignable(returnType, identifierType)) {
+      // Fix by assigning the assigning the result of the call to the root receiver reference.
+      fix = SuggestedFix.prefixWith(methodInvocationTree, identifierStr + " = ");
+    } else {
+      // Unclear what the programmer intended.  Delete since we don't know what else to do.
+      Tree parent = state.getPath()
+          .getParentPath()
+          .getLeaf();
+      fix = SuggestedFix.delete(parent);
+    }
+    return describeMatch(methodInvocationTree, fix);
+  }
+
+  /** Allow return values to be ignored in tests that expect an exception to be thrown. */
+  private static boolean expectedExceptionTest(Tree tree, VisitorState state) {
+    if (mockitoInvocation(tree, state)) {
+      return true;
+    }
+
+    // Allow unused return values in tests that check for thrown exceptions, e.g.:
+    //
+    // try {
+    //   Foo.newFoo(-1);
+    //   fail();
+    // } catch (IllegalArgumentException expected) {
+    // }
+    //
+    StatementTree statement = ASTHelpers.findEnclosingNode(state.getPath(), StatementTree.class);
+    if (statement != null && EXPECTED_EXCEPTION_MATCHER.matches(statement, state)) {
+      return true;
+    }
+    return false;
+  }
+
+  private static final Matcher<ExpressionTree> FAIL_METHOD =
+      anyOf(instanceMethod().onDescendantOf("com.google.common.truth.AbstractVerb")
+              .named("fail"),
+          instanceMethod().onDescendantOf("com.google.common.truth.StandardSubjectBuilder")
+              .named("fail"),
+          staticMethod().onClass("org.junit.Assert")
+              .named("fail"),
+          staticMethod().onClass("junit.framework.Assert")
+              .named("fail"),
+          staticMethod().onClass("junit.framework.TestCase")
+              .named("fail"));
+
+  private static final Matcher<StatementTree> EXPECTED_EXCEPTION_MATCHER = anyOf(
+      // expectedException.expect(Foo.class); me();
+      allOf(isLastStatementInBlock(),
+          previousStatement(expressionStatement(anyOf(instanceMethod().onExactClass(
+              "org.junit.rules.ExpectedException"))))),
+      // try { me(); fail(); } catch (Throwable t) {}
+      allOf(enclosingNode(kindIs(Kind.TRY)), nextStatement(expressionStatement(FAIL_METHOD))),
+      // assertThrows(Throwable.class, () => { me(); })
+      allOf(anyOf(isLastStatementInBlock(), parentNode(kindIs(Kind.LAMBDA_EXPRESSION))),
+          // Within the context of a ThrowingRunnable/Executable:
+          (t, s) -> methodCallInDeclarationOfThrowingRunnable(s)));
+
+  private static final Matcher<ExpressionTree> MOCKITO_MATCHER =
+      anyOf(staticMethod().onClass("org.mockito.Mockito")
+              .named("verify"),
+          instanceMethod().onDescendantOf("org.mockito.stubbing.Stubber")
+              .named("when"),
+          instanceMethod().onDescendantOf("org.mockito.InOrder")
+              .named("verify"));
+
+  /**
+   * Don't match the method that is invoked through {@code Mockito.verify(t)} or {@code
+   * doReturn(val).when(t)}.
+   */
+  private static boolean mockitoInvocation(Tree tree, VisitorState state) {
+    if (!(tree instanceof JCMethodInvocation)) {
+      return false;
+    }
+    JCMethodInvocation invocation = (JCMethodInvocation) tree;
+    if (!(invocation.getMethodSelect() instanceof JCFieldAccess)) {
+      return false;
+    }
+    ExpressionTree receiver = ASTHelpers.getReceiver(invocation);
+    return MOCKITO_MATCHER.matches(receiver, state);
+  }
+}

--- a/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/AbstractReturnValueIgnored.java
+++ b/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/AbstractReturnValueIgnored.java
@@ -80,9 +80,6 @@ abstract class AbstractReturnValueIgnored extends BugChecker
     return matchMethodInvocationNew(tree, state);
   }
 
-  /**
-   * This is what I want to do, but am messing up some sort of logic here
-   */
   private Description matchMethodInvocationNew(MethodInvocationTree tree, VisitorState state) {
     boolean matches = specializedMatcher().matches(tree, state);
     if (!matches) {

--- a/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/AbstractReturnValueIgnored.java
+++ b/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/AbstractReturnValueIgnored.java
@@ -71,12 +71,6 @@ import javax.lang.model.type.TypeKind;
 abstract class AbstractReturnValueIgnored extends BugChecker
     implements MethodInvocationTreeMatcher, MemberReferenceTreeMatcher {
 
-  /**
-   * @return {@code true} if this should be lenient and only run the checks if the return value is
-   * ignored, {@code false} if it should always check {@link #specializedMatcher()}.
-   */
-  abstract boolean lenient();
-
   @Override public Description matchMethodInvocation(MethodInvocationTree methodInvocationTree,
       VisitorState state) {
     if (!lenient()) {
@@ -192,6 +186,12 @@ abstract class AbstractReturnValueIgnored extends BugChecker
    * side-effect-free methods, has a @OptionalCheckReturnValue annotation, etc.).
    */
   public abstract Matcher<? super ExpressionTree> specializedMatcher();
+
+  /**
+   * @return {@code true} if this should be lenient and only run the checks if the return value is
+   * ignored, {@code false} if it should always check {@link #specializedMatcher()}.
+   */
+  abstract boolean lenient();
 
   private static Matcher<IdentifierTree> identifierHasName(final String name) {
     return (item, state) -> item.getName()

--- a/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
+++ b/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
@@ -18,6 +18,7 @@ package com.uber.autodispose.errorprone;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
@@ -32,8 +33,8 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.code.Type;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.BugPattern.StandardTags.CONCURRENCY;
@@ -48,14 +49,98 @@ import static com.google.errorprone.matchers.Matchers.instanceMethod;
  * </code></pre>
  */
 @AutoService(BugChecker.class)
-@BugPattern(name = "UseAutoDispose", summary = "Always apply an AutoDispose scope before "
-    + "subscribing within defined scoped elements.", tags = CONCURRENCY, severity = ERROR)
-public final class UseAutoDispose extends BugChecker implements MethodInvocationTreeMatcher {
+@BugPattern(
+    name = "UseAutoDispose",
+    summary = "Always apply an AutoDispose scope before "
+        + "subscribing within defined scoped elements.",
+    tags = CONCURRENCY,
+    severity = ERROR
+)
+public final class UseAutoDispose extends BugChecker
+    implements MethodInvocationTreeMatcher {
 
   private static final String AS = "as";
-  private static final ImmutableList<MethodMatchers.MethodNameMatcher> AS_CALL_MATCHERS;
-  private static final ImmutableList<MethodMatchers.MethodNameMatcher> SUBSCRIBE_MATCHERS;
   private static final String SUBSCRIBE = "subscribe";
+  private static final ImmutableList<MethodMatchers.MethodNameMatcher> AS_CALL_MATCHERS =
+      ImmutableList.<MethodMatchers.MethodNameMatcher>builder()
+          .add(instanceMethod().onDescendantOf("io.reactivex.Single")
+              .named(AS))
+          .add(instanceMethod().onDescendantOf("io.reactivex.Observable")
+              .named(AS))
+          .add(instanceMethod().onDescendantOf("io.reactivex.Completable")
+              .named(AS))
+          .add(instanceMethod().onDescendantOf("io.reactivex.Flowable")
+              .named(AS))
+          .add(instanceMethod().onDescendantOf("io.reactivex.Maybe")
+              .named(AS))
+          .add(instanceMethod().onDescendantOf("io.reactivex.parallel.ParallelFlowable")
+              .named(AS))
+          .build();
+  private static final ImmutableList<MethodMatchers.MethodNameMatcher> SUBSCRIBE_MATCHERS =
+      ImmutableList.<MethodMatchers.MethodNameMatcher>builder()
+          .add(instanceMethod().onDescendantOf("io.reactivex.Single")
+              .named(SUBSCRIBE))
+          .add(instanceMethod().onDescendantOf("io.reactivex.Observable")
+              .named(SUBSCRIBE))
+          .add(instanceMethod().onDescendantOf("io.reactivex.Completable")
+              .named(SUBSCRIBE))
+          .add(instanceMethod().onDescendantOf("io.reactivex.Flowable")
+              .named(SUBSCRIBE))
+          .add(instanceMethod().onDescendantOf("io.reactivex.Maybe")
+              .named(SUBSCRIBE))
+          .add(instanceMethod().onDescendantOf("io.reactivex.parallel.ParallelFlowable")
+              .named(SUBSCRIBE))
+          .build();
+  private static final ImmutableSet<String> DEFAULT_CLASSES_WITH_LIFECYCLE =
+      new ImmutableSet.Builder<String>().add("android.app.Activity")
+          .add("android.app.Fragment")
+          .add("com.uber.autodispose.LifecycleScopeProvider")
+          .add("android.support.v4.app.Fragment")
+          .add("androidx.fragment.app.Fragment")
+          .add("android.arch.lifecycle.LifecycleOwner")
+          .add("androidx.lifecycle.LifecycleOwner")
+          .add("com.uber.autodispose.ScopeProvider")
+          .build();
+
+  /**
+   * Matcher to find the as operator in the observable chain.
+   */
+  private static final Matcher<ExpressionTree> METHOD_NAME_MATCHERS =
+      (Matcher<ExpressionTree>) (tree, state) -> {
+        if (!(tree instanceof MethodInvocationTree)) {
+          return false;
+        }
+        MethodInvocationTree invTree = (MethodInvocationTree) tree;
+
+        ExpressionTree methodSelectTree = invTree.getMethodSelect();
+
+        // MemberSelectTree is used only for member access expression.
+        // This is not true for scenarios such as calling super constructor.
+        if (!(methodSelectTree instanceof MemberSelectTree)) {
+          return false;
+        }
+
+        final MemberSelectTree memberTree = (MemberSelectTree) methodSelectTree;
+        if (!memberTree.getIdentifier()
+            .contentEquals(AS)) {
+          return false;
+        }
+
+        return AS_CALL_MATCHERS.stream()
+            .filter(methodNameMatcher -> methodNameMatcher.matches(invTree, state))
+            .map(methodNameMatcher -> {
+              ExpressionTree arg = invTree.getArguments()
+                  .get(0);
+              final Type scoper =
+                  state.getTypeFromString("com.uber.autodispose.AutoDisposeConverter");
+              return ASTHelpers.isSubtype(ASTHelpers.getType(arg), scoper, state);
+            })
+            // Filtering the method invocation with name as
+            // and has an argument of type AutoDisposeConverter.
+            .filter(Boolean::booleanValue)
+            .findFirst()
+            .orElse(false);
+      };
 
   private final Matcher<MethodInvocationTree> matcher;
 
@@ -64,93 +149,15 @@ public final class UseAutoDispose extends BugChecker implements MethodInvocation
   }
 
   public UseAutoDispose(ErrorProneFlags flags) {
-    Optional<ImmutableList<String>> inputClasses = flags.getList("ClassesWithScope");
-    ImmutableList<String> defaultClassesWithLifecycle = new ImmutableList.Builder<String>().add("android.app.Activity")
-        .add("android.app.Fragment")
-        .add("com.uber.autodispose.LifecycleScopeProvider")
-        .add("android.support.v4.app.Fragment")
-        .add("androidx.fragment.app.Fragment")
-        .add("android.arch.lifecycle.LifecycleOwner")
-        .add("androidx.lifecycle.LifecycleOwner")
-        .add("com.uber.autodispose.ScopeProvider")
-        .build();
-    ImmutableList<String> classesWithLifecycle = inputClasses.orElse(defaultClassesWithLifecycle);
+    // Borrowed from getList() impl
+    Optional<ImmutableSet<String>> inputClasses = flags.getList("ClassesWithScope")
+        .map(ImmutableSet::copyOf);
+
+    ImmutableSet<String> classesWithLifecycle = inputClasses.orElse(DEFAULT_CLASSES_WITH_LIFECYCLE);
     matcher = matcher(classesWithLifecycle);
   }
 
-  static {
-    AS_CALL_MATCHERS = new ImmutableList.Builder<MethodMatchers.MethodNameMatcher>().add(
-        instanceMethod().onDescendantOf("io.reactivex.Single")
-            .named(AS))
-        .add(instanceMethod().onDescendantOf("io.reactivex.Observable")
-            .named(AS))
-        .add(instanceMethod().onDescendantOf("io.reactivex.Completable")
-            .named(AS))
-        .add(instanceMethod().onDescendantOf("io.reactivex.Flowable")
-            .named(AS))
-        .add(instanceMethod().onDescendantOf("io.reactivex.Maybe")
-            .named(AS))
-        .add(instanceMethod().onDescendantOf("io.reactivex.parallel.ParallelFlowable")
-            .named(AS))
-        .build();
-
-    SUBSCRIBE_MATCHERS = new ImmutableList.Builder<MethodMatchers.MethodNameMatcher>().add(
-        instanceMethod().onDescendantOf("io.reactivex.Single")
-            .named(SUBSCRIBE))
-        .add(instanceMethod().onDescendantOf("io.reactivex.Observable")
-            .named(SUBSCRIBE))
-        .add(instanceMethod().onDescendantOf("io.reactivex.Completable")
-            .named(SUBSCRIBE))
-        .add(instanceMethod().onDescendantOf("io.reactivex.Flowable")
-            .named(SUBSCRIBE))
-        .add(instanceMethod().onDescendantOf("io.reactivex.Maybe")
-            .named(SUBSCRIBE))
-        .add(instanceMethod().onDescendantOf("io.reactivex.parallel.ParallelFlowable")
-            .named(SUBSCRIBE))
-        .build();
-  }
-
-  /**
-   * Matcher to find the as operator in the observable chain.
-   */
-  private static final Matcher<ExpressionTree> METHOD_NAME_MATCHERS = new Matcher<ExpressionTree>() {
-    @Override public boolean matches(ExpressionTree tree, VisitorState state) {
-      if (!(tree instanceof MethodInvocationTree)) {
-        return false;
-      }
-      MethodInvocationTree invTree = (MethodInvocationTree) tree;
-
-      ExpressionTree methodSelectTree = invTree.getMethodSelect();
-
-      // MemberSelectTree is used only for member access expression.
-      // This is not true for scenarios such as calling super constructor.
-      if (!(methodSelectTree instanceof MemberSelectTree)) {
-        return false;
-      }
-
-      final MemberSelectTree memberTree = (MemberSelectTree) methodSelectTree;
-      if (!memberTree.getIdentifier()
-          .contentEquals(AS)) {
-        return false;
-      }
-
-      return AS_CALL_MATCHERS.stream()
-          .filter(methodNameMatcher -> methodNameMatcher.matches(invTree, state))
-          .map(methodNameMatcher -> {
-            ExpressionTree arg = invTree.getArguments()
-                .get(0);
-            final Type scoper = state.getTypeFromString("com.uber.autodispose.AutoDisposeConverter");
-            return ASTHelpers.isSubtype(ASTHelpers.getType(arg), scoper, state);
-          })
-          // Filtering the method invocation with name as
-          // and has an argument of type AutoDisposeConverter.
-          .filter(Boolean::booleanValue)
-          .findFirst()
-          .orElse(false);
-    }
-  };
-
-  private static Matcher<MethodInvocationTree> matcher(List<String> classesWithLifecycle) {
+  private static Matcher<MethodInvocationTree> matcher(Set<String> classesWithLifecycle) {
     return (Matcher<MethodInvocationTree>) (tree, state) -> {
 
       ExpressionTree methodSelectTree = tree.getMethodSelect();
@@ -183,8 +190,8 @@ public final class UseAutoDispose extends BugChecker implements MethodInvocation
       return classesWithLifecycle.stream()
           .map(classWithLifecycle -> {
             Type lifecycleType = state.getTypeFromString(classWithLifecycle);
-            return ASTHelpers.isSubtype(enclosingClassType, lifecycleType, state) && !METHOD_NAME_MATCHERS.matches(
-                memberTree.getExpression(), state);
+            return ASTHelpers.isSubtype(enclosingClassType, lifecycleType, state)
+                && !METHOD_NAME_MATCHERS.matches(memberTree.getExpression(), state);
           })
           // Filtering the method invocation which is a
           // subtype of one of the classes with lifecycle and name as

--- a/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
+++ b/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
@@ -61,7 +61,7 @@ public final class UseAutoDispose extends AbstractReturnValueIgnored
   private static final ImmutableSet<String> DEFAULT_CLASSES_WITH_LIFECYCLE =
       new ImmutableSet.Builder<String>().add("android.app.Activity")
           .add("android.app.Fragment")
-          .add("com.uber.autodispose.LifecycleScopeProvider")
+          .add("com.uber.autodispose.lifecycle.LifecycleScopeProvider")
           .add("android.support.v4.app.Fragment")
           .add("androidx.fragment.app.Fragment")
           .add("android.arch.lifecycle.LifecycleOwner")

--- a/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
+++ b/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
@@ -17,27 +17,23 @@
 package com.uber.autodispose.errorprone;
 
 import com.google.auto.service.AutoService;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.ErrorProneFlags;
-import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
-import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.method.MethodMatchers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
-import com.sun.source.tree.MemberSelectTree;
-import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.code.Type;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.BugPattern.StandardTags.CONCURRENCY;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
 
 /**
@@ -56,42 +52,12 @@ import static com.google.errorprone.matchers.Matchers.instanceMethod;
     tags = CONCURRENCY,
     severity = ERROR
 )
-public final class UseAutoDispose extends BugChecker
+public final class UseAutoDispose extends AbstractReturnValueIgnored
     implements MethodInvocationTreeMatcher {
 
   private static final String AS = "as";
   private static final String SUBSCRIBE = "subscribe";
   private static final String SUBSCRIBE_WITH = "subscribeWith";
-  private static final ImmutableList<MethodMatchers.MethodNameMatcher> AS_CALL_MATCHERS =
-      ImmutableList.<MethodMatchers.MethodNameMatcher>builder()
-          .add(instanceMethod().onDescendantOf("io.reactivex.Single")
-              .named(AS))
-          .add(instanceMethod().onDescendantOf("io.reactivex.Observable")
-              .named(AS))
-          .add(instanceMethod().onDescendantOf("io.reactivex.Completable")
-              .named(AS))
-          .add(instanceMethod().onDescendantOf("io.reactivex.Flowable")
-              .named(AS))
-          .add(instanceMethod().onDescendantOf("io.reactivex.Maybe")
-              .named(AS))
-          .add(instanceMethod().onDescendantOf("io.reactivex.parallel.ParallelFlowable")
-              .named(AS))
-          .build();
-  private static final ImmutableList<MethodMatchers.MethodNameMatcher> SUBSCRIBE_MATCHERS =
-      ImmutableList.<MethodMatchers.MethodNameMatcher>builder()
-          .add(instanceMethod().onDescendantOf("io.reactivex.Single")
-              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH))
-          .add(instanceMethod().onDescendantOf("io.reactivex.Observable")
-              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH))
-          .add(instanceMethod().onDescendantOf("io.reactivex.Completable")
-              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH))
-          .add(instanceMethod().onDescendantOf("io.reactivex.Flowable")
-              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH))
-          .add(instanceMethod().onDescendantOf("io.reactivex.Maybe")
-              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH))
-          .add(instanceMethod().onDescendantOf("io.reactivex.parallel.ParallelFlowable")
-              .named(SUBSCRIBE))
-          .build();
   private static final ImmutableSet<String> DEFAULT_CLASSES_WITH_LIFECYCLE =
       new ImmutableSet.Builder<String>().add("android.app.Activity")
           .add("android.app.Fragment")
@@ -103,108 +69,51 @@ public final class UseAutoDispose extends BugChecker
           .add("com.uber.autodispose.ScopeProvider")
           .build();
 
-  /**
-   * Matcher to find the as operator in the observable chain.
-   */
-  private static final Matcher<ExpressionTree> METHOD_NAME_MATCHERS =
-      (Matcher<ExpressionTree>) (tree, state) -> {
-        if (!(tree instanceof MethodInvocationTree)) {
-          return false;
-        }
-        MethodInvocationTree invTree = (MethodInvocationTree) tree;
+  private static final Matcher<ExpressionTree> SUBSCRIBE_METHOD =
+      anyOf(instanceMethod().onDescendantOf("io.reactivex.Single")
+              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH),
+          instanceMethod().onDescendantOf("io.reactivex.Observable")
+              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH),
+          instanceMethod().onDescendantOf("io.reactivex.Completable")
+              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH),
+          instanceMethod().onDescendantOf("io.reactivex.Flowable")
+              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH),
+          instanceMethod().onDescendantOf("io.reactivex.Maybe")
+              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH),
+          instanceMethod().onDescendantOf("io.reactivex.parallel.ParallelFlowable")
+              .named(SUBSCRIBE));
 
-        ExpressionTree methodSelectTree = invTree.getMethodSelect();
-
-        // MemberSelectTree is used only for member access expression.
-        // This is not true for scenarios such as calling super constructor.
-        if (!(methodSelectTree instanceof MemberSelectTree)) {
-          return false;
-        }
-
-        final MemberSelectTree memberTree = (MemberSelectTree) methodSelectTree;
-        if (!memberTree.getIdentifier()
-            .contentEquals(AS)) {
-          return false;
-        }
-
-        return AS_CALL_MATCHERS.stream()
-            .filter(methodNameMatcher -> methodNameMatcher.matches(invTree, state))
-            .map(methodNameMatcher -> {
-              ExpressionTree arg = invTree.getArguments()
-                  .get(0);
-              final Type scoper =
-                  state.getTypeFromString("com.uber.autodispose.AutoDisposeConverter");
-              return ASTHelpers.isSubtype(ASTHelpers.getType(arg), scoper, state);
-            })
-            // Filtering the method invocation with name as
-            // and has an argument of type AutoDisposeConverter.
-            .filter(Boolean::booleanValue)
-            .findFirst()
-            .orElse(false);
-      };
-
-  private final Matcher<MethodInvocationTree> matcher;
+  private final Matcher<ExpressionTree> matcher;
 
   public UseAutoDispose() {
     this(ErrorProneFlags.empty());
   }
 
   public UseAutoDispose(ErrorProneFlags flags) {
-    // Borrowed from getList() impl
     Optional<ImmutableSet<String>> inputClasses = flags.getList("ClassesWithScope")
         .map(ImmutableSet::copyOf);
 
     ImmutableSet<String> classesWithLifecycle = inputClasses.orElse(DEFAULT_CLASSES_WITH_LIFECYCLE);
-    matcher = matcher(classesWithLifecycle);
+    matcher = allOf(SUBSCRIBE_METHOD, matcher(classesWithLifecycle));
   }
 
-  @Override public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-    if (matcher.matches(tree, state)) {
-      return buildDescription(tree).build();
-    } else {
-      return Description.NO_MATCH;
-    }
+  @Override public Matcher<? super ExpressionTree> specializedMatcher() {
+    return matcher;
   }
 
   @Override public String linkUrl() {
     return "https://github.com/uber/AutoDispose/wiki/Error-Prone-Checker";
   }
 
-  private static Matcher<MethodInvocationTree> matcher(Set<String> classesWithLifecycle) {
-    return (Matcher<MethodInvocationTree>) (tree, state) -> {
-
-      ExpressionTree methodSelectTree = tree.getMethodSelect();
-
-      // MemberSelectTree is used only for member access expression.
-      // This is not true for scenarios such as calling super constructor.
-      if (!(methodSelectTree instanceof MemberSelectTree)) {
-        return false;
-      }
-
-      final MemberSelectTree memberTree = (MemberSelectTree) tree.getMethodSelect();
-      if (!memberTree.getIdentifier()
-          .contentEquals(SUBSCRIBE)) {
-        return false;
-      }
-
-      boolean matchFound = SUBSCRIBE_MATCHERS.stream()
-          .map(methodNameMatcher -> methodNameMatcher.matches(tree, state))
-          .filter(Boolean::booleanValue) // Filtering the method invocation with name subscribe
-          .findFirst()
-          .orElse(false);
-
-      if (!matchFound) {
-        return false;
-      }
-
+  private static Matcher<ExpressionTree> matcher(Set<String> classesWithLifecycle) {
+    return (Matcher<ExpressionTree>) (tree, state) -> {
       ClassTree enclosingClass = ASTHelpers.findEnclosingNode(state.getPath(), ClassTree.class);
       Type.ClassType enclosingClassType = ASTHelpers.getType(enclosingClass);
 
       return classesWithLifecycle.stream()
           .map(classWithLifecycle -> {
             Type lifecycleType = state.getTypeFromString(classWithLifecycle);
-            return ASTHelpers.isSubtype(enclosingClassType, lifecycleType, state)
-                && !METHOD_NAME_MATCHERS.matches(memberTree.getExpression(), state);
+            return ASTHelpers.isSubtype(enclosingClassType, lifecycleType, state);
           })
           // Filtering the method invocation which is a
           // subtype of one of the classes with lifecycle and name as

--- a/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
+++ b/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
@@ -61,6 +61,7 @@ public final class UseAutoDispose extends BugChecker
 
   private static final String AS = "as";
   private static final String SUBSCRIBE = "subscribe";
+  private static final String SUBSCRIBE_WITH = "subscribeWith";
   private static final ImmutableList<MethodMatchers.MethodNameMatcher> AS_CALL_MATCHERS =
       ImmutableList.<MethodMatchers.MethodNameMatcher>builder()
           .add(instanceMethod().onDescendantOf("io.reactivex.Single")
@@ -79,15 +80,15 @@ public final class UseAutoDispose extends BugChecker
   private static final ImmutableList<MethodMatchers.MethodNameMatcher> SUBSCRIBE_MATCHERS =
       ImmutableList.<MethodMatchers.MethodNameMatcher>builder()
           .add(instanceMethod().onDescendantOf("io.reactivex.Single")
-              .named(SUBSCRIBE))
+              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH))
           .add(instanceMethod().onDescendantOf("io.reactivex.Observable")
-              .named(SUBSCRIBE))
+              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH))
           .add(instanceMethod().onDescendantOf("io.reactivex.Completable")
-              .named(SUBSCRIBE))
+              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH))
           .add(instanceMethod().onDescendantOf("io.reactivex.Flowable")
-              .named(SUBSCRIBE))
+              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH))
           .add(instanceMethod().onDescendantOf("io.reactivex.Maybe")
-              .named(SUBSCRIBE))
+              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH))
           .add(instanceMethod().onDescendantOf("io.reactivex.parallel.ParallelFlowable")
               .named(SUBSCRIBE))
           .build();

--- a/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
+++ b/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
@@ -84,6 +84,7 @@ public final class UseAutoDispose extends AbstractReturnValueIgnored
               .named(SUBSCRIBE));
 
   private final Matcher<ExpressionTree> matcher;
+  private final boolean lenient;
 
   public UseAutoDispose() {
     this(ErrorProneFlags.empty());
@@ -95,6 +96,11 @@ public final class UseAutoDispose extends AbstractReturnValueIgnored
 
     ImmutableSet<String> classesWithLifecycle = inputClasses.orElse(DEFAULT_CLASSES_WITH_LIFECYCLE);
     matcher = allOf(SUBSCRIBE_METHOD, matcher(classesWithLifecycle));
+    lenient = flags.getBoolean("Lenient").orElse(false);
+  }
+
+  @Override boolean lenient() {
+    return lenient;
   }
 
   @Override public Matcher<? super ExpressionTree> specializedMatcher() {

--- a/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
+++ b/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
@@ -20,10 +20,10 @@ import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.ErrorProneFlags;
+import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.tools.javac.code.Type;
@@ -35,6 +35,9 @@ import static com.google.errorprone.BugPattern.StandardTags.CONCURRENCY;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
+import static com.google.errorprone.util.ASTHelpers.findEnclosingNode;
+import static com.google.errorprone.util.ASTHelpers.getType;
+import static com.google.errorprone.util.ASTHelpers.isSubtype;
 
 /**
  * Checker for subscriptions not binding to lifecycle in components with lifecycle.
@@ -45,17 +48,14 @@ import static com.google.errorprone.matchers.Matchers.instanceMethod;
  * </code></pre>
  */
 @AutoService(BugChecker.class)
-@BugPattern(
-    name = "UseAutoDispose",
+@BugPattern(name = "UseAutoDispose",
     summary = "Always apply an AutoDispose scope before "
         + "subscribing within defined scoped elements.",
     tags = CONCURRENCY,
-    severity = ERROR
-)
+    severity = ERROR)
 public final class UseAutoDispose extends AbstractReturnValueIgnored
     implements MethodInvocationTreeMatcher {
 
-  private static final String AS = "as";
   private static final String SUBSCRIBE = "subscribe";
   private static final String SUBSCRIBE_WITH = "subscribeWith";
   private static final ImmutableSet<String> DEFAULT_CLASSES_WITH_LIFECYCLE =
@@ -69,30 +69,30 @@ public final class UseAutoDispose extends AbstractReturnValueIgnored
           .add("com.uber.autodispose.ScopeProvider")
           .build();
 
-  private static final Matcher<ExpressionTree> SUBSCRIBE_METHOD =
-      anyOf(instanceMethod().onDescendantOf("io.reactivex.Single")
-              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH),
-          instanceMethod().onDescendantOf("io.reactivex.Observable")
-              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH),
-          instanceMethod().onDescendantOf("io.reactivex.Completable")
-              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH),
-          instanceMethod().onDescendantOf("io.reactivex.Flowable")
-              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH),
-          instanceMethod().onDescendantOf("io.reactivex.Maybe")
-              .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH),
-          instanceMethod().onDescendantOf("io.reactivex.parallel.ParallelFlowable")
-              .named(SUBSCRIBE));
+  private static final Matcher<ExpressionTree> SUBSCRIBE_METHOD = anyOf(
+      instanceMethod().onDescendantOf("io.reactivex.Single").namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH),
+      instanceMethod().onDescendantOf("io.reactivex.Observable")
+          .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH),
+      instanceMethod().onDescendantOf("io.reactivex.Completable")
+          .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH),
+      instanceMethod().onDescendantOf("io.reactivex.Flowable")
+          .namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH),
+      instanceMethod().onDescendantOf("io.reactivex.Maybe").namedAnyOf(SUBSCRIBE, SUBSCRIBE_WITH),
+      instanceMethod().onDescendantOf("io.reactivex.parallel.ParallelFlowable").named(SUBSCRIBE)
+  );
 
   private final Matcher<ExpressionTree> matcher;
   private final boolean lenient;
 
+  @SuppressWarnings("unused") // Default constructor used for SPI
   public UseAutoDispose() {
     this(ErrorProneFlags.empty());
   }
 
+  @SuppressWarnings("WeakerAccess") // Public for ErrorProne
   public UseAutoDispose(ErrorProneFlags flags) {
-    Optional<ImmutableSet<String>> inputClasses = flags.getList("ClassesWithScope")
-        .map(ImmutableSet::copyOf);
+    Optional<ImmutableSet<String>> inputClasses =
+        flags.getList("ClassesWithScope").map(ImmutableSet::copyOf);
 
     ImmutableSet<String> classesWithLifecycle = inputClasses.orElse(DEFAULT_CLASSES_WITH_LIFECYCLE);
     matcher = allOf(SUBSCRIBE_METHOD, matcher(classesWithLifecycle));
@@ -107,25 +107,26 @@ public final class UseAutoDispose extends AbstractReturnValueIgnored
     return matcher;
   }
 
+  @Override protected boolean capturedTypeAllowed(Type type, VisitorState state) {
+    return isSubtype(type, state.getTypeFromString("io.reactivex.disposables.Disposable"), state);
+  }
+
   @Override public String linkUrl() {
     return "https://github.com/uber/AutoDispose/wiki/Error-Prone-Checker";
   }
 
   private static Matcher<ExpressionTree> matcher(Set<String> classesWithLifecycle) {
     return (Matcher<ExpressionTree>) (tree, state) -> {
-      ClassTree enclosingClass = ASTHelpers.findEnclosingNode(state.getPath(), ClassTree.class);
-      Type.ClassType enclosingClassType = ASTHelpers.getType(enclosingClass);
+      ClassTree enclosingClass = findEnclosingNode(state.getPath(), ClassTree.class);
+      Type.ClassType enclosingClassType = getType(enclosingClass);
 
-      return classesWithLifecycle.stream()
-          .map(classWithLifecycle -> {
-            Type lifecycleType = state.getTypeFromString(classWithLifecycle);
-            return ASTHelpers.isSubtype(enclosingClassType, lifecycleType, state);
-          })
+      return classesWithLifecycle.stream().map(classWithLifecycle -> {
+        Type lifecycleType = state.getTypeFromString(classWithLifecycle);
+        return isSubtype(enclosingClassType, lifecycleType, state);
+      })
           // Filtering the method invocation which is a
           // subtype of one of the classes with lifecycle and name as
-          .filter(Boolean::booleanValue)
-          .findFirst()
-          .orElse(false);
+          .filter(Boolean::booleanValue).findFirst().orElse(false);
     };
   }
 }

--- a/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
+++ b/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
@@ -158,6 +158,18 @@ public final class UseAutoDispose extends BugChecker
     matcher = matcher(classesWithLifecycle);
   }
 
+  @Override public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (matcher.matches(tree, state)) {
+      return buildDescription(tree).build();
+    } else {
+      return Description.NO_MATCH;
+    }
+  }
+
+  @Override public String linkUrl() {
+    return "https://github.com/uber/AutoDispose/wiki/Error-Prone-Checker";
+  }
+
   private static Matcher<MethodInvocationTree> matcher(Set<String> classesWithLifecycle) {
     return (Matcher<MethodInvocationTree>) (tree, state) -> {
 
@@ -200,17 +212,5 @@ public final class UseAutoDispose extends BugChecker
           .findFirst()
           .orElse(false);
     };
-  }
-
-  @Override public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-    if (matcher.matches(tree, state)) {
-      return buildDescription(tree).build();
-    } else {
-      return Description.NO_MATCH;
-    }
-  }
-
-  @Override public String linkUrl() {
-    return "https://github.com/uber/AutoDispose/wiki/Error-Prone-Checker";
   }
 }

--- a/static-analysis/autodispose-error-prone-checker/src/test/java/com/uber/autodispose/errorprone/UseAutoDisposeTest.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/java/com/uber/autodispose/errorprone/UseAutoDisposeTest.java
@@ -52,4 +52,16 @@ public class UseAutoDisposeTest {
     compilationHelper.addSourceFile("UseAutoDisposeNegativeCases.java")
         .doTest();
   }
+
+  @Test public void test_autodisposePositiveCasesWithDefaultClassLenient() {
+    compilationHelper.setArgs(ImmutableList.of("-XepOpt:Lenient=true"));
+    compilationHelper.addSourceFile("UseAutoDisposeDefaultClassPositiveCasesLenient.java")
+        .doTest();
+  }
+
+  @Test public void test_autodisposeNegativeCasesLenient() {
+    compilationHelper.setArgs(ImmutableList.of("-XepOpt:Lenient=true"));
+    compilationHelper.addSourceFile("UseAutoDisposeNegativeCasesLenient.java")
+        .doTest();
+  }
 }

--- a/static-analysis/autodispose-error-prone-checker/src/test/java/com/uber/autodispose/errorprone/UseAutoDisposeTest.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/java/com/uber/autodispose/errorprone/UseAutoDisposeTest.java
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class UseAutoDisposeTest {
+public final class UseAutoDisposeTest {
 
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -37,31 +37,26 @@ public class UseAutoDisposeTest {
   }
 
   @Test public void test_autodisposePositiveCasesWithDefaultClass() {
-    compilationHelper.addSourceFile("UseAutoDisposeDefaultClassPositiveCases.java")
-        .doTest();
+    compilationHelper.addSourceFile("UseAutoDisposeDefaultClassPositiveCases.java").doTest();
   }
 
-  @Test public void test_autodisposePositiveCaseswithCustomClass() {
+  @Test public void test_autodisposePositiveCasesWithCustomClass() {
     compilationHelper.setArgs(ImmutableList.of("-XepOpt:ClassesWithScope"
         + "=com.uber.autodispose.errorprone.ComponentWithLifecycle"));
-    compilationHelper.addSourceFile("UseAutoDisposeCustomClassPositiveCases.java")
-        .doTest();
+    compilationHelper.addSourceFile("UseAutoDisposeCustomClassPositiveCases.java").doTest();
   }
 
   @Test public void test_autodisposeNegativeCases() {
-    compilationHelper.addSourceFile("UseAutoDisposeNegativeCases.java")
-        .doTest();
+    compilationHelper.addSourceFile("UseAutoDisposeNegativeCases.java").doTest();
   }
 
   @Test public void test_autodisposePositiveCasesWithDefaultClassLenient() {
     compilationHelper.setArgs(ImmutableList.of("-XepOpt:Lenient=true"));
-    compilationHelper.addSourceFile("UseAutoDisposeDefaultClassPositiveCasesLenient.java")
-        .doTest();
+    compilationHelper.addSourceFile("UseAutoDisposeDefaultClassPositiveCasesLenient.java").doTest();
   }
 
   @Test public void test_autodisposeNegativeCasesLenient() {
     compilationHelper.setArgs(ImmutableList.of("-XepOpt:Lenient=true"));
-    compilationHelper.addSourceFile("UseAutoDisposeNegativeCasesLenient.java")
-        .doTest();
+    compilationHelper.addSourceFile("UseAutoDisposeNegativeCasesLenient.java").doTest();
   }
 }

--- a/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeCustomClassPositiveCases.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeCustomClassPositiveCases.java
@@ -32,7 +32,7 @@ public class UseAutoDisposeCustomClassPositiveCases extends ComponentWithLifecyc
   }
 
   public void single_subscribeWithoutAutoDispose() {
-    Single.just(true)
+    Single.just(1)
         // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
         .subscribe();
   }

--- a/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeCustomClassPositiveCases.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeCustomClassPositiveCases.java
@@ -16,7 +16,6 @@
 
 package com.uber.autodispose.errorprone;
 
-import com.uber.autodispose.errorprone.ComponentWithLifecycle;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;

--- a/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeDefaultClassPositiveCases.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeDefaultClassPositiveCases.java
@@ -30,8 +30,12 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.annotations.Nullable;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subscribers.TestSubscriber;
 import org.reactivestreams.Subscriber;
+
+import static com.uber.autodispose.AutoDispose.autoDisposable;
 
 /**
  * Cases that don't use autodispose and should fail the {@link UseAutoDispose} check.
@@ -86,7 +90,7 @@ public class UseAutoDisposeDefaultClassPositiveCases
   }
 
   public void single_subscribeWithoutAutoDispose() {
-    Single.just(true)
+    Single.just(1)
         // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
         .subscribe();
   }
@@ -115,5 +119,67 @@ public class UseAutoDisposeDefaultClassPositiveCases
         .parallel(2)
         // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
         .subscribe(subscribers);
+  }
+
+
+
+  public void observable_subscribeVoidSubscribe_withoutAutoDispose() {
+    Observable.just(1)
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        .subscribe(new TestObserver<>());
+  }
+
+  public void single_subscribeVoidSubscribe_withoutAutoDispose() {
+    Single.just(1)
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        .subscribe(new TestObserver<>());
+  }
+
+  public void completable_subscribeVoidSubscribe_withoutAutoDispose() {
+    Completable.complete()
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        .subscribe(new TestObserver<>());
+  }
+
+  public void maybe_subscribeVoidSubscribe_withoutAutoDispose() {
+    Maybe.just(1)
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        .subscribe(new TestObserver<>());
+  }
+
+  public void flowable_subscribeVoidSubscribe_withoutAutoDispose() {
+    Flowable.just(1)
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        .subscribe(new TestSubscriber<>());
+  }
+
+  public void observable_subscribeWith_notKeepingResult() {
+    Observable.just(1)
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        .subscribeWith(new TestObserver<>());
+  }
+
+  public void single_subscribeWith_notKeepingResult() {
+    Single.just(1)
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        .subscribeWith(new TestObserver<>());
+  }
+
+  public void completable_subscribeWith_notKeepingResult() {
+    Completable.complete()
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        .subscribeWith(new TestObserver<>());
+  }
+
+  public void maybe_subscribeWith_notKeepingResult() {
+    Maybe.just(1)
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        .subscribeWith(new TestObserver<>());
+  }
+
+  public void flowable_subscribeWith_notKeepingResult() {
+    Flowable.just(1)
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        .subscribeWith(new TestSubscriber<>());
   }
 }

--- a/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeDefaultClassPositiveCasesLenient.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeDefaultClassPositiveCasesLenient.java
@@ -30,7 +30,6 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.annotations.Nullable;
-import io.reactivex.disposables.Disposable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subscribers.TestSubscriber;
@@ -39,7 +38,7 @@ import org.reactivestreams.Subscriber;
 /**
  * Cases that don't use autodispose and should fail the {@link UseAutoDispose} check.
  */
-public class UseAutoDisposeDefaultClassPositiveCases
+public class UseAutoDisposeDefaultClassPositiveCasesLenient
     implements LifecycleScopeProvider<TestLifecycle> {
 
   private final BehaviorSubject<TestLifecycle> lifecycleSubject =
@@ -77,7 +76,7 @@ public class UseAutoDisposeDefaultClassPositiveCases
     return lifecycleSubject.getValue();
   }
 
-  @Override public CompletableSource requestScope()  {
+  @Override public CompletableSource requestScope() throws Exception {
     return LifecycleScopes.resolveScopeFromLifecycle(this);
   }
 
@@ -175,66 +174,6 @@ public class UseAutoDisposeDefaultClassPositiveCases
 
   public void flowable_subscribeWith_notKeepingResult() {
     Flowable.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
-        .subscribeWith(new TestSubscriber<>());
-  }
-
-  public void observable_subscribeKeepingDisposable() {
-    Disposable d = Observable.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
-        .subscribe();
-  }
-
-  public void single_subscribeKeepingDisposable() {
-    Disposable d = Single.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
-        .subscribe();
-  }
-
-  public void completable_subscribeKeepingDisposable() {
-    Disposable d = Completable.complete()
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
-        .subscribe();
-  }
-
-  public void maybe_subscribeKeepingDisposable() {
-    Disposable d = Maybe.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
-        .subscribe();
-  }
-
-  public void flowable_subscribeKeepingDisposable() {
-    Disposable d = Flowable.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
-        .subscribe();
-  }
-
-  public void observable_subscribeWith_useReturnValue() {
-    TestObserver<Integer> o = Observable.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
-        .subscribeWith(new TestObserver<>());
-  }
-
-  public void single_subscribeWith_useReturnValue() {
-    TestObserver<Integer> o = Single.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
-        .subscribeWith(new TestObserver<>());
-  }
-
-  public void completable_subscribeWith_useReturnValue() {
-    TestObserver<Object> o = Completable.complete()
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
-        .subscribeWith(new TestObserver<>());
-  }
-
-  public void maybe_subscribeWith_useReturnValue() {
-    TestObserver<Integer> o = Maybe.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
-        .subscribeWith(new TestObserver<>());
-  }
-
-  public void flowable_subscribeWith_useReturnValue() {
-    TestSubscriber<Integer> o = Flowable.just(1)
         // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
         .subscribeWith(new TestSubscriber<>());
   }

--- a/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeDefaultClassPositiveCasesLenient.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeDefaultClassPositiveCasesLenient.java
@@ -20,19 +20,21 @@ import com.uber.autodispose.lifecycle.CorrespondingEventsFunction;
 import com.uber.autodispose.lifecycle.LifecycleEndedException;
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider;
 import com.uber.autodispose.lifecycle.LifecycleScopes;
-import com.uber.autodispose.lifecycle.TestLifecycleScopeProvider;
 import com.uber.autodispose.lifecycle.TestLifecycleScopeProvider.TestLifecycle;
 import io.reactivex.Completable;
 import io.reactivex.CompletableSource;
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
+import io.reactivex.Observer;
 import io.reactivex.Single;
 import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.annotations.Nullable;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subscribers.TestSubscriber;
+import java.util.function.Function;
 import org.reactivestreams.Subscriber;
 
 /**
@@ -41,8 +43,7 @@ import org.reactivestreams.Subscriber;
 public class UseAutoDisposeDefaultClassPositiveCasesLenient
     implements LifecycleScopeProvider<TestLifecycle> {
 
-  private final BehaviorSubject<TestLifecycle> lifecycleSubject =
-      BehaviorSubject.create();
+  private final BehaviorSubject<TestLifecycle> lifecycleSubject = BehaviorSubject.create();
 
   /**
    * @return a sequence of lifecycle events.
@@ -53,10 +54,9 @@ public class UseAutoDisposeDefaultClassPositiveCasesLenient
 
   /**
    * @return a sequence of lifecycle events. It's recommended to back this with a static instance to
-   * avoid unnecessary object allocation.
+   *     avoid unnecessary object allocation.
    */
-  @CheckReturnValue
-  public CorrespondingEventsFunction<TestLifecycle> correspondingEvents() {
+  @CheckReturnValue public CorrespondingEventsFunction<TestLifecycle> correspondingEvents() {
     return testLifecycle -> {
       switch (testLifecycle) {
         case STARTED:
@@ -82,99 +82,168 @@ public class UseAutoDisposeDefaultClassPositiveCasesLenient
 
   public void observable_subscribeWithoutAutoDispose() {
     Observable.empty()
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
         .subscribe();
   }
 
   public void single_subscribeWithoutAutoDispose() {
     Single.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
         .subscribe();
   }
 
   public void completable_subscribeWithoutAutoDispose() {
     Completable.complete()
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
         .subscribe();
   }
 
   public void maybe_subscribeWithoutAutoDispose() {
     Maybe.empty()
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
         .subscribe();
   }
 
   public void flowable_subscribeWithoutAutoDispose() {
     Flowable.empty()
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
         .subscribe();
   }
 
   public void parallelFlowable_subscribeWithoutAutoDispose() {
     Subscriber<Integer>[] subscribers = new Subscriber[] {};
-    Flowable.just(1, 2)
-        .parallel(2)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+    Flowable.just(1, 2).parallel(2)
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
         .subscribe(subscribers);
   }
 
   public void observable_subscribeVoidSubscribe_withoutAutoDispose() {
     Observable.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
         .subscribe(new TestObserver<>());
   }
 
   public void single_subscribeVoidSubscribe_withoutAutoDispose() {
     Single.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
         .subscribe(new TestObserver<>());
   }
 
   public void completable_subscribeVoidSubscribe_withoutAutoDispose() {
     Completable.complete()
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
         .subscribe(new TestObserver<>());
   }
 
   public void maybe_subscribeVoidSubscribe_withoutAutoDispose() {
     Maybe.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
         .subscribe(new TestObserver<>());
   }
 
   public void flowable_subscribeVoidSubscribe_withoutAutoDispose() {
     Flowable.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
         .subscribe(new TestSubscriber<>());
   }
 
   public void observable_subscribeWith_notKeepingResult() {
     Observable.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
         .subscribeWith(new TestObserver<>());
   }
 
   public void single_subscribeWith_notKeepingResult() {
     Single.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
         .subscribeWith(new TestObserver<>());
   }
 
   public void completable_subscribeWith_notKeepingResult() {
     Completable.complete()
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
         .subscribeWith(new TestObserver<>());
   }
 
   public void maybe_subscribeWith_notKeepingResult() {
     Maybe.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
         .subscribeWith(new TestObserver<>());
   }
 
   public void flowable_subscribeWith_notKeepingResult() {
     Flowable.just(1)
-        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within defined scoped elements.
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
         .subscribeWith(new TestSubscriber<>());
+  }
+
+  // subscribeWith only works IFF the argument passed implements Disposable
+  public void subscribeWithOnlyDisposable() {
+    Observer<Integer> o = Observable.just(1)
+        // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+        // defined scoped elements.
+        .subscribeWith(new Observer<Integer>() {
+          @Override public void onSubscribe(Disposable d) {
+
+          }
+
+          @Override public void onNext(Integer integer) {
+
+          }
+
+          @Override public void onError(Throwable e) {
+
+          }
+
+          @Override public void onComplete() {
+
+          }
+        });
+  }
+
+  // subscribeWith only works IFF the argument passed implements Disposable
+  // Method references in general are very tricky to get right, because we're relatively limited in
+  // being able to detect how the return type is used.
+  public void subscribeWithOnlyDisposable_asReference() {
+    Observable<Integer> source = Observable.just(1);
+    // BUG: Diagnostic contains: Always apply an AutoDispose scope before subscribing within
+    // defined scoped elements.
+    Observer<Integer> o = methodReferencable(source::subscribeWith);
+  }
+
+  Observer<Integer> methodReferencable(Function<Observer<Integer>, Observer<Integer>> func) {
+    return func.apply(new Observer<Integer>() {
+      @Override public void onSubscribe(Disposable d) {
+
+      }
+
+      @Override public void onNext(Integer integer) {
+
+      }
+
+      @Override public void onError(Throwable e) {
+
+      }
+
+      @Override public void onComplete() {
+
+      }
+    });
   }
 }

--- a/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeNegativeCases.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeNegativeCases.java
@@ -25,13 +25,16 @@ import com.uber.autodispose.lifecycle.LifecycleScopes;
 import com.uber.autodispose.lifecycle.TestLifecycleScopeProvider;
 import io.reactivex.Completable;
 import io.reactivex.CompletableSource;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.annotations.Nullable;
+import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subscribers.TestSubscriber;
 import org.reactivestreams.Subscriber;
 
 import static com.uber.autodispose.AutoDispose.autoDisposable;
@@ -88,7 +91,7 @@ public class UseAutoDisposeNegativeCases implements LifecycleScopeProvider<TestL
   }
 
   public void single_subscribeWithAutoDispose() {
-    Single.just(true)
+    Single.just(1)
         .as(autoDisposable(this))
         .subscribe();
   }
@@ -117,5 +120,115 @@ public class UseAutoDisposeNegativeCases implements LifecycleScopeProvider<TestL
         .parallel(2)
         .as(autoDisposable(this))
         .subscribe(subscribers);
+  }
+
+  public void observable_subscribeKeepingDisposable() {
+    Disposable d = Observable.just(1)
+        .subscribe();
+  }
+
+  public void single_subscribeKeepingDisposable() {
+    Disposable d = Single.just(1)
+        .subscribe();
+  }
+
+  public void completable_subscribeKeepingDisposable() {
+    Disposable d = Completable.complete()
+        .subscribe();
+  }
+
+  public void maybe_subscribeKeepingDisposable() {
+    Disposable d = Maybe.just(1)
+        .subscribe();
+  }
+
+  public void flowable_subscribeKeepingDisposable() {
+    Disposable d = Flowable.just(1)
+        .subscribe();
+  }
+
+  public void observable_subscribeVoidSubscribe() {
+    Observable.just(1)
+        .as(autoDisposable(this))
+        .subscribe(new TestObserver<>());
+  }
+
+  public void single_subscribeVoidSubscribe() {
+    Single.just(1)
+        .as(autoDisposable(this))
+        .subscribe(new TestObserver<>());
+  }
+
+  public void completable_subscribeVoidSubscribe() {
+    Completable.complete()
+        .as(autoDisposable(this))
+        .subscribe(new TestObserver<>());
+  }
+
+  public void maybe_subscribeVoidSubscribe() {
+    Maybe.just(1)
+        .as(autoDisposable(this))
+        .subscribe(new TestObserver<>());
+  }
+
+  public void flowable_subscribeVoidSubscribe() {
+    Flowable.just(1)
+        .as(autoDisposable(this))
+        .subscribe(new TestSubscriber<>());
+  }
+
+  public void observable_subscribeWith_useReturnValue() {
+    TestObserver<Integer> o = Observable.just(1)
+        .subscribeWith(new TestObserver<>());
+  }
+
+  public void single_subscribeWith_useReturnValue() {
+    TestObserver<Integer> o = Single.just(1)
+        .subscribeWith(new TestObserver<>());
+  }
+
+  public void completable_subscribeWith_useReturnValue() {
+    TestObserver<Object> o = Completable.complete()
+        .subscribeWith(new TestObserver<>());
+  }
+
+  public void maybe_subscribeWith_useReturnValue() {
+    TestObserver<Integer> o = Maybe.just(1)
+        .subscribeWith(new TestObserver<>());
+  }
+
+  public void flowable_subscribeWith_useReturnValue() {
+    TestSubscriber<Integer> o = Flowable.just(1)
+        .subscribeWith(new TestSubscriber<>());
+  }
+
+  public void observable_subscribeWith() {
+    Observable.just(1)
+        .as(autoDisposable(this))
+        .subscribeWith(new TestObserver<>());
+  }
+
+  public void single_subscribeWith() {
+    Single.just(1)
+        .as(autoDisposable(this))
+        .subscribeWith(new TestObserver<>());
+  }
+
+  public void completable_subscribeWith() {
+    Completable.complete()
+        .as(autoDisposable(this))
+        .subscribeWith(new TestObserver<>());
+  }
+
+  public void maybe_subscribeWith() {
+    Maybe.just(1)
+        .as(autoDisposable(this))
+        .subscribeWith(new TestObserver<>());
+  }
+
+  public void flowable_subscribeWith() {
+    Flowable.just(1)
+        .as(autoDisposable(this))
+        .subscribeWith(new TestSubscriber<>());
   }
 }

--- a/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeNegativeCasesLenient.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeNegativeCasesLenient.java
@@ -21,17 +21,18 @@ import com.uber.autodispose.lifecycle.CorrespondingEventsFunction;
 import com.uber.autodispose.lifecycle.LifecycleEndedException;
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider;
 import com.uber.autodispose.lifecycle.LifecycleScopes;
-import com.uber.autodispose.lifecycle.TestLifecycleScopeProvider;
 import com.uber.autodispose.lifecycle.TestLifecycleScopeProvider.TestLifecycle;
 import io.reactivex.Completable;
 import io.reactivex.CompletableSource;
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
+import io.reactivex.Observer;
 import io.reactivex.Single;
 import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.disposables.Disposable;
+import io.reactivex.observers.DisposableObserver;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subscribers.TestSubscriber;
@@ -42,11 +43,9 @@ import static com.uber.autodispose.AutoDispose.autoDisposable;
 /**
  * Cases that use {@link AutoDispose} and should not fail the {@link UseAutoDispose} check.
  */
-public class UseAutoDisposeNegativeCasesLenient
-    implements LifecycleScopeProvider<TestLifecycle> {
+public class UseAutoDisposeNegativeCasesLenient implements LifecycleScopeProvider<TestLifecycle> {
 
-  private final BehaviorSubject<TestLifecycle> lifecycleSubject =
-      BehaviorSubject.create();
+  private final BehaviorSubject<TestLifecycle> lifecycleSubject = BehaviorSubject.create();
 
   /**
    * @return a sequence of lifecycle events.
@@ -59,8 +58,7 @@ public class UseAutoDisposeNegativeCasesLenient
    * @return a sequence of lifecycle events. It's recommended to back this with a static instance to
    * avoid unnecessary object allocation.
    */
-  @CheckReturnValue
-  public CorrespondingEventsFunction<TestLifecycle> correspondingEvents() {
+  @CheckReturnValue public CorrespondingEventsFunction<TestLifecycle> correspondingEvents() {
     return testLifecycle -> {
       switch (testLifecycle) {
         case STARTED:
@@ -230,5 +228,39 @@ public class UseAutoDisposeNegativeCasesLenient
     Flowable.just(1)
         .as(autoDisposable(this))
         .subscribeWith(new TestSubscriber<>());
+  }
+
+  // subscribeWith only works IFF the argument passed implements Disposable
+  public void subscribeWithOnlyDisposable() {
+    Observer<Integer> o = Observable.just(1)
+        .subscribeWith(new DisposableObserver<Integer>() {
+
+          @Override public void onNext(Integer integer) {
+
+          }
+
+          @Override public void onError(Throwable e) {
+
+          }
+
+          @Override public void onComplete() {
+
+          }
+        });
+    DisposableObserver<Integer> o2 = Observable.just(1)
+        .subscribeWith(new DisposableObserver<Integer>() {
+
+          @Override public void onNext(Integer integer) {
+
+          }
+
+          @Override public void onError(Throwable e) {
+
+          }
+
+          @Override public void onComplete() {
+
+          }
+        });
   }
 }

--- a/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeNegativeCasesLenient.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/resources/com/uber/autodispose/errorprone/UseAutoDisposeNegativeCasesLenient.java
@@ -31,6 +31,7 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.annotations.Nullable;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subscribers.TestSubscriber;
@@ -41,7 +42,7 @@ import static com.uber.autodispose.AutoDispose.autoDisposable;
 /**
  * Cases that use {@link AutoDispose} and should not fail the {@link UseAutoDispose} check.
  */
-public class UseAutoDisposeNegativeCases
+public class UseAutoDisposeNegativeCasesLenient
     implements LifecycleScopeProvider<TestLifecycle> {
 
   private final BehaviorSubject<TestLifecycle> lifecycleSubject =
@@ -119,6 +120,56 @@ public class UseAutoDisposeNegativeCases
         .parallel(2)
         .as(autoDisposable(this))
         .subscribe(subscribers);
+  }
+
+  public void observable_subscribeKeepingDisposable() {
+    Disposable d = Observable.just(1)
+        .subscribe();
+  }
+
+  public void single_subscribeKeepingDisposable() {
+    Disposable d = Single.just(1)
+        .subscribe();
+  }
+
+  public void completable_subscribeKeepingDisposable() {
+    Disposable d = Completable.complete()
+        .subscribe();
+  }
+
+  public void maybe_subscribeKeepingDisposable() {
+    Disposable d = Maybe.just(1)
+        .subscribe();
+  }
+
+  public void flowable_subscribeKeepingDisposable() {
+    Disposable d = Flowable.just(1)
+        .subscribe();
+  }
+
+  public void observable_subscribeWith_useReturnValue() {
+    TestObserver<Integer> o = Observable.just(1)
+        .subscribeWith(new TestObserver<>());
+  }
+
+  public void single_subscribeWith_useReturnValue() {
+    TestObserver<Integer> o = Single.just(1)
+        .subscribeWith(new TestObserver<>());
+  }
+
+  public void completable_subscribeWith_useReturnValue() {
+    TestObserver<Object> o = Completable.complete()
+        .subscribeWith(new TestObserver<>());
+  }
+
+  public void maybe_subscribeWith_useReturnValue() {
+    TestObserver<Integer> o = Maybe.just(1)
+        .subscribeWith(new TestObserver<>());
+  }
+
+  public void flowable_subscribeWith_useReturnValue() {
+    TestSubscriber<Integer> o = Flowable.just(1)
+        .subscribeWith(new TestSubscriber<>());
   }
 
   public void observable_subscribeVoidSubscribe() {


### PR DESCRIPTION
This PR fixes a bunch of outstanding issues with the error-prone checker artifact, and adds a new "lenient" mode where you can opt out of the check IFF you're capturing a returned `Disposable` and want AutoDispose to assume you're doing manual management there. This new mode is disabled by default.

```java
// This is allowed in lenient mode
Disposable d = Observable.just(1).subscribe();

// This is allowed in lenient mode, because the subscribeWith arg type is Disposable
DisposableObserver<Integer> do = Observable.just(1).subscribeWith(new DisposableObserver...)

// This is not allowed in lenient mode, because the subscribeWith arg type is not Disposable
Observer<Integer> do = Observable.just(1).subscribeWith(new Observer...)

// This is not allowed in lenient mode, because the return value is not captured
Observable.just(1).subscribe();

// This is not allowed in lenient mode, because that subscribe() overload just returns void
Observable.just(1).subscribe(new Observer...)
```

Fixes #290 (2d3b568)
Fixes #288 (part of 2705b90)
Fixes #287 (13e85db)
Fixes #286 (part of 9948121)
Fixes #284 (part of 2705b90)