### PR TITLE
Refer to main gradle.properties for lint configuration

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -36,6 +36,10 @@ android {
   sourceSets {
     main.java.srcDirs += 'src/main/kotlin'
   }
+
+  lintOptions {
+    checkDependencies true
+  }
 }
 
 dependencies {

--- a/sample/gradle.properties
+++ b/sample/gradle.properties
@@ -1,1 +1,2 @@
 autodispose.typesWithScope=com.uber.autodispose.sample.CustomScope
+autodispose.lenient=false

--- a/static-analysis/autodispose-lint/src/main/kotlin/com/uber/autodispose/lint/AutoDisposeDetector.kt
+++ b/static-analysis/autodispose-lint/src/main/kotlin/com/uber/autodispose/lint/AutoDisposeDetector.kt
@@ -114,7 +114,7 @@ class AutoDisposeDetector: Detector(), SourceCodeScanner {
 
     // Add the custom scopes defined in configuration.
     val props = Properties()
-    context.project.propertyFiles.find { it.name == PROPERTY_FILE }?.apply {
+    context.mainProject.propertyFiles.find { it.name == PROPERTY_FILE }?.apply {
       val content = StringReader(context.client.readFile(this).toString())
       props.load(content)
       props.getProperty(CUSTOM_SCOPE_KEY)?.let { scopeProperty ->


### PR DESCRIPTION
**Description**: This changes the lint check to look for app level `gradle.properties` file instead of every library's. Relevant [lint thread](https://groups.google.com/forum/#!topic/lint-dev/fyY0Yz_n_Rk). This would require that you app level `build.gradle` has `checkDependencies=true` in it's `lintOptions`. Only then will lint be able to figure out that the library is part of the main project.

**Related issue(s)**: Resolves #333 