### PR TITLE
Add overrideScopes flag to lint check

### DIFF
--- a/static-analysis/autodispose-lint/src/main/kotlin/com/uber/autodispose/lint/AutoDisposeDetector.kt
+++ b/static-analysis/autodispose-lint/src/main/kotlin/com/uber/autodispose/lint/AutoDisposeDetector.kt
@@ -109,7 +109,7 @@ class AutoDisposeDetector: Detector(), SourceCodeScanner {
 
   override fun beforeCheckRootProject(context: Context) {
     var overrideScopes = false
-    val scopes = HashSet<String>()
+    val scopes = mutableSetOf<String>()
 
     // Add the custom scopes defined in configuration.
     val props = Properties()

--- a/static-analysis/autodispose-lint/src/main/kotlin/com/uber/autodispose/lint/AutoDisposeDetector.kt
+++ b/static-analysis/autodispose-lint/src/main/kotlin/com/uber/autodispose/lint/AutoDisposeDetector.kt
@@ -48,6 +48,7 @@ import java.util.EnumSet
 
 internal const val CUSTOM_SCOPE_KEY = "autodispose.typesWithScope"
 internal const val LENIENT = "autodispose.lenient"
+internal const val OVERRIDE_SCOPES = "autodispose.overrideScopes"
 
 /**
  * Detector which checks if your stream subscriptions are handled by AutoDispose.
@@ -107,8 +108,8 @@ class AutoDisposeDetector: Detector(), SourceCodeScanner {
   private var lenient: Boolean = false
 
   override fun beforeCheckRootProject(context: Context) {
-    // Add the default Android scopes.
-    val scopes = HashSet(DEFAULT_SCOPES)
+    var overrideScopes = false
+    val scopes = HashSet<String>()
 
     // Add the custom scopes defined in configuration.
     val props = Properties()
@@ -126,6 +127,13 @@ class AutoDisposeDetector: Detector(), SourceCodeScanner {
       props.getProperty(LENIENT)?.toBoolean()?.let {
         lenient = it
       }
+      props.getProperty(OVERRIDE_SCOPES)?.toBoolean()?.let {
+        overrideScopes = it
+      }
+    }
+    // If scopes are not overriden, add the default ones.
+    if (!overrideScopes) {
+      scopes.addAll(DEFAULT_SCOPES)
     }
     appliedScopes = scopes
   }

--- a/static-analysis/autodispose-lint/src/test/kotlin/com/uber/autodispose/lint/AutoDisposeDetectorTest.kt
+++ b/static-analysis/autodispose-lint/src/test/kotlin/com/uber/autodispose/lint/AutoDisposeDetectorTest.kt
@@ -536,7 +536,11 @@ class AutoDisposeDetectorTest {
     properties.property(OVERRIDE_SCOPES, "true")
     properties.to(AutoDisposeDetector.PROPERTY_FILE)
 
-    lint().files(rxJava2(), LIFECYCLE_OWNER, ACTIVITY, properties, kotlin("""
+    lint().files(rxJava2(),
+        LIFECYCLE_OWNER,
+        ACTIVITY,
+        properties,
+        kotlin("""
       package com.uber.autodispose.sample
       import com.uber.autodispose.sample.ClassWithCustomScope
       import androidx.appcompat.app.AppCompatActivity
@@ -562,7 +566,10 @@ class AutoDisposeDetectorTest {
     properties.property(OVERRIDE_SCOPES, "true")
     properties.to(AutoDisposeDetector.PROPERTY_FILE)
 
-    lint().files(rxJava2(), CUSTOM_SCOPE, properties, kotlin("""
+    lint().files(rxJava2(),
+        CUSTOM_SCOPE,
+        properties,
+        kotlin("""
       package com.uber.autodispose.sample
       import com.uber.autodispose.sample.ClassWithCustomScope
       import io.reactivex.Observable

--- a/static-analysis/autodispose-lint/src/test/kotlin/com/uber/autodispose/lint/AutoDisposeDetectorTest.kt
+++ b/static-analysis/autodispose-lint/src/test/kotlin/com/uber/autodispose/lint/AutoDisposeDetectorTest.kt
@@ -530,6 +530,57 @@ class AutoDisposeDetectorTest {
         .expectClean()
   }
 
+  @Test fun overrideCustomScopeWithoutAutoDispose() {
+    val properties = projectProperties()
+    properties.property(CUSTOM_SCOPE_KEY, "com.uber.autodispose.sample.ClassWithCustomScope")
+    properties.property(OVERRIDE_SCOPES, "true")
+    properties.to(AutoDisposeDetector.PROPERTY_FILE)
+
+    lint().files(rxJava2(), LIFECYCLE_OWNER, ACTIVITY, properties, kotlin("""
+      package com.uber.autodispose.sample
+      import com.uber.autodispose.sample.ClassWithCustomScope
+      import androidx.appcompat.app.AppCompatActivity
+      import io.reactivex.Observable
+      import com.uber.autodispose.ScopeProvider
+
+      class MyCustomClass: AppCompatActivity {
+        lateinit var scopeProvider: ScopeProvider
+        fun doSomething() {
+          val observable = Observable.just(1, 2, 3)
+          observable.subscribe() // No error since the scopes are being overriden and only custom ones are considered.
+        }
+      }
+    """).indented())
+        .issues(AutoDisposeDetector.ISSUE)
+        .run()
+        .expectClean()
+  }
+
+  @Test fun overrideCustomScopeWithAutoDispose() {
+    val properties = projectProperties()
+    properties.property(CUSTOM_SCOPE_KEY, "com.uber.autodispose.sample.ClassWithCustomScope")
+    properties.property(OVERRIDE_SCOPES, "true")
+    properties.to(AutoDisposeDetector.PROPERTY_FILE)
+
+    lint().files(rxJava2(), CUSTOM_SCOPE, properties, kotlin("""
+      package com.uber.autodispose.sample
+      import com.uber.autodispose.sample.ClassWithCustomScope
+      import io.reactivex.Observable
+      import com.uber.autodispose.ScopeProvider
+
+      class MyCustomClass: ClassWithCustomScope {
+        lateinit var scopeProvider: ScopeProvider
+        fun doSomething() {
+          val observable = Observable.just(1, 2, 3)
+          observable.autoDisposable(scopeProvider).subscribe()
+        }
+      }
+    """).indented())
+        .issues(AutoDisposeDetector.ISSUE)
+        .run()
+        .expectClean()
+  }
+
   @Test fun capturedDisposable() {
     val propertiesFile = lenientPropertiesFile()
     lint().files(rxJava2(), propertiesFile, LIFECYCLE_OWNER, ACTIVITY, kotlin("""


### PR DESCRIPTION
Adds an `overrideScopes` flag that would exclude the default scopes in the lint check. 

Resolves #298 