### PR TITLE
Fix Build Status showing a broken image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 AutoDispose
 ===========
 
-[![Build Status](https://travis-ci.org/uber/AutoDispose.svg?branch=master)](https://travis-ci.org/uber/AutoDispose)
+[![Build Status](https://travis-ci.com/uber/AutoDispose.svg?branch=master)](https://travis-ci.org/uber/AutoDispose)
 
 **AutoDispose** is an RxJava 2 tool for automatically binding the execution of RxJava 2 streams to a 
 provided scope via disposal/cancellation.


### PR DESCRIPTION
**Description**:
Build Status  is showing a broken image in README.md because travis-ci has been migrated from _travis-ci.org_ to _travis-ci.com_.