### PR TITLE
Upgrade to Kotlin 1.3.20!

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,5 @@ POM_DEVELOPER_NAME=Uber Technologies
 
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.parallel=true
+kotlin.parallel.tasks.in.project=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,5 +28,3 @@ POM_DEVELOPER_NAME=Uber Technologies
 
 android.useAndroidX=true
 android.enableJetifier=true
-org.gradle.parallel=true
-kotlin.parallel.tasks.in.project=true

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -20,7 +20,7 @@ def versions = [
     dokka: '0.9.17',
     errorProne: '2.3.2',
     errorPronePlugin: '0.6',
-    kotlin: '1.3.11',
+    kotlin: '1.3.20',
     lint: '26.3.0'
 ]
 


### PR DESCRIPTION
Faster builds with this one!

~`./gradlew clean check` previously took 1m 32s. Down to 52-53s.~
Had to disable the parallel build. It caused connectedTests to fail. 