### PR TITLE
Update to AGP 3.4.0

### DIFF
--- a/android/autodispose-android-archcomponents/build.gradle
+++ b/android/autodispose-android-archcomponents/build.gradle
@@ -25,7 +25,7 @@ dependencies {
   implementation project(':android:autodispose-android')
   implementation deps.rx.android
 
-  lintChecks project(':static-analysis:autodispose-lint')
+  lintPublish project(':static-analysis:autodispose-lint')
 
   androidTestImplementation project(':android:autodispose-android-archcomponents-test')
   androidTestImplementation project(':test-utils')

--- a/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/LifecycleEventsObservable.java
+++ b/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/LifecycleEventsObservable.java
@@ -15,7 +15,7 @@
  */
 package com.uber.autodispose.android.lifecycle;
 
-import static androidx.annotation.RestrictTo.Scope.LIBRARY;
+import static androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 import static androidx.lifecycle.Lifecycle.Event.ON_CREATE;
 import static androidx.lifecycle.Lifecycle.Event.ON_DESTROY;
 import static androidx.lifecycle.Lifecycle.Event.ON_RESUME;
@@ -34,7 +34,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.subjects.BehaviorSubject;
 
-@RestrictTo(LIBRARY)
+@RestrictTo(LIBRARY_GROUP)
 class LifecycleEventsObservable extends Observable<Event> {
 
   private final Lifecycle lifecycle;

--- a/android/autodispose-android/build.gradle
+++ b/android/autodispose-android/build.gradle
@@ -20,7 +20,7 @@ dependencies {
   api deps.androidx.annotations
   implementation deps.rx.android
 
-  lintChecks project(':static-analysis:autodispose-lint')
+  lintPublish project(':static-analysis:autodispose-lint')
 
   testImplementation project(':test-utils')
   testImplementation deps.test.junit

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -24,7 +24,7 @@ def versions = [
     gjf: '1.7',
     nullawayPlugin: '0.1',
     kotlin: '1.3.30',
-    lint: '26.3.2',
+    lint: '26.4.0',
     ktlint: '0.31.0',
     spotless: '3.21.1'
 ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,7 @@ def versions = [
     errorPronePlugin: '0.7.1',
     gjf: '1.7',
     nullawayPlugin: '0.1',
-    kotlin: '1.3.21',
+    kotlin: '1.3.30',
     lint: '26.3.2',
     ktlint: '0.31.0',
     spotless: '3.21.1'
@@ -49,7 +49,7 @@ def build = [
     animalSniffer: 'org.codehaus.mojo.signature:java17:1.0@signature',
 
     gradlePlugins: [
-        android: 'com.android.tools.build:gradle:3.3.2',
+        android: 'com.android.tools.build:gradle:3.4.0',
         dokka: "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
         dokkaAndroid: "org.jetbrains.dokka:dokka-android-gradle-plugin:${versions.dokka}",
         kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"


### PR DESCRIPTION
Resolves #325 

One caveat: The `autodispose` module (since it's a Java module) doesn't have `lintPublish` configuration. I've filed a bug in the [Issue Tracker](https://issuetracker.google.com/issues/130837765). 