### PR TITLE
Update to new Error Prone plugin

### DIFF
--- a/android/autodispose-android-archcomponents-test/build.gradle
+++ b/android/autodispose-android-archcomponents-test/build.gradle
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
   id 'com.android.library'
@@ -34,22 +35,24 @@ android {
 }
 
 dependencies {
-  annotationProcessor deps.build.nullAway
-  testAnnotationProcessor deps.build.nullAway
-  androidTestAnnotationProcessor deps.build.nullAway
-
   api project(':autodispose')
   api deps.androidx.annotations
   api deps.androidx.arch.lifecycle.common
   api deps.androidx.arch.lifecycle.runtime
 
+  errorproneJavac deps.build.errorProneJavac
+  errorprone deps.build.nullAway
   errorprone deps.build.errorProne
 }
 
-tasks.withType(JavaCompile) {
-  options.compilerArgs += ["-Xep:NullAway:ERROR",
-                           "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                           "-Xep:RestrictTo:OFF"]
+afterEvaluate {
+  tasks.withType(JavaCompile).configureEach {
+    options.errorprone {
+      option("NullAway:AnnotatedPackages", "com.uber")
+      check("NullAway", CheckSeverity.ERROR)
+      check("RestrictTo", CheckSeverity.OFF)
+    }
+  }
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/android/autodispose-android-archcomponents/build.gradle
+++ b/android/autodispose-android-archcomponents/build.gradle
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
   id 'com.android.library'
@@ -43,9 +44,6 @@ android {
 }
 
 dependencies {
-  annotationProcessor deps.build.nullAway
-  testAnnotationProcessor deps.build.nullAway
-  androidTestAnnotationProcessor deps.build.nullAway
   annotationProcessor deps.androidx.arch.lifecycle.compiler
 
   api project(':autodispose')
@@ -56,6 +54,8 @@ dependencies {
   implementation project(':android:autodispose-android')
   implementation deps.rx.android
 
+  errorproneJavac deps.build.errorProneJavac
+  errorprone deps.build.nullAway
   errorprone deps.build.errorProne
 
   androidTestImplementation project(':android:autodispose-android-archcomponents-test')
@@ -69,10 +69,15 @@ dependencies {
   androidTestUtil deps.test.androidOrchestrator
 }
 
-tasks.withType(JavaCompile) {
-  options.compilerArgs += ["-Xep:NullAway:ERROR",
-                           "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                           "-Xep:RestrictTo:OFF"]
+afterEvaluate {
+  tasks.withType(JavaCompile).configureEach {
+    options.errorprone {
+      disableWarningsInGeneratedCode = true
+      option("NullAway:AnnotatedPackages", "com.uber")
+      check("NullAway", CheckSeverity.ERROR)
+      check("RestrictTo", CheckSeverity.OFF)
+    }
+  }
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/android/autodispose-android/build.gradle
+++ b/android/autodispose-android/build.gradle
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
   id 'com.android.library'
@@ -38,15 +39,13 @@ android {
 }
 
 dependencies {
-  annotationProcessor deps.build.nullAway
-  testAnnotationProcessor deps.build.nullAway
-  androidTestAnnotationProcessor deps.build.nullAway
-
   api project(':autodispose')
   api deps.rx.java
   api deps.androidx.annotations
   implementation deps.rx.android
 
+  errorproneJavac deps.build.errorProneJavac
+  errorprone deps.build.nullAway
   errorprone deps.build.errorProne
 
   testImplementation project(':test-utils')
@@ -63,10 +62,14 @@ dependencies {
   androidTestUtil deps.test.androidOrchestrator
 }
 
-tasks.withType(JavaCompile) {
-  options.compilerArgs += ["-Xep:NullAway:ERROR",
-                           "-XepOpt:NullAway:AnnotatedPackages=com.uber",
-                           "-Xep:RestrictTo:OFF"]
+afterEvaluate {
+  tasks.withType(JavaCompile).configureEach {
+    options.errorprone {
+      option("NullAway:AnnotatedPackages", "com.uber")
+      check("NullAway", CheckSeverity.ERROR)
+      check("RestrictTo", CheckSeverity.OFF)
+    }
+  }
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/autodispose-rxlifecycle/build.gradle
+++ b/autodispose-rxlifecycle/build.gradle
@@ -13,33 +13,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-    id 'java-library'
-    id 'net.ltgt.errorprone'
+  id 'java-library'
+  id 'net.ltgt.errorprone'
 }
 
 sourceCompatibility = deps.build.javaVersion
 targetCompatibility = deps.build.javaVersion
 
 test {
-    testLogging.showStandardStreams = true
+  testLogging.showStandardStreams = true
 }
 
 dependencies {
-    annotationProcessor deps.build.nullAway
-    testAnnotationProcessor deps.build.nullAway
+  api project(':autodispose')
+  api deps.misc.rxlifecycle
 
-    api project(':autodispose')
-    api deps.misc.rxlifecycle
+  errorproneJavac deps.build.errorProneJavac
+  errorprone deps.build.nullAway
+  errorprone deps.build.errorProne
 
-    errorprone deps.build.errorProne
-
-    testCompile project(':test-utils')
+  testCompile project(':test-utils')
 }
 
-tasks.withType(JavaCompile) {
-    options.compilerArgs += ["-Xep:NullAway:ERROR", "-XepOpt:NullAway:AnnotatedPackages=com.uber"]
+tasks.withType(JavaCompile).configureEach {
+  options.errorprone {
+    option("NullAway:AnnotatedPackages", "com.uber")
+    check("NullAway", CheckSeverity.ERROR)
+  }
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/autodispose/build.gradle
+++ b/autodispose/build.gradle
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
   id 'java-library'
@@ -27,22 +28,24 @@ test {
 }
 
 dependencies {
-  annotationProcessor deps.build.nullAway
-  testAnnotationProcessor deps.build.nullAway
-
   api deps.rx.java
 
+  errorproneJavac deps.build.errorProneJavac
+  errorprone deps.build.nullAway
   errorprone deps.build.errorProne
 
   testCompile project(':test-utils')
 }
 
-tasks.withType(JavaCompile) {
-  options.compilerArgs += ["-Xep:NullAway:ERROR", "-XepOpt:NullAway:AnnotatedPackages=com.uber"]
+tasks.withType(JavaCompile).configureEach {
+  options.errorprone {
+    option("NullAway:AnnotatedPackages", "com.uber")
+    check("NullAway", CheckSeverity.ERROR)
+  }
 }
 
 tasks.withType(Test) {
-    setMaxParallelForks(Runtime.runtime.availableProcessors().intdiv(2) ?: 1)
+  setMaxParallelForks(Runtime.runtime.availableProcessors().intdiv(2) ?: 1)
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ def versions = [
     archLifecycle: '2.0.0',
     dokka: '0.9.17',
     errorProne: '2.3.2',
-    errorPronePlugin: '0.0.13',
+    errorPronePlugin: '0.6',
     kotlin: '1.3.10'
 ]
 

--- a/lifecycle/autodispose-lifecycle-jdk8/build.gradle
+++ b/lifecycle/autodispose-lifecycle-jdk8/build.gradle
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
   id 'java-library'
@@ -27,18 +28,20 @@ test {
 }
 
 dependencies {
-  annotationProcessor deps.build.nullAway
-  testAnnotationProcessor deps.build.nullAway
-
   api project(":lifecycle:autodispose-lifecycle")
 
+  errorproneJavac deps.build.errorProneJavac
+  errorprone deps.build.nullAway
   errorprone deps.build.errorProne
 
   testCompile project(':test-utils')
 }
 
-tasks.withType(JavaCompile) {
-  options.compilerArgs += ["-Xep:NullAway:ERROR", "-XepOpt:NullAway:AnnotatedPackages=com.uber"]
+tasks.withType(JavaCompile).configureEach {
+  options.errorprone {
+    option("NullAway:AnnotatedPackages", "com.uber")
+    check("NullAway", CheckSeverity.ERROR)
+  }
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/lifecycle/autodispose-lifecycle/build.gradle
+++ b/lifecycle/autodispose-lifecycle/build.gradle
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
   id 'java-library'
@@ -27,18 +28,20 @@ test {
 }
 
 dependencies {
-  annotationProcessor deps.build.nullAway
-  testAnnotationProcessor deps.build.nullAway
-
   api project(":autodispose")
 
+  errorproneJavac deps.build.errorProneJavac
+  errorprone deps.build.nullAway
   errorprone deps.build.errorProne
 
   testCompile project(':test-utils')
 }
 
-tasks.withType(JavaCompile) {
-  options.compilerArgs += ["-Xep:NullAway:ERROR", "-XepOpt:NullAway:AnnotatedPackages=com.uber"]
+tasks.withType(JavaCompile).configureEach {
+  options.errorprone {
+    option("NullAway:AnnotatedPackages", "com.uber")
+    check("NullAway", CheckSeverity.ERROR)
+  }
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopesTest.java
+++ b/lifecycle/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/LifecycleScopesTest.java
@@ -125,7 +125,7 @@ public final class LifecycleScopesTest {
 
     @Override public boolean equals(Object o) {
       if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
+      if (!(o instanceof IntHolder)) return false;
 
       IntHolder intHolder = (IntHolder) o;
 

--- a/static-analysis/autodispose-error-prone-checker/build.gradle
+++ b/static-analysis/autodispose-error-prone-checker/build.gradle
@@ -13,23 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
   id 'java-library'
   id 'net.ltgt.errorprone'
 }
 
-// we use this config to get the path of the JDK 9 javac jar, to
-// stick it in the bootclasspath when running tests
-configurations.maybeCreate("epJavac")
-
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-  annotationProcessor deps.build.nullAway
-  testAnnotationProcessor deps.build.nullAway
-
   compileOnly deps.apt.autoService
   compileOnly deps.build.errorProneCheckApi
 
@@ -41,15 +35,20 @@ dependencies {
   testImplementation project(':autodispose')
   testImplementation project(':lifecycle:autodispose-lifecycle')
 
-  epJavac deps.build.errorProneJavac
+  errorproneJavac deps.build.errorProneJavac
+  errorprone deps.build.nullAway
+  errorprone deps.build.errorProne
 }
 
-tasks.withType(JavaCompile) {
-  options.compilerArgs += ["-Xep:NullAway:ERROR", "-XepOpt:NullAway:AnnotatedPackages=com.uber"]
+tasks.withType(JavaCompile).configureEach {
+  options.errorprone {
+    option("NullAway:AnnotatedPackages", "com.uber")
+    check("NullAway", CheckSeverity.ERROR)
+  }
 }
 
 test {
-  jvmArgs "-Xbootclasspath/p:${configurations.epJavac.asPath}"
+  jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
 }
 
 apply from: rootProject.file("gradle/gradle-mvn-push.gradle")

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
   id 'java-library'
@@ -23,9 +24,8 @@ sourceCompatibility = deps.build.javaVersion
 targetCompatibility = deps.build.javaVersion
 
 dependencies {
-  annotationProcessor deps.build.nullAway
-  testAnnotationProcessor deps.build.nullAway
-
+  errorproneJavac deps.build.errorProneJavac
+  errorprone deps.build.nullAway
   errorprone deps.build.errorProne
 
   api deps.rx.java
@@ -33,6 +33,9 @@ dependencies {
   api deps.test.truth
 }
 
-tasks.withType(JavaCompile) {
-  options.compilerArgs += ["-Xep:NullAway:ERROR", "-XepOpt:NullAway:AnnotatedPackages=com.uber"]
+tasks.withType(JavaCompile).configureEach {
+  options.errorprone {
+    option("NullAway:AnnotatedPackages", "com.uber")
+    check("NullAway", CheckSeverity.ERROR)
+  }
 }


### PR DESCRIPTION
Re-hash of #219, resolves #218

I'd like to unify this configuration to a shared gradle file like `errorprone-config.gradle`, but I can't figure out how to do that cleanly in a root build.gradle since
A. per-project plugins don't seem to be registered yet at that point (can't check if a subproject is a java project)
B. can't seem to declare plugin other than via `apply: plugin` (though this part is manageable I guess)