### PR TITLE
Android ViewModel ScopeProvider created

### DIFF
--- a/android/autodispose-androidx-lifecycle/build.gradle
+++ b/android/autodispose-androidx-lifecycle/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 
   implementation project(':android:autodispose-android')
   implementation deps.rx.android
+  implementation deps.androidx.lifecycle.ktx
 
   lintPublish project(':static-analysis:autodispose-lint')
 

--- a/android/autodispose-androidx-lifecycle/src/main/java/autodispose2/androidx/lifecycle/AndroidViewModelScopeProvider.kt
+++ b/android/autodispose-androidx-lifecycle/src/main/java/autodispose2/androidx/lifecycle/AndroidViewModelScopeProvider.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package autodispose2.androidx.lifecycle
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import autodispose2.ScopeProvider
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.core.CompletableSource
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
+
+class AndroidViewModelScopeProvider(private val viewModel: ViewModel) : ScopeProvider {
+
+  override fun requestScope(): CompletableSource = Completable.create { emitter ->
+    with(viewModel.viewModelScope) {
+      if (isActive) {
+        coroutineContext[Job]?.invokeOnCompletion {
+          emitter.onComplete()
+        } ?: emitter.tryOnError(IllegalStateException("coroutineContext doesn't contain Job"))
+      } else {
+        emitter.onComplete()
+      }
+    }
+  }
+}

--- a/android/autodispose-androidx-lifecycle/src/main/java/autodispose2/androidx/lifecycle/KotlinExtensions.kt
+++ b/android/autodispose-androidx-lifecycle/src/main/java/autodispose2/androidx/lifecycle/KotlinExtensions.kt
@@ -20,6 +20,7 @@ package autodispose2.androidx.lifecycle
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Lifecycle.Event
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModel
 import autodispose2.AutoDispose
 import autodispose2.CompletableSubscribeProxy
 import autodispose2.FlowableSubscribeProxy
@@ -207,3 +208,5 @@ inline fun <T> ParallelFlowable<T>.autoDispose(lifecycleOwner: LifecycleOwner, u
             untilEvent)))
   }
 }
+
+val ViewModel.viewModelScope: ScopeProvider get() = AndroidViewModelScopeProvider(this)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,7 +17,7 @@
 def versions = [
     androidTest: '1.3.0-alpha02',
     animalSniffer: '1.5.0',
-    androidxLifecycle: '2.1.0',
+    androidxLifecycle: '2.2.0',
     dokka: '0.9.18',
     errorProne: '2.3.3',
     errorPronePlugin: '0.7.1',
@@ -81,7 +81,8 @@ def androidx = [
     lifecycle: [
         compiler: "androidx.lifecycle:lifecycle-compiler:${versions.androidxLifecycle}",
         common: "androidx.lifecycle:lifecycle-common:${versions.androidxLifecycle}",
-        runtime: "androidx.lifecycle:lifecycle-runtime:${versions.androidxLifecycle}"
+        runtime: "androidx.lifecycle:lifecycle-runtime:${versions.androidxLifecycle}",
+        ktx: "androidx.lifecycle:lifecycle-viewmodel-ktx:${versions.androidxLifecycle}"
     ]
 ]
 

--- a/sample/src/main/kotlin/autodispose2/sample/DisposingViewModel.kt
+++ b/sample/src/main/kotlin/autodispose2/sample/DisposingViewModel.kt
@@ -18,8 +18,8 @@ package autodispose2.sample
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import autodispose2.androidx.lifecycle.viewModelScope
 import autodispose2.autoDispose
-import autodispose2.recipes.AutoDisposeViewModel
 import autodispose2.sample.repository.NetworkRepository
 import autodispose2.sample.state.DownloadState
 import com.jakewharton.rxrelay2.BehaviorRelay
@@ -28,7 +28,7 @@ import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.schedulers.Schedulers
 
 /**
- * Demo AutoDisposing ViewModel.
+ * Demo autoDispose in ViewModel.
  *
  * This ViewModel will subscribe to Rx streams for you and pass along
  * the values through the [viewRelay].
@@ -47,9 +47,9 @@ import io.reactivex.rxjava3.schedulers.Schedulers
  * updated value.
  *
  * AutoDispose will automatically dispose any pending subscriptions when
- * the [onCleared] method is called since it extends from [AutoDisposeViewModel].
+ * the [onCleared] method is called.
  */
-class DisposingViewModel(private val repository: NetworkRepository) : AutoDisposeViewModel() {
+class DisposingViewModel(private val repository: NetworkRepository) : ViewModel() {
 
   /**
    * The relay to communicate state to the UI.
@@ -82,7 +82,7 @@ class DisposingViewModel(private val repository: NetworkRepository) : AutoDispos
     repository.downloadProgress()
         .subscribeOn(Schedulers.io())
         .doOnDispose { Log.i(TAG, "Disposing subscription from the ViewModel") }
-        .autoDispose(this)
+        .autoDispose(viewModelScope)
         .subscribe({ progress ->
           viewRelay.accept(DownloadState.InProgress(progress))
         }, { error ->


### PR DESCRIPTION
**Description**:
I found very convenient to use autoDispose() on a ViewModel without extending it from the AutoDisposeViewModel. 
So, I propose the next idea:
  1. Do not force the user to extend AutoDisposeViewModel
  2. Make it possible to work with direct ViewModel children

The implementation of idea is new ScopeProvider creation. Such a ScopeProvider binds to the ViewModel's lifecycle (in general meaning). The binding is done with the support of the Kotlin Coroutine Scope for ViewModel, which is provided as extension property ViewModel.viewModelScope in the androidx.lifecycle:lifecycle-viewmodel-ktx library.

If you find this idea is interesting too, feel free to tell me what is missing in my PR.
