### PR TITLE
Remove redundant LifecycleScopeProvider static analysis checks

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -69,7 +69,6 @@ dependencies {
 //    def classesWithScope = [
 //        "android.app.Activity",
 //        "android.app.Fragment",
-//        "com.uber.autodispose.LifecycleScopeProvider",
 //        "android.arch.lifecycle.LifecycleOwner",
 //        "androidx.lifecycle.LifecycleOwner",
 //        "com.uber.autodispose.ScopeProvider",

--- a/static-analysis/autodispose-error-prone/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
+++ b/static-analysis/autodispose-error-prone/src/main/java/com/uber/autodispose/errorprone/UseAutoDispose.java
@@ -61,7 +61,6 @@ public final class UseAutoDispose extends AbstractReturnValueIgnored
   private static final ImmutableSet<String> DEFAULT_CLASSES_WITH_LIFECYCLE =
       new ImmutableSet.Builder<String>().add("android.app.Activity")
           .add("android.app.Fragment")
-          .add("com.uber.autodispose.lifecycle.LifecycleScopeProvider")
           .add("android.support.v4.app.Fragment")
           .add("androidx.fragment.app.Fragment")
           .add("android.arch.lifecycle.LifecycleOwner")

--- a/static-analysis/autodispose-lint/src/main/kotlin/com/uber/autodispose/lint/AutoDisposeDetector.kt
+++ b/static-analysis/autodispose-lint/src/main/kotlin/com/uber/autodispose/lint/AutoDisposeDetector.kt
@@ -69,7 +69,6 @@ class AutoDisposeDetector: Detector(), SourceCodeScanner {
     // The default scopes for Android.
     private val DEFAULT_SCOPES = listOf("androidx.lifecycle.LifecycleOwner",
         "com.uber.autodispose.ScopeProvider",
-        "com.uber.autodispose.lifecycle.LifecycleScopeProvider",
         "android.app.Activity",
         "android.app.Fragment")
 


### PR DESCRIPTION
**Description**: `LifecycleScopeProvider` extends `ScopeProvider` so it's covered for the static analysis checks. 

Resolves #305 