### PR TITLE
Rename extension functions

### DIFF
--- a/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/KotlinExtensions.kt
+++ b/android/autodispose-android-archcomponents/src/main/java/com/uber/autodispose/android/lifecycle/KotlinExtensions.kt
@@ -99,7 +99,28 @@ inline fun Lifecycle.scope(
  * @param untilEvent Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleOwner, untilEvent)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T> Flowable<T>.autoDisposable(lifecycleOwner: LifecycleOwner, untilEvent: Event? = null): FlowableSubscribeProxy<T> {
+  return if (untilEvent == null) {
+    this.`as`(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycleOwner)))
+  } else {
+    this.`as`(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycleOwner, untilEvent)))
+  }
+}
+
+/**
+ * Extension that proxies to [Flowable.as] + [AutoDispose.autoDisposable] and takes an [untilEvent] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleOwner The lifecycle owner.
+ * @param untilEvent Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <T> Flowable<T>.autoDispose(lifecycleOwner: LifecycleOwner, untilEvent: Event? = null): FlowableSubscribeProxy<T> {
   return if (untilEvent == null) {
     this.`as`(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycleOwner)))
   } else {
@@ -115,7 +136,28 @@ inline fun <T> Flowable<T>.autoDisposable(lifecycleOwner: LifecycleOwner, untilE
  * @param untilEvent Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleOwner, untilEvent)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T> Observable<T>.autoDisposable(lifecycleOwner: LifecycleOwner, untilEvent: Event? = null): ObservableSubscribeProxy<T> {
+  return if (untilEvent == null) {
+    this.`as`(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycleOwner)))
+  } else {
+    this.`as`(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycleOwner, untilEvent)))
+  }
+}
+
+/**
+ * Extension that proxies to [Observable.as] + [AutoDispose.autoDisposable] and takes an [untilEvent] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleOwner The lifecycle owner.
+ * @param untilEvent Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <T> Observable<T>.autoDispose(lifecycleOwner: LifecycleOwner, untilEvent: Event? = null): ObservableSubscribeProxy<T> {
   return if (untilEvent == null) {
     this.`as`(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycleOwner)))
   } else {
@@ -131,7 +173,28 @@ inline fun <T> Observable<T>.autoDisposable(lifecycleOwner: LifecycleOwner, unti
  * @param untilEvent Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleOwner, untilEvent)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T> Single<T>.autoDisposable(lifecycleOwner: LifecycleOwner, untilEvent: Event? = null): SingleSubscribeProxy<T> {
+  return if (untilEvent == null) {
+    this.`as`(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycleOwner)))
+  } else {
+    this.`as`(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycleOwner, untilEvent)))
+  }
+}
+
+/**
+ * Extension that proxies to [Single.as] + [AutoDispose.autoDisposable] and takes an [untilEvent] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleOwner The lifecycle owner.
+ * @param untilEvent Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <T> Single<T>.autoDispose(lifecycleOwner: LifecycleOwner, untilEvent: Event? = null): SingleSubscribeProxy<T> {
   return if (untilEvent == null) {
     this.`as`(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycleOwner)))
   } else {
@@ -147,7 +210,28 @@ inline fun <T> Single<T>.autoDisposable(lifecycleOwner: LifecycleOwner, untilEve
  * @param untilEvent Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleOwner, untilEvent)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T> Maybe<T>.autoDisposable(lifecycleOwner: LifecycleOwner, untilEvent: Event? = null): MaybeSubscribeProxy<T> {
+  return if (untilEvent == null) {
+    this.`as`(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycleOwner)))
+  } else {
+    this.`as`(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycleOwner, untilEvent)))
+  }
+}
+
+/**
+ * Extension that proxies to [Maybe.as] + [AutoDispose.autoDisposable] and takes an [untilEvent] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleOwner The lifecycle owner.
+ * @param untilEvent Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <T> Maybe<T>.autoDispose(lifecycleOwner: LifecycleOwner, untilEvent: Event? = null): MaybeSubscribeProxy<T> {
   return if (untilEvent == null) {
     this.`as`(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycleOwner)))
   } else {
@@ -163,7 +247,28 @@ inline fun <T> Maybe<T>.autoDisposable(lifecycleOwner: LifecycleOwner, untilEven
  * @param untilEvent Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleOwner, untilEvent)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun Completable.autoDisposable(lifecycleOwner: LifecycleOwner, untilEvent: Event? = null): CompletableSubscribeProxy {
+  return if (untilEvent == null) {
+    this.`as`(AutoDispose.autoDisposable<Any>(AndroidLifecycleScopeProvider.from(lifecycleOwner)))
+  } else {
+    this.`as`(AutoDispose.autoDisposable<Any>(AndroidLifecycleScopeProvider.from(lifecycleOwner, untilEvent)))
+  }
+}
+
+/**
+ * Extension that proxies to [Completable.as] + [AutoDispose.autoDisposable] and takes an [untilEvent] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleOwner The lifecycle owner.
+ * @param untilEvent Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun Completable.autoDispose(lifecycleOwner: LifecycleOwner, untilEvent: Event? = null): CompletableSubscribeProxy {
   return if (untilEvent == null) {
     this.`as`(AutoDispose.autoDisposable<Any>(AndroidLifecycleScopeProvider.from(lifecycleOwner)))
   } else {
@@ -179,7 +284,28 @@ inline fun Completable.autoDisposable(lifecycleOwner: LifecycleOwner, untilEvent
  * @param untilEvent Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleOwner, untilEvent)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T> ParallelFlowable<T>.autoDisposable(lifecycleOwner: LifecycleOwner, untilEvent: Event? = null): ParallelFlowableSubscribeProxy<T> {
+  return if (untilEvent == null) {
+    this.`as`(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycleOwner)))
+  } else {
+    this.`as`(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycleOwner, untilEvent)))
+  }
+}
+
+/**
+ * Extension that proxies to [ParallelFlowable.as] + [AutoDispose.autoDisposable] and takes an [untilEvent] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleOwner The lifecycle owner.
+ * @param untilEvent Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <T> ParallelFlowable<T>.autoDispose(lifecycleOwner: LifecycleOwner, untilEvent: Event? = null): ParallelFlowableSubscribeProxy<T> {
   return if (untilEvent == null) {
     this.`as`(AutoDispose.autoDisposable(AndroidLifecycleScopeProvider.from(lifecycleOwner)))
   } else {

--- a/android/autodispose-android/src/main/java/com/uber/autodispose/android/KotlinExtensions.kt
+++ b/android/autodispose-android/src/main/java/com/uber/autodispose/android/KotlinExtensions.kt
@@ -44,7 +44,17 @@ inline fun View.scope(): ScopeProvider = ViewScopeProvider.from(this)
  * Extension that proxies to [Flowable.as] + [AutoDispose.autoDisposable]
  */
 @CheckReturnValue
+@Deprecated(replaceWith = ReplaceWith("autoDispose(view)"), message = "Renamed to `autoDispose()`", level = DeprecationLevel.ERROR)
 inline fun <T> Flowable<T>.autoDisposable(
+  view: View
+): FlowableSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(ViewScopeProvider.from(view)))
+
+/**
+ * Extension that proxies to [Flowable.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun <T> Flowable<T>.autoDispose(
   view: View
 ): FlowableSubscribeProxy<T> =
     this.`as`(AutoDispose.autoDisposable(ViewScopeProvider.from(view)))
@@ -53,7 +63,17 @@ inline fun <T> Flowable<T>.autoDisposable(
  * Extension that proxies to [Observable.as] + [AutoDispose.autoDisposable]
  */
 @CheckReturnValue
+@Deprecated(replaceWith = ReplaceWith("autoDispose(view)"), message = "Renamed to `autoDispose()`", level = DeprecationLevel.ERROR)
 inline fun <T> Observable<T>.autoDisposable(
+  view: View
+): ObservableSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(ViewScopeProvider.from(view)))
+
+/**
+ * Extension that proxies to [Observable.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun <T> Observable<T>.autoDispose(
   view: View
 ): ObservableSubscribeProxy<T> =
     this.`as`(AutoDispose.autoDisposable(ViewScopeProvider.from(view)))
@@ -62,7 +82,17 @@ inline fun <T> Observable<T>.autoDisposable(
  * Extension that proxies to [Single.as] + [AutoDispose.autoDisposable]
  */
 @CheckReturnValue
+@Deprecated(replaceWith = ReplaceWith("autoDispose(view)"), message = "Renamed to `autoDispose()`", level = DeprecationLevel.ERROR)
 inline fun <T> Single<T>.autoDisposable(
+  view: View
+): SingleSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(ViewScopeProvider.from(view)))
+
+/**
+ * Extension that proxies to [Single.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun <T> Single<T>.autoDispose(
   view: View
 ): SingleSubscribeProxy<T> =
     this.`as`(AutoDispose.autoDisposable(ViewScopeProvider.from(view)))
@@ -71,7 +101,17 @@ inline fun <T> Single<T>.autoDisposable(
  * Extension that proxies to [Maybe.as] + [AutoDispose.autoDisposable]
  */
 @CheckReturnValue
+@Deprecated(replaceWith = ReplaceWith("autoDispose(view)"), message = "Renamed to `autoDispose()`", level = DeprecationLevel.ERROR)
 inline fun <T> Maybe<T>.autoDisposable(
+  view: View
+): MaybeSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(ViewScopeProvider.from(view)))
+
+/**
+ * Extension that proxies to [Maybe.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun <T> Maybe<T>.autoDispose(
   view: View
 ): MaybeSubscribeProxy<T> =
     this.`as`(AutoDispose.autoDisposable(ViewScopeProvider.from(view)))
@@ -80,7 +120,17 @@ inline fun <T> Maybe<T>.autoDisposable(
  * Extension that proxies to [Completable.as] + [AutoDispose.autoDisposable]
  */
 @CheckReturnValue
+@Deprecated(replaceWith = ReplaceWith("autoDispose(view)"), message = "Renamed to `autoDispose()`", level = DeprecationLevel.ERROR)
 inline fun Completable.autoDisposable(
+  view: View
+): CompletableSubscribeProxy =
+    this.`as`(AutoDispose.autoDisposable<Any>(ViewScopeProvider.from(view)))
+
+/**
+ * Extension that proxies to [Completable.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun Completable.autoDispose(
   view: View
 ): CompletableSubscribeProxy =
     this.`as`(AutoDispose.autoDisposable<Any>(ViewScopeProvider.from(view)))
@@ -89,7 +139,17 @@ inline fun Completable.autoDisposable(
  * Extension that proxies to [ParallelFlowable.as] + [AutoDispose.autoDisposable]
  */
 @CheckReturnValue
+@Deprecated(replaceWith = ReplaceWith("autoDispose(view)"), message = "Renamed to `autoDispose()`", level = DeprecationLevel.ERROR)
 inline fun <T> ParallelFlowable<T>.autoDisposable(
+  view: View
+): ParallelFlowableSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(ViewScopeProvider.from(view)))
+
+/**
+ * Extension that proxies to [ParallelFlowable.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun <T> ParallelFlowable<T>.autoDispose(
   view: View
 ): ParallelFlowableSubscribeProxy<T> =
     this.`as`(AutoDispose.autoDisposable(ViewScopeProvider.from(view)))

--- a/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/AutoDisposeLifecycleTest.kt
+++ b/autodispose-lifecycle/src/test/java/com/uber/autodispose/lifecycle/AutoDisposeLifecycleTest.kt
@@ -17,7 +17,7 @@
 
 package com.uber.autodispose.lifecycle
 
-import com.uber.autodispose.autoDisposable
+import com.uber.autodispose.autoDispose
 import io.reactivex.BackpressureStrategy.ERROR
 import io.reactivex.Completable
 import io.reactivex.Flowable
@@ -41,7 +41,7 @@ class AutoDisposeLifecycleTest {
 
   @Test fun observable_lifecycleNotStarted() {
     Observable.just("Hello")
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(o)
 
     o.assertError { it is LifecycleNotStartedException }
@@ -50,7 +50,7 @@ class AutoDisposeLifecycleTest {
   @Test fun observable_lifecycleNormalCompletion() {
     lifecycleScopeProvider.start()
     Observable.just("Hello")
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(o)
 
     o.assertValue { it == "Hello" }
@@ -61,7 +61,7 @@ class AutoDisposeLifecycleTest {
     lifecycleScopeProvider.start()
     val subject = PublishSubject.create<String>()
     subject
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(o)
 
     subject.onNext("Hello")
@@ -79,7 +79,7 @@ class AutoDisposeLifecycleTest {
     lifecycleScopeProvider.start()
     lifecycleScopeProvider.stop()
     Observable.just("Hello")
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(o)
 
     o.assertError { it is LifecycleEndedException }
@@ -87,7 +87,7 @@ class AutoDisposeLifecycleTest {
 
   @Test fun flowable_lifecycleNotStarted() {
     Flowable.just("Hello")
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(s)
 
     s.assertError { it is LifecycleNotStartedException }
@@ -96,7 +96,7 @@ class AutoDisposeLifecycleTest {
   @Test fun flowable_lifecycleNormalCompletion() {
     lifecycleScopeProvider.start()
     Flowable.just("Hello")
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(s)
 
     s.assertValue { it == "Hello" }
@@ -107,7 +107,7 @@ class AutoDisposeLifecycleTest {
     lifecycleScopeProvider.start()
     val subject = PublishSubject.create<String>()
     subject.toFlowable(ERROR)
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(s)
 
     subject.onNext("Hello")
@@ -125,7 +125,7 @@ class AutoDisposeLifecycleTest {
     lifecycleScopeProvider.start()
     lifecycleScopeProvider.stop()
     Flowable.just("Hello")
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(s)
 
     s.assertError { it is LifecycleEndedException }
@@ -133,7 +133,7 @@ class AutoDisposeLifecycleTest {
 
   @Test fun maybe_lifecycleNotStarted() {
     Maybe.just("Hello")
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(o)
 
     o.assertError { it is LifecycleNotStartedException }
@@ -142,7 +142,7 @@ class AutoDisposeLifecycleTest {
   @Test fun maybe_lifecycleNormalCompletion() {
     lifecycleScopeProvider.start()
     Maybe.just("Hello")
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(o)
 
     o.assertValue { it == "Hello" }
@@ -153,7 +153,7 @@ class AutoDisposeLifecycleTest {
     lifecycleScopeProvider.start()
     val subject = PublishSubject.create<String>()
     subject
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(o)
 
     lifecycleScopeProvider.stop()
@@ -167,7 +167,7 @@ class AutoDisposeLifecycleTest {
     lifecycleScopeProvider.start()
     lifecycleScopeProvider.stop()
     Maybe.just("Hello")
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(o)
 
     o.assertError { it is LifecycleEndedException }
@@ -175,7 +175,7 @@ class AutoDisposeLifecycleTest {
 
   @Test fun single_lifecycleNotStarted() {
     Single.just("Hello")
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(o)
 
     o.assertError { it is LifecycleNotStartedException }
@@ -184,7 +184,7 @@ class AutoDisposeLifecycleTest {
   @Test fun single_lifecycleNormalCompletion() {
     lifecycleScopeProvider.start()
     Single.just("Hello")
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(o)
 
     o.assertValue { it == "Hello" }
@@ -195,7 +195,7 @@ class AutoDisposeLifecycleTest {
     lifecycleScopeProvider.start()
     val subject = PublishSubject.create<String>()
     subject
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(o)
 
     lifecycleScopeProvider.stop()
@@ -209,7 +209,7 @@ class AutoDisposeLifecycleTest {
     lifecycleScopeProvider.start()
     lifecycleScopeProvider.stop()
     Single.just("Hello")
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(o)
 
     o.assertError { it is LifecycleEndedException }
@@ -217,7 +217,7 @@ class AutoDisposeLifecycleTest {
 
   @Test fun completable_lifecycleNotStarted() {
     Completable.complete()
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(o)
 
     o.assertError { it is LifecycleNotStartedException }
@@ -226,7 +226,7 @@ class AutoDisposeLifecycleTest {
   @Test fun completable_lifecycleNormalCompletion() {
     lifecycleScopeProvider.start()
     Completable.complete()
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(o)
 
     o.assertComplete()
@@ -236,7 +236,7 @@ class AutoDisposeLifecycleTest {
     lifecycleScopeProvider.start()
     val subject = CompletableSubject.create()
     subject
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(o)
 
     lifecycleScopeProvider.stop()
@@ -250,7 +250,7 @@ class AutoDisposeLifecycleTest {
     lifecycleScopeProvider.start()
     lifecycleScopeProvider.stop()
     Completable.complete()
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(o)
 
     o.assertError { it is LifecycleEndedException }
@@ -260,7 +260,7 @@ class AutoDisposeLifecycleTest {
     val s2 = TestSubscriber<String>()
     Flowable.just("Hello", "World")
         .parallel(DEFAULT_PARALLELISM)
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(arrayOf(s, s2))
 
     s.assertError { it is LifecycleNotStartedException }
@@ -272,7 +272,7 @@ class AutoDisposeLifecycleTest {
     val s2 = TestSubscriber<String>()
     Flowable.just("Hello", "World")
         .parallel(DEFAULT_PARALLELISM)
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(arrayOf(s, s2))
 
     s.assertValue { it == "Hello" }
@@ -287,7 +287,7 @@ class AutoDisposeLifecycleTest {
     val s2 = TestSubscriber<String>()
     subject.toFlowable(ERROR)
         .parallel(DEFAULT_PARALLELISM)
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(arrayOf(s, s2))
 
     subject.onNext("Hello")
@@ -308,7 +308,7 @@ class AutoDisposeLifecycleTest {
     val s2 = TestSubscriber<String>()
     Flowable.just("Hello")
         .parallel(DEFAULT_PARALLELISM)
-        .autoDisposable(lifecycleScopeProvider)
+        .autoDispose(lifecycleScopeProvider)
         .subscribe(arrayOf(s, s2))
 
     s.assertError { it is LifecycleEndedException }

--- a/autodispose-rxlifecycle/src/main/java/com/ubercab/autodispose/rxlifecycle/KotlinExtensions.kt
+++ b/autodispose-rxlifecycle/src/main/java/com/ubercab/autodispose/rxlifecycle/KotlinExtensions.kt
@@ -51,7 +51,24 @@ inline fun <E> LifecycleProvider<E>.scope(event: E? = null): ScopeProvider {
  * @param event Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleProvider, event)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T, E> Flowable<T>.autoDisposable(lifecycleProvider: LifecycleProvider<E>, event: E? = null): FlowableSubscribeProxy<T> {
+  return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
+}
+
+/**
+ * Extension that proxies to [Flowable.as] + [AutoDispose.autoDisposable] and takes an [event] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleProvider The lifecycle provider from RxLifecycle.
+ * @param event Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <T, E> Flowable<T>.autoDispose(lifecycleProvider: LifecycleProvider<E>, event: E? = null): FlowableSubscribeProxy<T> {
   return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
 }
 
@@ -63,7 +80,24 @@ inline fun <T, E> Flowable<T>.autoDisposable(lifecycleProvider: LifecycleProvide
  * @param event Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleProvider, event)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T, E> Observable<T>.autoDisposable(lifecycleProvider: LifecycleProvider<E>, event: E? = null): ObservableSubscribeProxy<T> {
+  return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
+}
+
+/**
+ * Extension that proxies to [Observable.as] + [AutoDispose.autoDisposable] and takes an [event] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleProvider The lifecycle provider from RxLifecycle.
+ * @param event Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <T, E> Observable<T>.autoDispose(lifecycleProvider: LifecycleProvider<E>, event: E? = null): ObservableSubscribeProxy<T> {
   return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
 }
 
@@ -75,7 +109,24 @@ inline fun <T, E> Observable<T>.autoDisposable(lifecycleProvider: LifecycleProvi
  * @param event Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleProvider, event)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T, E> Single<T>.autoDisposable(lifecycleProvider: LifecycleProvider<E>, event: E? = null): SingleSubscribeProxy<T> {
+  return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
+}
+
+/**
+ * Extension that proxies to [Single.as] + [AutoDispose.autoDisposable] and takes an [event] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleProvider The lifecycle provider from RxLifecycle.
+ * @param event Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <T, E> Single<T>.autoDispose(lifecycleProvider: LifecycleProvider<E>, event: E? = null): SingleSubscribeProxy<T> {
   return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
 }
 
@@ -87,7 +138,24 @@ inline fun <T, E> Single<T>.autoDisposable(lifecycleProvider: LifecycleProvider<
  * @param event Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleProvider, event)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T, E> Maybe<T>.autoDisposable(lifecycleProvider: LifecycleProvider<E>, event: E? = null): MaybeSubscribeProxy<T> {
+  return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
+}
+
+/**
+ * Extension that proxies to [Maybe.as] + [AutoDispose.autoDisposable] and takes an [event] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleProvider The lifecycle provider from RxLifecycle.
+ * @param event Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <T, E> Maybe<T>.autoDispose(lifecycleProvider: LifecycleProvider<E>, event: E? = null): MaybeSubscribeProxy<T> {
   return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
 }
 
@@ -99,7 +167,24 @@ inline fun <T, E> Maybe<T>.autoDisposable(lifecycleProvider: LifecycleProvider<E
  * @param event Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleProvider, event)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <E> Completable.autoDisposable(lifecycleProvider: LifecycleProvider<E>, event: E? = null): CompletableSubscribeProxy {
+  return this.`as`(AutoDispose.autoDisposable<Any>(lifecycleProvider.scope(event)))
+}
+
+/**
+ * Extension that proxies to [Completable.as] + [AutoDispose.autoDisposable] and takes an [event] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleProvider The lifecycle provider from RxLifecycle.
+ * @param event Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <E> Completable.autoDispose(lifecycleProvider: LifecycleProvider<E>, event: E? = null): CompletableSubscribeProxy {
   return this.`as`(AutoDispose.autoDisposable<Any>(lifecycleProvider.scope(event)))
 }
 
@@ -111,6 +196,23 @@ inline fun <E> Completable.autoDisposable(lifecycleProvider: LifecycleProvider<E
  * @param event Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleProvider, event)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T, E> ParallelFlowable<T>.autoDisposable(lifecycleProvider: LifecycleProvider<E>, event: E? = null): ParallelFlowableSubscribeProxy<T> {
+  return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
+}
+
+/**
+ * Extension that proxies to [ParallelFlowable.as] + [AutoDispose.autoDisposable] and takes an [event] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleProvider The lifecycle provider from RxLifecycle.
+ * @param event Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <T, E> ParallelFlowable<T>.autoDispose(lifecycleProvider: LifecycleProvider<E>, event: E? = null): ParallelFlowableSubscribeProxy<T> {
   return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
 }

--- a/autodispose-rxlifecycle3/src/main/java/com/ubercab/autodispose/rxlifecycle3/KotlinExtensions.kt
+++ b/autodispose-rxlifecycle3/src/main/java/com/ubercab/autodispose/rxlifecycle3/KotlinExtensions.kt
@@ -51,7 +51,24 @@ inline fun <E> LifecycleProvider<E>.scope(event: E? = null): ScopeProvider {
  * @param event Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleProvider, event)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T, E> Flowable<T>.autoDisposable(lifecycleProvider: LifecycleProvider<E>, event: E? = null): FlowableSubscribeProxy<T> {
+  return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
+}
+
+/**
+ * Extension that proxies to [Flowable.as] + [AutoDispose.autoDisposable] and takes an [event] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleProvider The lifecycle provider from RxLifecycle.
+ * @param event Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <T, E> Flowable<T>.autoDispose(lifecycleProvider: LifecycleProvider<E>, event: E? = null): FlowableSubscribeProxy<T> {
   return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
 }
 
@@ -63,7 +80,24 @@ inline fun <T, E> Flowable<T>.autoDisposable(lifecycleProvider: LifecycleProvide
  * @param event Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleProvider, event)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T, E> Observable<T>.autoDisposable(lifecycleProvider: LifecycleProvider<E>, event: E? = null): ObservableSubscribeProxy<T> {
+  return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
+}
+
+/**
+ * Extension that proxies to [Observable.as] + [AutoDispose.autoDisposable] and takes an [event] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleProvider The lifecycle provider from RxLifecycle.
+ * @param event Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <T, E> Observable<T>.autoDispose(lifecycleProvider: LifecycleProvider<E>, event: E? = null): ObservableSubscribeProxy<T> {
   return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
 }
 
@@ -75,7 +109,24 @@ inline fun <T, E> Observable<T>.autoDisposable(lifecycleProvider: LifecycleProvi
  * @param event Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleProvider, event)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T, E> Single<T>.autoDisposable(lifecycleProvider: LifecycleProvider<E>, event: E? = null): SingleSubscribeProxy<T> {
+  return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
+}
+
+/**
+ * Extension that proxies to [Single.as] + [AutoDispose.autoDisposable] and takes an [event] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleProvider The lifecycle provider from RxLifecycle.
+ * @param event Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <T, E> Single<T>.autoDispose(lifecycleProvider: LifecycleProvider<E>, event: E? = null): SingleSubscribeProxy<T> {
   return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
 }
 
@@ -87,7 +138,24 @@ inline fun <T, E> Single<T>.autoDisposable(lifecycleProvider: LifecycleProvider<
  * @param event Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleProvider, event)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T, E> Maybe<T>.autoDisposable(lifecycleProvider: LifecycleProvider<E>, event: E? = null): MaybeSubscribeProxy<T> {
+  return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
+}
+
+/**
+ * Extension that proxies to [Maybe.as] + [AutoDispose.autoDisposable] and takes an [event] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleProvider The lifecycle provider from RxLifecycle.
+ * @param event Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <T, E> Maybe<T>.autoDispose(lifecycleProvider: LifecycleProvider<E>, event: E? = null): MaybeSubscribeProxy<T> {
   return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
 }
 
@@ -99,7 +167,24 @@ inline fun <T, E> Maybe<T>.autoDisposable(lifecycleProvider: LifecycleProvider<E
  * @param event Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleProvider, event)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <E> Completable.autoDisposable(lifecycleProvider: LifecycleProvider<E>, event: E? = null): CompletableSubscribeProxy {
+  return this.`as`(AutoDispose.autoDisposable<Any>(lifecycleProvider.scope(event)))
+}
+
+/**
+ * Extension that proxies to [Completable.as] + [AutoDispose.autoDisposable] and takes an [event] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleProvider The lifecycle provider from RxLifecycle.
+ * @param event Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <E> Completable.autoDispose(lifecycleProvider: LifecycleProvider<E>, event: E? = null): CompletableSubscribeProxy {
   return this.`as`(AutoDispose.autoDisposable<Any>(lifecycleProvider.scope(event)))
 }
 
@@ -111,6 +196,23 @@ inline fun <E> Completable.autoDisposable(lifecycleProvider: LifecycleProvider<E
  * @param event Optional lifecycle event when subscription will be disposed.
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(lifecycleProvider, event)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T, E> ParallelFlowable<T>.autoDisposable(lifecycleProvider: LifecycleProvider<E>, event: E? = null): ParallelFlowableSubscribeProxy<T> {
+  return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
+}
+
+/**
+ * Extension that proxies to [ParallelFlowable.as] + [AutoDispose.autoDisposable] and takes an [event] when
+ * subscription will be disposed.
+ *
+ * @param lifecycleProvider The lifecycle provider from RxLifecycle.
+ * @param event Optional lifecycle event when subscription will be disposed.
+ */
+@CheckReturnValue
+inline fun <T, E> ParallelFlowable<T>.autoDispose(lifecycleProvider: LifecycleProvider<E>, event: E? = null): ParallelFlowableSubscribeProxy<T> {
   return this.`as`(AutoDispose.autoDisposable(lifecycleProvider.scope(event)))
 }

--- a/autodispose/src/main/java/com/uber/autodispose/KotlinExtensions.kt
+++ b/autodispose/src/main/java/com/uber/autodispose/KotlinExtensions.kt
@@ -30,82 +30,226 @@ import io.reactivex.parallel.ParallelFlowable
  * Extension that proxies to [Flowable.as] + [AutoDispose.autoDisposable]
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(scope)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T> Flowable<T>.autoDisposable(scope: Completable): FlowableSubscribeProxy<T> =
-    this.`as`(AutoDispose.autoDisposable(scope))
-
-/**
- * Extension that proxies to [Observable.as] + [AutoDispose.autoDisposable]
- */
-@CheckReturnValue
-inline fun <T> Observable<T>.autoDisposable(scope: Completable): ObservableSubscribeProxy<T> =
-    this.`as`(AutoDispose.autoDisposable(scope))
-
-/**
- * Extension that proxies to [Single.as] + [AutoDispose.autoDisposable]
- */
-@CheckReturnValue
-inline fun <T> Single<T>.autoDisposable(scope: Completable): SingleSubscribeProxy<T> =
-    this.`as`(AutoDispose.autoDisposable(scope))
-
-/**
- * Extension that proxies to [Maybe.as] + [AutoDispose.autoDisposable]
- */
-@CheckReturnValue
-inline fun <T> Maybe<T>.autoDisposable(scope: Completable): MaybeSubscribeProxy<T> =
-    this.`as`(AutoDispose.autoDisposable(scope))
-
-/**
- * Extension that proxies to [Completable.as] + [AutoDispose.autoDisposable]
- */
-@CheckReturnValue
-inline fun Completable.autoDisposable(scope: Completable): CompletableSubscribeProxy =
-    this.`as`(AutoDispose.autoDisposable<Any>(scope))
-
-/**
- * Extension that proxies to [ParallelFlowable.as] + [AutoDispose.autoDisposable]
- */
-@CheckReturnValue
-inline fun <T> ParallelFlowable<T>.autoDisposable(scope: Completable): ParallelFlowableSubscribeProxy<T> =
     this.`as`(AutoDispose.autoDisposable(scope))
 
 /**
  * Extension that proxies to [Flowable.as] + [AutoDispose.autoDisposable]
  */
 @CheckReturnValue
+inline fun <T> Flowable<T>.autoDispose(scope: Completable): FlowableSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(scope))
+
+/**
+ * Extension that proxies to [Observable.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(scope)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
+inline fun <T> Observable<T>.autoDisposable(scope: Completable): ObservableSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(scope))
+
+/**
+ * Extension that proxies to [Observable.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun <T> Observable<T>.autoDispose(scope: Completable): ObservableSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(scope))
+
+/**
+ * Extension that proxies to [Single.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(scope)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
+inline fun <T> Single<T>.autoDisposable(scope: Completable): SingleSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(scope))
+
+/**
+ * Extension that proxies to [Single.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun <T> Single<T>.autoDispose(scope: Completable): SingleSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(scope))
+
+/**
+ * Extension that proxies to [Maybe.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(scope)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
+inline fun <T> Maybe<T>.autoDisposable(scope: Completable): MaybeSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(scope))
+
+/**
+ * Extension that proxies to [Maybe.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun <T> Maybe<T>.autoDispose(scope: Completable): MaybeSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(scope))
+
+/**
+ * Extension that proxies to [Completable.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(scope)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
+inline fun Completable.autoDisposable(scope: Completable): CompletableSubscribeProxy =
+    this.`as`(AutoDispose.autoDisposable<Any>(scope))
+
+/**
+ * Extension that proxies to [Completable.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun Completable.autoDispose(scope: Completable): CompletableSubscribeProxy =
+    this.`as`(AutoDispose.autoDisposable<Any>(scope))
+
+/**
+ * Extension that proxies to [ParallelFlowable.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(scope)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
+inline fun <T> ParallelFlowable<T>.autoDisposable(scope: Completable): ParallelFlowableSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(scope))
+
+/**
+ * Extension that proxies to [ParallelFlowable.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun <T> ParallelFlowable<T>.autoDispose(scope: Completable): ParallelFlowableSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(scope))
+
+/**
+ * Extension that proxies to [Flowable.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(provider)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T> Flowable<T>.autoDisposable(provider: ScopeProvider): FlowableSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(provider))
+
+/**
+ * Extension that proxies to [Flowable.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun <T> Flowable<T>.autoDispose(provider: ScopeProvider): FlowableSubscribeProxy<T> =
     this.`as`(AutoDispose.autoDisposable(provider))
 
 /**
  * Extension that proxies to [Observable.as] + [AutoDispose.autoDisposable]
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(provider)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T> Observable<T>.autoDisposable(provider: ScopeProvider): ObservableSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(provider))
+
+/**
+ * Extension that proxies to [Observable.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun <T> Observable<T>.autoDispose(provider: ScopeProvider): ObservableSubscribeProxy<T> =
     this.`as`(AutoDispose.autoDisposable(provider))
 
 /**
  * Extension that proxies to [Single.as] + [AutoDispose.autoDisposable]
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(provider)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T> Single<T>.autoDisposable(provider: ScopeProvider): SingleSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(provider))
+
+/**
+ * Extension that proxies to [Single.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun <T> Single<T>.autoDispose(provider: ScopeProvider): SingleSubscribeProxy<T> =
     this.`as`(AutoDispose.autoDisposable(provider))
 
 /**
  * Extension that proxies to [Maybe.as] + [AutoDispose.autoDisposable]
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(provider)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T> Maybe<T>.autoDisposable(provider: ScopeProvider): MaybeSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(provider))
+
+/**
+ * Extension that proxies to [Maybe.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun <T> Maybe<T>.autoDispose(provider: ScopeProvider): MaybeSubscribeProxy<T> =
     this.`as`(AutoDispose.autoDisposable(provider))
 
 /**
  * Extension that proxies to [Completable.as] + [AutoDispose.autoDisposable]
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(provider)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun Completable.autoDisposable(provider: ScopeProvider): CompletableSubscribeProxy =
+    this.`as`(AutoDispose.autoDisposable<Any>(provider))
+
+/**
+ * Extension that proxies to [Completable.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun Completable.autoDispose(provider: ScopeProvider): CompletableSubscribeProxy =
     this.`as`(AutoDispose.autoDisposable<Any>(provider))
 
 /**
  * Extension that proxies to [ParallelFlowable.as] + [AutoDispose.autoDisposable]
  */
 @CheckReturnValue
+@Deprecated(
+    replaceWith = ReplaceWith("autoDispose(provider)"),
+    message = "Renamed to `autoDispose`",
+    level = DeprecationLevel.ERROR
+)
 inline fun <T> ParallelFlowable<T>.autoDisposable(provider: ScopeProvider): ParallelFlowableSubscribeProxy<T> =
+    this.`as`(AutoDispose.autoDisposable(provider))
+
+/**
+ * Extension that proxies to [ParallelFlowable.as] + [AutoDispose.autoDisposable]
+ */
+@CheckReturnValue
+inline fun <T> ParallelFlowable<T>.autoDispose(provider: ScopeProvider): ParallelFlowableSubscribeProxy<T> =
     this.`as`(AutoDispose.autoDisposable(provider))

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeKotlinTest.kt
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeKotlinTest.kt
@@ -42,7 +42,7 @@ class AutoDisposeKotlinTest {
 
   @Test fun observable_maybeNormalCompletion() {
     Observable.just("Hello")
-        .autoDisposable(scope)
+        .autoDispose(scope)
         .subscribe(o)
 
     o.assertValue { it == "Hello" }
@@ -52,7 +52,7 @@ class AutoDisposeKotlinTest {
   @Test fun observable_maybeNormalInterrupted() {
     val subject = PublishSubject.create<String>()
     subject
-        .autoDisposable(scope)
+        .autoDispose(scope)
         .subscribe(o)
 
     subject.onNext("Hello")
@@ -68,7 +68,7 @@ class AutoDisposeKotlinTest {
 
   @Test fun observable_scopeProviderNormalCompletion() {
     Observable.just("Hello")
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribe(o)
 
     o.assertValue { it == "Hello" }
@@ -78,7 +78,7 @@ class AutoDisposeKotlinTest {
   @Test fun observable_scopeProviderNormalInterrupted() {
     val subject = PublishSubject.create<String>()
     subject
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribe(o)
 
     subject.onNext("Hello")
@@ -94,7 +94,7 @@ class AutoDisposeKotlinTest {
 
   @Test fun flowable_maybeNormalCompletion() {
     Flowable.just("Hello")
-        .autoDisposable(scope)
+        .autoDispose(scope)
         .subscribe(s)
 
     s.assertValue { it == "Hello" }
@@ -104,7 +104,7 @@ class AutoDisposeKotlinTest {
   @Test fun flowable_maybeNormalInterrupted() {
     val subject = PublishSubject.create<String>()
     subject.toFlowable(ERROR)
-        .autoDisposable(scope)
+        .autoDispose(scope)
         .subscribe(s)
 
     subject.onNext("Hello")
@@ -120,7 +120,7 @@ class AutoDisposeKotlinTest {
 
   @Test fun flowable_scopeProviderNormalCompletion() {
     Flowable.just("Hello")
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribe(s)
 
     s.assertValue { it == "Hello" }
@@ -130,7 +130,7 @@ class AutoDisposeKotlinTest {
   @Test fun flowable_scopeProviderNormalInterrupted() {
     val subject = PublishSubject.create<String>()
     subject.toFlowable(ERROR)
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribe(s)
 
     subject.onNext("Hello")
@@ -146,7 +146,7 @@ class AutoDisposeKotlinTest {
 
   @Test fun maybe_maybeNormalCompletion() {
     Maybe.just("Hello")
-        .autoDisposable(scope)
+        .autoDispose(scope)
         .subscribe(o)
 
     o.assertValue { it == "Hello" }
@@ -156,7 +156,7 @@ class AutoDisposeKotlinTest {
   @Test fun maybe_maybeNormalInterrupted() {
     val subject = MaybeSubject.create<String>()
     subject
-        .autoDisposable(scope)
+        .autoDispose(scope)
         .subscribe(o)
 
     subject.onSuccess("Hello")
@@ -172,7 +172,7 @@ class AutoDisposeKotlinTest {
 
   @Test fun maybe_scopeProviderNormalCompletion() {
     Maybe.just("Hello")
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribe(o)
 
     o.assertValue { it == "Hello" }
@@ -182,7 +182,7 @@ class AutoDisposeKotlinTest {
   @Test fun maybe_scopeProviderNormalInterrupted() {
     val subject = MaybeSubject.create<String>()
     subject
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribe(o)
 
     scopeProvider.emit()
@@ -198,7 +198,7 @@ class AutoDisposeKotlinTest {
 
   @Test fun single_maybeNormalCompletion() {
     Single.just("Hello")
-        .autoDisposable(scope)
+        .autoDispose(scope)
         .subscribe(o)
 
     o.assertValue { it == "Hello" }
@@ -208,7 +208,7 @@ class AutoDisposeKotlinTest {
   @Test fun single_maybeNormalInterrupted() {
     val subject = SingleSubject.create<String>()
     subject
-        .autoDisposable(scope)
+        .autoDispose(scope)
         .subscribe(o)
 
     subject.onSuccess("Hello")
@@ -224,7 +224,7 @@ class AutoDisposeKotlinTest {
 
   @Test fun single_scopeProviderNormalCompletion() {
     Single.just("Hello")
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribe(o)
 
     o.assertValue { it == "Hello" }
@@ -234,7 +234,7 @@ class AutoDisposeKotlinTest {
   @Test fun single_scopeProviderNormalInterrupted() {
     val subject = SingleSubject.create<String>()
     subject
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribe(o)
 
     subject.onSuccess("Hello")
@@ -250,7 +250,7 @@ class AutoDisposeKotlinTest {
 
   @Test fun completable_maybeNormalCompletion() {
     Completable.complete()
-        .autoDisposable(scope)
+        .autoDispose(scope)
         .subscribe(o)
 
     o.assertComplete()
@@ -259,7 +259,7 @@ class AutoDisposeKotlinTest {
   @Test fun completable_maybeNormalInterrupted() {
     val subject = PublishSubject.create<String>()
     subject
-        .autoDisposable(scope)
+        .autoDispose(scope)
         .subscribe(o)
 
     subject.onNext("Hello")
@@ -275,7 +275,7 @@ class AutoDisposeKotlinTest {
 
   @Test fun completable_scopeProviderNormalCompletion() {
     Completable.complete()
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribe(o)
 
     o.assertComplete()
@@ -284,7 +284,7 @@ class AutoDisposeKotlinTest {
   @Test fun completable_scopeProviderNormalInterrupted() {
     val subject = CompletableSubject.create()
     subject
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribe(o)
 
     subject.onComplete()
@@ -300,7 +300,7 @@ class AutoDisposeKotlinTest {
     val s2 = TestSubscriber<String>()
     Flowable.just("Hello", "World")
         .parallel(DEFAULT_PARALLELISM)
-        .autoDisposable(scope)
+        .autoDispose(scope)
         .subscribe(arrayOf(s, s2))
 
     s.assertValue { it == "Hello" }
@@ -314,7 +314,7 @@ class AutoDisposeKotlinTest {
     val s2 = TestSubscriber<String>()
     subject.toFlowable(ERROR)
         .parallel(DEFAULT_PARALLELISM)
-        .autoDisposable(scope)
+        .autoDispose(scope)
         .subscribe(arrayOf(s, s2))
 
     subject.onNext("Hello")
@@ -334,7 +334,7 @@ class AutoDisposeKotlinTest {
     val s2 = TestSubscriber<String>()
     Flowable.just("Hello", "World")
         .parallel(DEFAULT_PARALLELISM)
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribe(arrayOf(s, s2))
 
     s.assertValue { it == "Hello" }
@@ -348,7 +348,7 @@ class AutoDisposeKotlinTest {
     val s2 = TestSubscriber<String>()
     subject.toFlowable(ERROR)
         .parallel(DEFAULT_PARALLELISM)
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribe(arrayOf(s, s2))
 
     subject.onNext("Hello")

--- a/sample/src/androidTest/java/com/uber/autodispose/TestKotlinActivity.kt
+++ b/sample/src/androidTest/java/com/uber/autodispose/TestKotlinActivity.kt
@@ -21,11 +21,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import com.trello.rxlifecycle3.LifecycleProvider
 import com.trello.rxlifecycle3.LifecycleTransformer
-import com.uber.autodispose.android.autoDisposable
+import com.uber.autodispose.android.autoDispose
 import com.uber.autodispose.android.lifecycle.AndroidLifecycleScopeProvider
-import com.uber.autodispose.android.lifecycle.autoDisposable
+import com.uber.autodispose.android.lifecycle.autoDispose
 import com.uber.autodispose.android.lifecycle.scope
-import com.ubercab.autodispose.rxlifecycle3.autoDisposable
+import com.ubercab.autodispose.rxlifecycle3.autoDispose
 import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.Single
@@ -46,12 +46,12 @@ class TestKotlinActivity : AppCompatActivity(), ScopeProvider {
 
     // With extension function that overloads LifecycleOwner
     Observable.interval(1, TimeUnit.SECONDS)
-        .autoDisposable(this)
+        .autoDispose(this)
         .subscribe()
 
     // With extension function that overloads LifecycleOwner and until Event
     Observable.interval(1, TimeUnit.SECONDS)
-        .autoDisposable(this, Lifecycle.Event.ON_DESTROY)
+        .autoDispose(this, Lifecycle.Event.ON_DESTROY)
         .subscribe()
 
     // With extension function that overloads ScopeProvider
@@ -65,52 +65,52 @@ class TestKotlinActivity : AppCompatActivity(), ScopeProvider {
         .subscribe()
 
     Maybe.just(1)
-        .autoDisposable(this)
+        .autoDispose(this)
         .subscribe()
 
     Maybe.just(1)
-        .autoDisposable(this, Lifecycle.Event.ON_DESTROY)
+        .autoDispose(this, Lifecycle.Event.ON_DESTROY)
         .subscribe()
 
     Flowable.just(1)
-        .autoDisposable(this)
+        .autoDispose(this)
         .subscribe()
 
     Flowable.just(1)
-        .autoDisposable(this, Lifecycle.Event.ON_DESTROY)
+        .autoDispose(this, Lifecycle.Event.ON_DESTROY)
         .subscribe()
 
     Single.just(1)
-        .autoDisposable(this)
+        .autoDispose(this)
         .subscribe()
 
     Single.just(1)
-        .autoDisposable(this, Lifecycle.Event.ON_DESTROY)
+        .autoDispose(this, Lifecycle.Event.ON_DESTROY)
         .subscribe()
 
     Completable.never()
-        .autoDisposable(this)
+        .autoDispose(this)
         .subscribe()
 
     Completable.never()
-        .autoDisposable(this, Lifecycle.Event.ON_DESTROY)
+        .autoDispose(this, Lifecycle.Event.ON_DESTROY)
         .subscribe()
 
     val rootView = findViewById<View>(android.R.id.content)
 
     // Taking scope of a View
     Observable.interval(1, TimeUnit.DAYS)
-        .autoDisposable(rootView)
+        .autoDispose(rootView)
         .subscribe()
 
     // RxLifecycle
     val lifecycleProvider = TestLifecycleProvider()
     Observable.interval(1, TimeUnit.SECONDS)
-        .autoDisposable(lifecycleProvider)
+        .autoDispose(lifecycleProvider)
         .subscribe()
 
     Observable.interval(1, TimeUnit.SECONDS)
-        .autoDisposable(lifecycleProvider, TestLifecycleProvider.Event.CREATE)
+        .autoDispose(lifecycleProvider, TestLifecycleProvider.Event.CREATE)
         .subscribe()
   }
 

--- a/sample/src/androidTest/java/com/uber/autodispose/TestKotlinActivity.kt
+++ b/sample/src/androidTest/java/com/uber/autodispose/TestKotlinActivity.kt
@@ -56,12 +56,12 @@ class TestKotlinActivity : AppCompatActivity(), ScopeProvider {
 
     // With extension function that overloads ScopeProvider
     Observable.interval(1, TimeUnit.SECONDS)
-        .autoDisposable(scope(Lifecycle.Event.ON_DESTROY))
+        .autoDispose(scope(Lifecycle.Event.ON_DESTROY))
         .subscribe()
 
     // With no extension function
     Observable.interval(1, TimeUnit.SECONDS)
-        .autoDisposable(AndroidLifecycleScopeProvider.from(this))
+        .autoDispose(AndroidLifecycleScopeProvider.from(this))
         .subscribe()
 
     Maybe.just(1)

--- a/sample/src/main/kotlin/com/uber/autodispose/sample/ArchComponentActivity.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/sample/ArchComponentActivity.kt
@@ -22,7 +22,7 @@ import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProviders
 import com.uber.autodispose.android.lifecycle.AndroidLifecycleScopeProvider
-import com.uber.autodispose.autoDisposable
+import com.uber.autodispose.autoDispose
 import com.uber.autodispose.sample.repository.ImageRepository
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
@@ -58,7 +58,7 @@ class ArchComponentActivity : AppCompatActivity() {
         .doOnDispose { Log.i(TAG, "Disposing ViewModel observer from onCreate()") }
         .subscribeOn(Schedulers.io())
         .observeOn(AndroidSchedulers.mainThread())
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribe { bitmap ->
           Log.i(TAG, "Received bitmap")
           imageView.setImageBitmap(bitmap)

--- a/sample/src/main/kotlin/com/uber/autodispose/sample/DisposingViewModel.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/sample/DisposingViewModel.kt
@@ -19,7 +19,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import android.util.Log
 import com.jakewharton.rxrelay2.BehaviorRelay
-import com.uber.autodispose.autoDisposable
+import com.uber.autodispose.autoDispose
 import com.uber.autodispose.recipes.AutoDisposeViewModel
 import com.uber.autodispose.sample.repository.NetworkRepository
 import com.uber.autodispose.sample.state.DownloadState
@@ -81,7 +81,7 @@ class DisposingViewModel(private val repository: NetworkRepository) : AutoDispos
     repository.downloadProgress()
         .subscribeOn(Schedulers.io())
         .doOnDispose { Log.i(TAG, "Disposing subscription from the ViewModel") }
-        .autoDisposable(this)
+        .autoDispose(this)
         .subscribe({ progress ->
           viewRelay.accept(DownloadState.InProgress(progress))
         }, { error ->

--- a/sample/src/main/kotlin/com/uber/autodispose/sample/DisposingViewModelActivity.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/sample/DisposingViewModelActivity.kt
@@ -22,7 +22,7 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import com.uber.autodispose.ScopeProvider
 import com.uber.autodispose.android.lifecycle.AndroidLifecycleScopeProvider
-import com.uber.autodispose.autoDisposable
+import com.uber.autodispose.autoDispose
 import com.uber.autodispose.sample.repository.NetworkRepository
 import com.uber.autodispose.sample.state.DownloadState
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -58,7 +58,7 @@ class DisposingViewModelActivity : AppCompatActivity() {
     // Get latest value from ViewModel unaffected by any config changes.
     viewModel.downloadState()
         .observeOn(AndroidSchedulers.mainThread())
-        .autoDisposable(scope)
+        .autoDispose(scope)
         .subscribe({ state ->
           resolveState(state)
         }, {})

--- a/sample/src/main/kotlin/com/uber/autodispose/sample/KotlinActivity.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/sample/KotlinActivity.kt
@@ -20,7 +20,7 @@ import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import com.uber.autodispose.android.lifecycle.AndroidLifecycleScopeProvider
-import com.uber.autodispose.autoDisposable
+import com.uber.autodispose.autoDispose
 import com.uber.autodispose.recipes.subscribeBy
 import io.reactivex.Observable
 import java.util.concurrent.TimeUnit
@@ -44,7 +44,7 @@ class KotlinActivity : AppCompatActivity() {
     // dispose is onDestroy (the opposite of onCreate).
     Observable.interval(1, TimeUnit.SECONDS)
         .doOnDispose { Log.i(TAG, "Disposing subscription from onCreate()") }
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribeBy { num -> Log.i(TAG, "Started in onCreate(), running until onDestroy(): $num") }
 
     supportFragmentManager.beginTransaction()
@@ -61,7 +61,7 @@ class KotlinActivity : AppCompatActivity() {
     // dispose is onStop (the opposite of onStart).
     Observable.interval(1, TimeUnit.SECONDS)
         .doOnDispose { Log.i(TAG, "Disposing subscription from onStart()") }
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribeBy { num -> Log.i(TAG, "Started in onStart(), running until in onStop(): $num") }
   }
 
@@ -74,7 +74,7 @@ class KotlinActivity : AppCompatActivity() {
     // dispose is onPause (the opposite of onResume).
     Observable.interval(1, TimeUnit.SECONDS)
         .doOnDispose { Log.i(TAG, "Disposing subscription from onResume()") }
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribeBy { num -> Log.i(TAG, "Started in onResume(), running until in onPause(): $num") }
 
     // Setting a specific untilEvent, this should dispose in onDestroy.
@@ -82,7 +82,7 @@ class KotlinActivity : AppCompatActivity() {
         .doOnDispose {
           Log.i(TAG, "Disposing subscription from onResume() with untilEvent ON_DESTROY")
         }
-        .autoDisposable(AndroidLifecycleScopeProvider.from(this, Lifecycle.Event.ON_DESTROY))
+        .autoDispose(AndroidLifecycleScopeProvider.from(this, Lifecycle.Event.ON_DESTROY))
         .subscribeBy { num -> Log.i(TAG, "Started in onResume(), running until in onDestroy(): $num") }
   }
 

--- a/sample/src/main/kotlin/com/uber/autodispose/sample/KotlinFragment.kt
+++ b/sample/src/main/kotlin/com/uber/autodispose/sample/KotlinFragment.kt
@@ -23,7 +23,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import com.uber.autodispose.android.lifecycle.AndroidLifecycleScopeProvider
-import com.uber.autodispose.autoDisposable
+import com.uber.autodispose.autoDispose
 import com.uber.autodispose.recipes.subscribeBy
 import io.reactivex.Observable
 import java.util.concurrent.TimeUnit
@@ -47,7 +47,7 @@ class KotlinFragment : Fragment() {
     // dispose is onDestroy (the opposite of onCreate).
     Observable.interval(1, TimeUnit.SECONDS)
         .doOnDispose { Log.i(TAG, "Disposing subscription from onCreate()") }
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribeBy { num -> Log.i(TAG, "Started in onCreate(), running until onDestroy(): $num") }
   }
 
@@ -68,7 +68,7 @@ class KotlinFragment : Fragment() {
     // Note we do this in onViewCreated to defer until after the view is created
     Observable.interval(1, TimeUnit.SECONDS)
         .doOnDispose { Log.i(TAG, "Disposing subscription from onViewCreated()") }
-        .autoDisposable(AndroidLifecycleScopeProvider.from(viewLifecycleOwner))
+        .autoDispose(AndroidLifecycleScopeProvider.from(viewLifecycleOwner))
         .subscribeBy { num ->
           Log.i(TAG, "Started in onViewCreated(), running until onDestroyView(): $num")
         }
@@ -83,7 +83,7 @@ class KotlinFragment : Fragment() {
     // dispose is onStop (the opposite of onStart).
     Observable.interval(1, TimeUnit.SECONDS)
         .doOnDispose { Log.i(TAG, "Disposing subscription from onStart()") }
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribeBy { num -> Log.i(TAG, "Started in onStart(), running until in onStop(): $num") }
   }
 
@@ -96,7 +96,7 @@ class KotlinFragment : Fragment() {
     // dispose is onPause (the opposite of onResume).
     Observable.interval(1, TimeUnit.SECONDS)
         .doOnDispose { Log.i(TAG, "Disposing subscription from onResume()") }
-        .autoDisposable(scopeProvider)
+        .autoDispose(scopeProvider)
         .subscribeBy { num ->
           Log.i(TAG, "Started in onResume(), running until in onPause(): $num")
         }
@@ -106,7 +106,7 @@ class KotlinFragment : Fragment() {
         .doOnDispose {
           Log.i(TAG, "Disposing subscription from onResume() with untilEvent ON_DESTROY")
         }
-        .autoDisposable(AndroidLifecycleScopeProvider.from(this, Lifecycle.Event.ON_DESTROY))
+        .autoDispose(AndroidLifecycleScopeProvider.from(this, Lifecycle.Event.ON_DESTROY))
         .subscribeBy { num ->
           Log.i(TAG, "Started in onResume(), running until in onDestroy(): $num")
         }


### PR DESCRIPTION
Resolves #355 

I feel like we can keep the severity to be WARN for 1.4.0? That way the upgrade to 1.4.0 can be smooth while 2.0.0 can be where we break. 