### PR TITLE
Add AutoDisposeContext + withScope functions

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -15,6 +15,9 @@
  */
 package com.uber.autodispose;
 
+import static com.uber.autodispose.AutoDisposeUtil.checkNotNull;
+import static com.uber.autodispose.Scopes.completableOf;
+
 import io.reactivex.Completable;
 import io.reactivex.CompletableObserver;
 import io.reactivex.CompletableSource;
@@ -35,9 +38,6 @@ import io.reactivex.parallel.ParallelFlowable;
 import io.reactivex.subscribers.TestSubscriber;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-
-import static com.uber.autodispose.AutoDisposeUtil.checkNotNull;
-import static com.uber.autodispose.Scopes.completableOf;
 
 /**
  * Factories for autodispose converters that can be used with RxJava types' corresponding {@code

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -15,8 +15,6 @@
  */
 package com.uber.autodispose;
 
-import static com.uber.autodispose.AutoDisposeUtil.checkNotNull;
-
 import io.reactivex.Completable;
 import io.reactivex.CompletableObserver;
 import io.reactivex.CompletableSource;
@@ -37,6 +35,9 @@ import io.reactivex.parallel.ParallelFlowable;
 import io.reactivex.subscribers.TestSubscriber;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+
+import static com.uber.autodispose.AutoDisposeUtil.checkNotNull;
+import static com.uber.autodispose.Scopes.completableOf;
 
 /**
  * Factories for autodispose converters that can be used with RxJava types' corresponding {@code
@@ -78,22 +79,7 @@ public final class AutoDispose {
    */
   public static <T> AutoDisposeConverter<T> autoDisposable(final ScopeProvider provider) {
     checkNotNull(provider, "provider == null");
-    return autoDisposable(
-        Completable.defer(
-            () -> {
-              try {
-                return provider.requestScope();
-              } catch (OutsideScopeException e) {
-                Consumer<? super OutsideScopeException> handler =
-                    AutoDisposePlugins.getOutsideScopeHandler();
-                if (handler != null) {
-                  handler.accept(e);
-                  return Completable.complete();
-                } else {
-                  return Completable.error(e);
-                }
-              }
-            }));
+    return autoDisposable(completableOf(provider));
   }
 
   /**

--- a/autodispose/src/main/java/com/uber/autodispose/KotlinExtensions.kt
+++ b/autodispose/src/main/java/com/uber/autodispose/KotlinExtensions.kt
@@ -255,12 +255,12 @@ inline fun <T> ParallelFlowable<T>.autoDisposable(provider: ScopeProvider): Para
 inline fun <T> ParallelFlowable<T>.autoDispose(provider: ScopeProvider): ParallelFlowableSubscribeProxy<T> =
     this.`as`(AutoDispose.autoDisposable(provider))
 
-/** Executes a [body] with under an [AutoDisposeContext] backed by the given [scope]. */
+/** Executes a [body] with an [AutoDisposeContext] backed by the given [scope]. */
 fun withScope(scope: ScopeProvider, body: AutoDisposeContext.() -> Unit) {
   withScope(completableOf(scope), body)
 }
 
-/** Executes a [body] with under an [AutoDisposeContext] backed by the given [completableScope]. */
+/** Executes a [body] with an [AutoDisposeContext] backed by the given [completableScope]. */
 fun withScope(completableScope: Completable, body: AutoDisposeContext.() -> Unit) {
   val context = RealAutoDisposeContext(completableScope)
   context.body()

--- a/autodispose/src/main/java/com/uber/autodispose/KotlinExtensions.kt
+++ b/autodispose/src/main/java/com/uber/autodispose/KotlinExtensions.kt
@@ -18,6 +18,7 @@
 
 package com.uber.autodispose
 
+import com.uber.autodispose.Scopes.completableOf
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Maybe
@@ -253,3 +254,48 @@ inline fun <T> ParallelFlowable<T>.autoDisposable(provider: ScopeProvider): Para
 @CheckReturnValue
 inline fun <T> ParallelFlowable<T>.autoDispose(provider: ScopeProvider): ParallelFlowableSubscribeProxy<T> =
     this.`as`(AutoDispose.autoDisposable(provider))
+
+/** Executes a [body] with under an [AutoDisposeContext] backed by the given [scope]. */
+fun withScope(scope: ScopeProvider, body: AutoDisposeContext.() -> Unit) {
+  withScope(completableOf(scope), body)
+}
+
+/** Executes a [body] with under an [AutoDisposeContext] backed by the given [completableScope]. */
+fun withScope(completableScope: Completable, body: AutoDisposeContext.() -> Unit) {
+  val context = RealAutoDisposeContext(completableScope)
+  context.body()
+}
+
+/**
+ * A context intended for use as `AutoDisposeCoroutineScope.() -> Unit` function body parameters
+ * where zero-arg [autoDispose] functions can be called. This should be backed by an underlying
+ * [Completable] or [ScopeProvider].
+ */
+interface AutoDisposeContext {
+  /** Extension that proxies to the normal [autoDispose] extension function. */
+  fun <T> ParallelFlowable<T>.autoDispose(): ParallelFlowableSubscribeProxy<T>
+
+  /** Extension that proxies to the normal [autoDispose] extension function. */
+  fun <T> Flowable<T>.autoDispose(): FlowableSubscribeProxy<T>
+
+  /** Extension that proxies to the normal [autoDispose] extension function. */
+  fun <T> Observable<T>.autoDispose(): ObservableSubscribeProxy<T>
+
+  /** Extension that proxies to the normal [autoDispose] extension function. */
+  fun <T> Single<T>.autoDispose(): SingleSubscribeProxy<T>
+
+  /** Extension that proxies to the normal [autoDispose] extension function. */
+  fun <T> Maybe<T>.autoDispose(): MaybeSubscribeProxy<T>
+
+  /** Extension that proxies to the normal [autoDispose] extension function. */
+  fun Completable.autoDispose(): CompletableSubscribeProxy
+}
+
+private class RealAutoDisposeContext(private val scope: Completable) : AutoDisposeContext {
+  override fun <T> ParallelFlowable<T>.autoDispose() = autoDispose(scope)
+  override fun <T> Flowable<T>.autoDispose() = autoDispose(scope)
+  override fun <T> Observable<T>.autoDispose() = autoDispose(scope)
+  override fun <T> Single<T>.autoDispose() = autoDispose(scope)
+  override fun <T> Maybe<T>.autoDispose() = autoDispose(scope)
+  override fun Completable.autoDispose() = autoDispose(scope)
+}

--- a/autodispose/src/main/java/com/uber/autodispose/KotlinExtensions.kt
+++ b/autodispose/src/main/java/com/uber/autodispose/KotlinExtensions.kt
@@ -267,7 +267,7 @@ fun withScope(completableScope: Completable, body: AutoDisposeContext.() -> Unit
 }
 
 /**
- * A context intended for use as `AutoDisposeCoroutineScope.() -> Unit` function body parameters
+ * A context intended for use as `AutoDisposeContext.() -> Unit` function body parameters
  * where zero-arg [autoDispose] functions can be called. This should be backed by an underlying
  * [Completable] or [ScopeProvider].
  */

--- a/autodispose/src/main/java/com/uber/autodispose/Scopes.java
+++ b/autodispose/src/main/java/com/uber/autodispose/Scopes.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.autodispose;
+
+import io.reactivex.Completable;
+import io.reactivex.functions.Consumer;
+
+/** Utilities for dealing with AutoDispose scopes. */
+public final class Scopes {
+
+  private Scopes() {}
+
+  /**
+   * @return a {@link Completable} representation of the given {@code scopeProvider}. This will be
+   *     deferred appropriately and handle {@link OutsideScopeException OutsideScopeExceptions}.
+   */
+  public static Completable completableOf(ScopeProvider scopeProvider) {
+    return Completable.defer(
+        () -> {
+          try {
+            return scopeProvider.requestScope();
+          } catch (OutsideScopeException e) {
+            Consumer<? super OutsideScopeException> handler =
+                AutoDisposePlugins.getOutsideScopeHandler();
+            if (handler != null) {
+              handler.accept(e);
+              return Completable.complete();
+            } else {
+              return Completable.error(e);
+            }
+          }
+        });
+  }
+}


### PR DESCRIPTION
This allows for some more idiomatic kotlin usage like so:

```kotlin
withScope(sourceScope) {
  someObservable.autoDispose().subscribe()
}
```