### PR TITLE
Downgrade Gradle wrapper to 5.6.4

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Downgrades Gradle to the latest 5.x release.

Fixes #400