### PR TITLE
Add API to fuse autodispose rx types and proxy interfaces

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDispose.java
@@ -103,12 +103,18 @@ public final class AutoDispose {
     return new AutoDisposeConverter<T>() {
       @Override
       public ParallelFlowableSubscribeProxy<T> apply(final ParallelFlowable<T> upstream) {
+        if (!AutoDisposePlugins.hideProxies) {
+          return new AutoDisposeParallelFlowable<>(upstream, scope);
+        }
         return subscribers ->
             new AutoDisposeParallelFlowable<>(upstream, scope).subscribe(subscribers);
       }
 
       @Override
       public CompletableSubscribeProxy apply(final Completable upstream) {
+        if (!AutoDisposePlugins.hideProxies) {
+          return new AutoDisposeCompletable(upstream, scope);
+        }
         return new CompletableSubscribeProxy() {
           @Override
           public Disposable subscribe() {
@@ -156,6 +162,9 @@ public final class AutoDispose {
 
       @Override
       public FlowableSubscribeProxy<T> apply(final Flowable<T> upstream) {
+        if (!AutoDisposePlugins.hideProxies) {
+          return new AutoDisposeFlowable<>(upstream, scope);
+        }
         return new FlowableSubscribeProxy<T>() {
           @Override
           public Disposable subscribe() {
@@ -228,6 +237,9 @@ public final class AutoDispose {
 
       @Override
       public MaybeSubscribeProxy<T> apply(final Maybe<T> upstream) {
+        if (!AutoDisposePlugins.hideProxies) {
+          return new AutoDisposeMaybe<>(upstream, scope);
+        }
         return new MaybeSubscribeProxy<T>() {
           @Override
           public Disposable subscribe() {
@@ -285,6 +297,9 @@ public final class AutoDispose {
 
       @Override
       public ObservableSubscribeProxy<T> apply(final Observable<T> upstream) {
+        if (!AutoDisposePlugins.hideProxies) {
+          return new AutoDisposeObservable<>(upstream, scope);
+        }
         return new ObservableSubscribeProxy<T>() {
           @Override
           public Disposable subscribe() {
@@ -350,6 +365,9 @@ public final class AutoDispose {
 
       @Override
       public SingleSubscribeProxy<T> apply(final Single<T> upstream) {
+        if (!AutoDisposePlugins.hideProxies) {
+          return new AutoDisposeSingle<>(upstream, scope);
+        }
         return new SingleSubscribeProxy<T>() {
           @Override
           public Disposable subscribe() {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposeCompletable.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposeCompletable.java
@@ -19,7 +19,7 @@ import io.reactivex.Completable;
 import io.reactivex.CompletableObserver;
 import io.reactivex.CompletableSource;
 
-final class AutoDisposeCompletable extends Completable {
+final class AutoDisposeCompletable extends Completable implements CompletableSubscribeProxy {
 
   private final Completable source;
   private final CompletableSource scope;

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposeFlowable.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposeFlowable.java
@@ -20,7 +20,7 @@ import io.reactivex.Flowable;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
-final class AutoDisposeFlowable<T> extends Flowable<T> {
+final class AutoDisposeFlowable<T> extends Flowable<T> implements FlowableSubscribeProxy<T> {
   private final Publisher<T> source;
   private final CompletableSource scope;
 

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposeMaybe.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposeMaybe.java
@@ -20,7 +20,7 @@ import io.reactivex.Maybe;
 import io.reactivex.MaybeObserver;
 import io.reactivex.MaybeSource;
 
-final class AutoDisposeMaybe<T> extends Maybe<T> {
+final class AutoDisposeMaybe<T> extends Maybe<T> implements MaybeSubscribeProxy<T> {
   private final MaybeSource<T> source;
   private final CompletableSource scope;
 

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposeObservable.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposeObservable.java
@@ -20,7 +20,7 @@ import io.reactivex.Observable;
 import io.reactivex.ObservableSource;
 import io.reactivex.Observer;
 
-final class AutoDisposeObservable<T> extends Observable<T> {
+final class AutoDisposeObservable<T> extends Observable<T> implements ObservableSubscribeProxy<T> {
   private final ObservableSource<T> source;
   private final CompletableSource scope;
 

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposeParallelFlowable.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposeParallelFlowable.java
@@ -19,7 +19,8 @@ import io.reactivex.CompletableSource;
 import io.reactivex.parallel.ParallelFlowable;
 import org.reactivestreams.Subscriber;
 
-final class AutoDisposeParallelFlowable<T> extends ParallelFlowable<T> {
+final class AutoDisposeParallelFlowable<T> extends ParallelFlowable<T>
+    implements ParallelFlowableSubscribeProxy<T>{
 
   private final ParallelFlowable<T> source;
   private final CompletableSource scope;

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposeParallelFlowable.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposeParallelFlowable.java
@@ -20,7 +20,7 @@ import io.reactivex.parallel.ParallelFlowable;
 import org.reactivestreams.Subscriber;
 
 final class AutoDisposeParallelFlowable<T> extends ParallelFlowable<T>
-    implements ParallelFlowableSubscribeProxy<T>{
+    implements ParallelFlowableSubscribeProxy<T> {
 
   private final ParallelFlowable<T> source;
   private final CompletableSource scope;

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
@@ -93,9 +93,9 @@ public final class AutoDisposePlugins {
   }
 
   /**
-   * @param hideProxies {@code true} hide proxy interfaces. This wraps all proxy interfaces
-   *     in {@link com.uber.autodispose} at runtime in an anonymous instance to prevent
-   *     introspection, similar to {@link Observable#hide()}. The default is {@code true}.
+   * @param hideProxies {@code true} hide proxy interfaces. This wraps all proxy interfaces in
+   *     {@link com.uber.autodispose} at runtime in an anonymous instance to prevent introspection,
+   *     similar to {@link Observable#hide()}. The default is {@code true}.
    */
   public static void setHideProxies(boolean hideProxies) {
     if (lockdown) {

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
@@ -25,7 +25,7 @@ public final class AutoDisposePlugins {
   private AutoDisposePlugins() {}
 
   @Nullable private static volatile Consumer<? super OutsideScopeException> outsideScopeHandler;
-  private static volatile boolean fillInOutsideScopeExceptionStacktraces;
+  static volatile boolean fillInOutsideScopeExceptionStacktraces;
   static volatile boolean hideProxies = true;
 
   /** Prevents changing the plugins. */

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposePlugins.java
@@ -15,6 +15,7 @@
  */
 package com.uber.autodispose;
 
+import io.reactivex.Observable;
 import io.reactivex.annotations.Nullable;
 import io.reactivex.functions.Consumer;
 
@@ -25,6 +26,7 @@ public final class AutoDisposePlugins {
 
   @Nullable private static volatile Consumer<? super OutsideScopeException> outsideScopeHandler;
   private static volatile boolean fillInOutsideScopeExceptionStacktraces;
+  static volatile boolean hideProxies = true;
 
   /** Prevents changing the plugins. */
   static volatile boolean lockdown;
@@ -45,6 +47,14 @@ public final class AutoDisposePlugins {
    */
   public static boolean isLockdown() {
     return lockdown;
+  }
+
+  /**
+   * @return the value indicating whether or not to hide proxy interfaces.
+   * @see #setHideProxies(boolean)
+   */
+  public static boolean getHideProxies() {
+    return hideProxies;
   }
 
   /**
@@ -80,6 +90,18 @@ public final class AutoDisposePlugins {
       throw new IllegalStateException("Plugins can't be changed anymore");
     }
     fillInOutsideScopeExceptionStacktraces = fillInStacktrace;
+  }
+
+  /**
+   * @param hideProxies {@code true} hide proxy interfaces. This wraps all proxy interfaces
+   *     in {@link com.uber.autodispose} at runtime in an anonymous instance to prevent
+   *     introspection, similar to {@link Observable#hide()}. The default is {@code true}.
+   */
+  public static void setHideProxies(boolean hideProxies) {
+    if (lockdown) {
+      throw new IllegalStateException("Plugins can't be changed anymore");
+    }
+    AutoDisposePlugins.hideProxies = hideProxies;
   }
 
   /** Removes all handlers and resets to default behavior. */

--- a/autodispose/src/main/java/com/uber/autodispose/AutoDisposeSingle.java
+++ b/autodispose/src/main/java/com/uber/autodispose/AutoDisposeSingle.java
@@ -20,7 +20,7 @@ import io.reactivex.Single;
 import io.reactivex.SingleObserver;
 import io.reactivex.SingleSource;
 
-final class AutoDisposeSingle<T> extends Single<T> {
+final class AutoDisposeSingle<T> extends Single<T> implements SingleSubscribeProxy<T> {
   private final SingleSource<T> source;
   private final CompletableSource scope;
 

--- a/autodispose/src/main/java/com/uber/autodispose/OutsideScopeException.java
+++ b/autodispose/src/main/java/com/uber/autodispose/OutsideScopeException.java
@@ -24,7 +24,7 @@ public class OutsideScopeException extends RuntimeException {
 
   @Override
   public final synchronized Throwable fillInStackTrace() {
-    if (AutoDisposePlugins.getFillInOutsideScopeExceptionStacktraces()) {
+    if (AutoDisposePlugins.fillInOutsideScopeExceptionStacktraces) {
       return super.fillInStackTrace();
     } else {
       return this;

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeCompletableObserverTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class AutoDisposeCompletableObserverTest {
+public class AutoDisposeCompletableObserverTest extends PluginsMatrixTest {
 
   private static final RecordingObserver.Logger LOGGER =
       message ->
@@ -41,6 +41,10 @@ public class AutoDisposeCompletableObserverTest {
               AutoDisposeCompletableObserverTest.class.getSimpleName() + ": " + message);
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
+
+  public AutoDisposeCompletableObserverTest(boolean hideProxies) {
+    super(hideProxies);
+  }
 
   @Test
   public void autoDispose_withMaybe_normal() {
@@ -226,5 +230,16 @@ public class AutoDisposeCompletableObserverTest {
         throwable ->
             throwable instanceof IllegalStateException
                 && throwable.getCause() instanceof OutsideScopeException);
+  }
+
+  @Test
+  public void hideProxies() {
+    CompletableSubscribeProxy proxy = Completable.never().as(autoDisposable(ScopeProvider.UNBOUND));
+    // If hideProxies is disabled, the underlying return should be the direct AutoDispose type.
+    if (hideProxies) {
+      assertThat(proxy).isNotInstanceOf(Completable.class);
+    } else {
+      assertThat(proxy).isInstanceOf(AutoDisposeCompletable.class);
+    }
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeMaybeObserverTest.java
@@ -35,13 +35,17 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class AutoDisposeMaybeObserverTest {
+public class AutoDisposeMaybeObserverTest extends PluginsMatrixTest {
 
   private static final RecordingObserver.Logger LOGGER =
       message ->
           System.out.println(AutoDisposeMaybeObserverTest.class.getSimpleName() + ": " + message);
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
+
+  public AutoDisposeMaybeObserverTest(boolean hideProxies) {
+    super(hideProxies);
+  }
 
   @Test
   public void autoDispose_withMaybe_normal() {
@@ -251,5 +255,16 @@ public class AutoDisposeMaybeObserverTest {
         throwable ->
             throwable instanceof IllegalStateException
                 && throwable.getCause() instanceof OutsideScopeException);
+  }
+
+  @Test
+  public void hideProxies() {
+    MaybeSubscribeProxy proxy = Maybe.never().as(autoDisposable(ScopeProvider.UNBOUND));
+    // If hideProxies is disabled, the underlying return should be the direct AutoDispose type.
+    if (hideProxies) {
+      assertThat(proxy).isNotInstanceOf(Maybe.class);
+    } else {
+      assertThat(proxy).isInstanceOf(AutoDisposeMaybe.class);
+    }
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeObserverTest.java
@@ -36,12 +36,16 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class AutoDisposeObserverTest {
+public class AutoDisposeObserverTest extends PluginsMatrixTest {
 
   private static final RecordingObserver.Logger LOGGER =
       message -> System.out.println(AutoDisposeObserverTest.class.getSimpleName() + ": " + message);
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
+
+  public AutoDisposeObserverTest(boolean hideProxies) {
+    super(hideProxies);
+  }
 
   @Test
   public void autoDispose_withMaybe_normal() {
@@ -226,5 +230,16 @@ public class AutoDisposeObserverTest {
         throwable ->
             throwable instanceof IllegalStateException
                 && throwable.getCause() instanceof OutsideScopeException);
+  }
+
+  @Test
+  public void hideProxies() {
+    ObservableSubscribeProxy proxy = Observable.never().as(autoDisposable(ScopeProvider.UNBOUND));
+    // If hideProxies is disabled, the underlying return should be the direct AutoDispose type.
+    if (hideProxies) {
+      assertThat(proxy).isNotInstanceOf(Observable.class);
+    } else {
+      assertThat(proxy).isInstanceOf(AutoDisposeObservable.class);
+    }
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeParallelFlowableTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeParallelFlowableTest.java
@@ -20,6 +20,7 @@ import static com.uber.autodispose.AutoDispose.autoDisposable;
 
 import com.uber.autodispose.test.RxErrorsRule;
 import io.reactivex.Flowable;
+import io.reactivex.parallel.ParallelFlowable;
 import io.reactivex.processors.PublishProcessor;
 import io.reactivex.subjects.CompletableSubject;
 import io.reactivex.subscribers.TestSubscriber;
@@ -28,11 +29,15 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
-public class AutoDisposeParallelFlowableTest {
+public class AutoDisposeParallelFlowableTest extends PluginsMatrixTest {
 
   private static final int DEFAULT_PARALLELISM = 2;
 
   @Rule public final RxErrorsRule rule = new RxErrorsRule();
+
+  public AutoDisposeParallelFlowableTest(boolean hideProxies) {
+    super(hideProxies);
+  }
 
   @Test
   public void ifParallelism_and_subscribersCount_dontMatch_shouldFail() {
@@ -190,5 +195,17 @@ public class AutoDisposeParallelFlowableTest {
     secondSubscriber.assertValue(2);
     firstSubscriber.dispose();
     secondSubscriber.dispose();
+  }
+
+  @Test
+  public void hideProxies() {
+    ParallelFlowableSubscribeProxy proxy =
+        Flowable.never().parallel().as(autoDisposable(ScopeProvider.UNBOUND));
+    // If hideProxies is disabled, the underlying return should be the direct AutoDispose type.
+    if (hideProxies) {
+      assertThat(proxy).isNotInstanceOf(ParallelFlowable.class);
+    } else {
+      assertThat(proxy).isInstanceOf(AutoDisposeParallelFlowable.class);
+    }
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSingleObserverTest.java
@@ -35,13 +35,17 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class AutoDisposeSingleObserverTest {
+public class AutoDisposeSingleObserverTest extends PluginsMatrixTest {
 
   private static final RecordingObserver.Logger LOGGER =
       message ->
           System.out.println(AutoDisposeSingleObserverTest.class.getSimpleName() + ": " + message);
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
+
+  public AutoDisposeSingleObserverTest(boolean hideProxies) {
+    super(hideProxies);
+  }
 
   @Test
   public void autoDispose_withMaybe_normal() {
@@ -230,5 +234,16 @@ public class AutoDisposeSingleObserverTest {
         throwable ->
             throwable instanceof IllegalStateException
                 && throwable.getCause() instanceof OutsideScopeException);
+  }
+
+  @Test
+  public void hideProxies() {
+    SingleSubscribeProxy proxy = Single.never().as(autoDisposable(ScopeProvider.UNBOUND));
+    // If hideProxies is disabled, the underlying return should be the direct AutoDispose type.
+    if (hideProxies) {
+      assertThat(proxy).isNotInstanceOf(Single.class);
+    } else {
+      assertThat(proxy).isInstanceOf(AutoDisposeSingle.class);
+    }
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/AutoDisposeSubscriberTest.java
@@ -36,9 +36,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
 
-public class AutoDisposeSubscriberTest {
+public class AutoDisposeSubscriberTest extends PluginsMatrixTest {
 
   @Rule public RxErrorsRule rule = new RxErrorsRule();
+
+  public AutoDisposeSubscriberTest(boolean hideProxies) {
+    super(hideProxies);
+  }
 
   @Test
   public void autoDispose_withMaybe_normal() {
@@ -234,5 +238,16 @@ public class AutoDisposeSubscriberTest {
         throwable ->
             throwable instanceof IllegalStateException
                 && throwable.getCause() instanceof OutsideScopeException);
+  }
+
+  @Test
+  public void hideProxies() {
+    FlowableSubscribeProxy proxy = Flowable.never().as(autoDisposable(ScopeProvider.UNBOUND));
+    // If hideProxies is disabled, the underlying return should be the direct AutoDispose type.
+    if (hideProxies) {
+      assertThat(proxy).isNotInstanceOf(Flowable.class);
+    } else {
+      assertThat(proxy).isInstanceOf(AutoDisposeFlowable.class);
+    }
   }
 }

--- a/autodispose/src/test/java/com/uber/autodispose/PluginsMatrixTest.java
+++ b/autodispose/src/test/java/com/uber/autodispose/PluginsMatrixTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.autodispose;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public abstract class PluginsMatrixTest {
+
+  @Parameterized.Parameters
+  public static Collection primeNumbers() {
+    return Arrays.asList(new Object[][] {{true}, {false}});
+  }
+
+  protected final boolean hideProxies;
+
+  public PluginsMatrixTest(boolean hideProxies) {
+    this.hideProxies = hideProxies;
+  }
+
+  @Before
+  public void setUp() {
+    AutoDisposePlugins.setHideProxies(hideProxies);
+  }
+
+  @After
+  public void tearDown() {
+    AutoDisposePlugins.reset();
+  }
+}


### PR DESCRIPTION
Right now, AutoDispose will always create anonymous instances of *Proxy interfaces that that call through to underlying custom rx types (e.g. AutoDisposeObservable) that have the custom observer implementations. This was done defensively to prevent introspection and is similar to APIs like `Observable.hide()`, but does come at the cost of an extra allocation + virtual invocations at runtime.

We can save this allocation at the cost of the hiding behavior by just making the custom rx types implement their corresponding proxy interface and returning them directly. This is easy in code because they have matching subscribe signatures.

This PR adds a new plugin to control this hiding behavior via `AutoDisposePlugins#setHideProxies()`. The default is `true`, matching current behavior. If set to false, the rx types will be returned directly and unhidden (though casted as the proxy interface). This can be useful for those wanting to squeeze a little bit of extra juice at runtime.