### PR TITLE
Rename `ClassesWithScope` to `TypesWithScope`

### DIFF
--- a/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
+++ b/static-analysis/autodispose-error-prone-checker/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
@@ -41,10 +41,10 @@ import static com.google.errorprone.util.ASTHelpers.isSubtype;
 
 /**
  * Checker for subscriptions not binding to lifecycle in components with lifecycle.
- * Use -XepOpt:ClassesWithScope flag to add support for custom components with lifecycle.
+ * Use -XepOpt:TypesWithScope flag to add support for custom components with lifecycle.
  * The sample configuration for Conductor:
  * <pre><code>
- *   -XepOpt:ClassesWithScope=com.bluelinelabs.conductor.Controller,android.app.Activity
+ *   -XepOpt:TypesWithScope=com.bluelinelabs.conductor.Controller,android.app.Activity
  * </code></pre>
  */
 @AutoService(BugChecker.class)
@@ -92,7 +92,7 @@ public final class UseAutoDispose extends AbstractReturnValueIgnored
   @SuppressWarnings("WeakerAccess") // Public for ErrorProne
   public UseAutoDispose(ErrorProneFlags flags) {
     Optional<ImmutableSet<String>> inputClasses =
-        flags.getList("ClassesWithScope").map(ImmutableSet::copyOf);
+        flags.getList("TypesWithScope").map(ImmutableSet::copyOf);
 
     ImmutableSet<String> classesWithLifecycle = inputClasses.orElse(DEFAULT_CLASSES_WITH_LIFECYCLE);
     matcher = allOf(SUBSCRIBE_METHOD, matcher(classesWithLifecycle));

--- a/static-analysis/autodispose-error-prone-checker/src/test/java/com/uber/autodispose/errorprone/UseAutoDisposeTest.java
+++ b/static-analysis/autodispose-error-prone-checker/src/test/java/com/uber/autodispose/errorprone/UseAutoDisposeTest.java
@@ -41,7 +41,7 @@ public final class UseAutoDisposeTest {
   }
 
   @Test public void test_autodisposePositiveCasesWithCustomClass() {
-    compilationHelper.setArgs(ImmutableList.of("-XepOpt:ClassesWithScope"
+    compilationHelper.setArgs(ImmutableList.of("-XepOpt:TypesWithScope"
         + "=com.uber.autodispose.errorprone.ComponentWithLifecycle"));
     compilationHelper.addSourceFile("UseAutoDisposeCustomClassPositiveCases.java").doTest();
   }

--- a/static-analysis/autodispose-lint/src/main/kotlin/com/uber/autodispose/lint/AutoDisposeDetector.kt
+++ b/static-analysis/autodispose-lint/src/main/kotlin/com/uber/autodispose/lint/AutoDisposeDetector.kt
@@ -26,7 +26,7 @@ import java.io.StringReader
 import java.util.Properties
 import java.util.EnumSet
 
-internal const val CUSTOM_SCOPE_KEY = "autodispose.classes_with_scope"
+internal const val CUSTOM_SCOPE_KEY = "autodispose.typesWithScope"
 
 /**
  * Detector which checks if your stream subscriptions are handled by AutoDispose.


### PR DESCRIPTION
Took this opportunity to move to camelCase for the `properties` file. The Gradle docs have properties with camelCase. I'm also fine with keeping it `TypesWithScope` just for consistency. Thoughts @hzsweers ?

Fixes #297 