### PR TITLE
Support withScope() in AutoDisposeDetector

### DIFF
--- a/autodispose/src/main/java/com/uber/autodispose/KotlinExtensions.kt
+++ b/autodispose/src/main/java/com/uber/autodispose/KotlinExtensions.kt
@@ -256,12 +256,12 @@ inline fun <T> ParallelFlowable<T>.autoDispose(provider: ScopeProvider): Paralle
     this.`as`(AutoDispose.autoDisposable(provider))
 
 /** Executes a [body] with an [AutoDisposeContext] backed by the given [scope]. */
-fun withScope(scope: ScopeProvider, body: AutoDisposeContext.() -> Unit) {
+inline fun withScope(scope: ScopeProvider, body: AutoDisposeContext.() -> Unit) {
   withScope(completableOf(scope), body)
 }
 
 /** Executes a [body] with an [AutoDisposeContext] backed by the given [completableScope]. */
-fun withScope(completableScope: Completable, body: AutoDisposeContext.() -> Unit) {
+inline fun withScope(completableScope: Completable, body: AutoDisposeContext.() -> Unit) {
   val context = RealAutoDisposeContext(completableScope)
   context.body()
 }
@@ -291,7 +291,8 @@ interface AutoDisposeContext {
   fun Completable.autoDispose(): CompletableSubscribeProxy
 }
 
-private class RealAutoDisposeContext(private val scope: Completable) : AutoDisposeContext {
+@PublishedApi
+internal class RealAutoDisposeContext(private val scope: Completable) : AutoDisposeContext {
   override fun <T> ParallelFlowable<T>.autoDispose() = autoDispose(scope)
   override fun <T> Flowable<T>.autoDispose() = autoDispose(scope)
   override fun <T> Observable<T>.autoDispose() = autoDispose(scope)

--- a/static-analysis/autodispose-lint/src/main/kotlin/com/uber/autodispose/lint/AutoDisposeDetector.kt
+++ b/static-analysis/autodispose-lint/src/main/kotlin/com/uber/autodispose/lint/AutoDisposeDetector.kt
@@ -188,19 +188,19 @@ class AutoDisposeDetector : Detector(), SourceCodeScanner {
   }
 
   private fun callExpressionChecker(
-      context: JavaContext,
-      node: UCallExpression,
-      method: PsiMethod,
-      isInScope: (JavaEvaluator, UCallExpression) -> Boolean
+    context: JavaContext,
+    node: UCallExpression,
+    method: PsiMethod,
+    isInScope: (JavaEvaluator, UCallExpression) -> Boolean
   ) {
     evaluateMethodCall(node, method, context, isInScope)
   }
 
   private fun callableReferenceChecker(
-      context: JavaContext,
-      node: UCallableReferenceExpression,
-      method: PsiMethod,
-      isInScope: (JavaEvaluator, UCallExpression) -> Boolean
+    context: JavaContext,
+    node: UCallableReferenceExpression,
+    method: PsiMethod,
+    isInScope: (JavaEvaluator, UCallExpression) -> Boolean
   ) {
     // Check if the resolved call reference is method and check that it's invocation is a
     // call expression so that we can get it's return type etc.
@@ -210,9 +210,9 @@ class AutoDisposeDetector : Detector(), SourceCodeScanner {
   }
 
   private class SubscribeCallVisitor(
-      private val context: JavaContext,
-      private val callExpressionChecker: (JavaContext, UCallExpression, PsiMethod) -> Unit,
-      private val callableReferenceChecker: (JavaContext, UCallableReferenceExpression, PsiMethod) -> Unit
+    private val context: JavaContext,
+    private val callExpressionChecker: (JavaContext, UCallExpression, PsiMethod) -> Unit,
+    private val callableReferenceChecker: (JavaContext, UCallableReferenceExpression, PsiMethod) -> Unit
   ) : AbstractUastVisitor() {
 
     override fun visitCallExpression(node: UCallExpression): Boolean {
@@ -287,10 +287,10 @@ class AutoDisposeDetector : Detector(), SourceCodeScanner {
    * @param context project context.
    */
   private fun evaluateMethodCall(
-      node: UCallExpression,
-      method: PsiMethod,
-      context: JavaContext,
-      isInScope: (JavaEvaluator, UCallExpression) -> Boolean
+    node: UCallExpression,
+    method: PsiMethod,
+    context: JavaContext,
+    isInScope: (JavaEvaluator, UCallExpression) -> Boolean
   ) {
     if (!getApplicableMethodNames().contains(method.name)) return
     val evaluator = context.evaluator

--- a/static-analysis/autodispose-lint/src/test/kotlin/com/uber/autodispose/lint/AutoDisposeDetectorTest.kt
+++ b/static-analysis/autodispose-lint/src/test/kotlin/com/uber/autodispose/lint/AutoDisposeDetectorTest.kt
@@ -82,7 +82,7 @@ class AutoDisposeDetectorTest {
         """
           @file:JvmName("KotlinExtensions")
           package com.uber.autodispose
-          
+
           fun withScope(scope: ScopeProvider, body: AutoDisposeContext.() -> Unit) {
           }
         """).indented().within("src/")
@@ -92,9 +92,9 @@ class AutoDisposeDetectorTest {
         """
           @file:JvmName("KotlinExtensions")
           package com.uber.autodispose
-          
+
           import io.reactivex.Completable
-          
+
           fun withScope(scope: Completable, body: AutoDisposeContext.() -> Unit) {
           }
         """).indented().within("src/")


### PR DESCRIPTION
This adds support for the new `withScope()` API in `AutoDisposeDetector`. This works by detecting when that function is called, and then visits the contents of the lambda argument passed to it with the same machinery we used before. This refactors out that machinery a bit to allow defining a custom "isInScope" check, and in the case of `withScope()` it's just hardcoded to `true` when it checks if an enclosed subscribe() call is made in a scope