### PR TITLE
Deprecate TestLifecycleOwner 

### DIFF
--- a/android/autodispose-androidx-lifecycle-test/Module.md
+++ b/android/autodispose-androidx-lifecycle-test/Module.md
@@ -1,3 +1,3 @@
 # Module autodispose-androidx-lifecycle-test
 
-Test helpers for `autodispose-androidx-lifecycle` support.
+DEPRECATED

--- a/android/autodispose-androidx-lifecycle-test/src/main/java/autodispose2/androidx/lifecycle/test/KotlinExtensions.kt
+++ b/android/autodispose-androidx-lifecycle-test/src/main/java/autodispose2/androidx/lifecycle/test/KotlinExtensions.kt
@@ -26,4 +26,5 @@ import io.reactivex.rxjava3.annotations.CheckReturnValue
  */
 @SuppressLint("RestrictedApi")
 @CheckReturnValue
+@Deprecated("Switch to androidx.lifecycle.testing.TestLifecycleOwner")
 inline fun LifecycleRegistry.test(): TestLifecycleOwner = TestLifecycleOwner.create(this)

--- a/android/autodispose-androidx-lifecycle-test/src/main/java/autodispose2/androidx/lifecycle/test/TestLifecycleOwner.java
+++ b/android/autodispose-androidx-lifecycle-test/src/main/java/autodispose2/androidx/lifecycle/test/TestLifecycleOwner.java
@@ -26,7 +26,10 @@ import androidx.lifecycle.LifecycleRegistry;
 /**
  * A test {@link LifecycleOwner} implementation for testing. You can either back it with your own
  * instance or just stub it in place and use its public emit() API.
+ *
+ * @deprecated Switch to androidx.lifecycle.testing.TestLifecycleOwner
  */
+@Deprecated
 @RestrictTo(TESTS)
 public final class TestLifecycleOwner implements LifecycleOwner {
 

--- a/android/autodispose-androidx-lifecycle/build.gradle
+++ b/android/autodispose-androidx-lifecycle/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
   androidTestImplementation project(':android:autodispose-androidx-lifecycle-test')
   androidTestImplementation project(':test-utils')
+  androidTestImplementation deps.androidx.lifecycle.runtimeTest
   androidTestImplementation deps.test.androidExtJunit
   androidTestImplementation deps.test.androidRunner
   androidTestImplementation deps.test.androidRules

--- a/android/autodispose-androidx-lifecycle/src/androidTest/java/autodispose2/androidx/lifecycle/AndroidLifecycleScopeProviderTest.java
+++ b/android/autodispose-androidx-lifecycle/src/androidTest/java/autodispose2/androidx/lifecycle/AndroidLifecycleScopeProviderTest.java
@@ -23,7 +23,7 @@ import androidx.lifecycle.Lifecycle;
 import androidx.test.annotation.UiThreadTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
-import autodispose2.androidx.lifecycle.test.TestLifecycleOwner;
+import androidx.lifecycle.testing.TestLifecycleOwner;
 import autodispose2.lifecycle.LifecycleEndedException;
 import autodispose2.test.RecordingObserver;
 import io.reactivex.rxjava3.disposables.Disposable;
@@ -44,11 +44,11 @@ public final class AndroidLifecycleScopeProviderTest {
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
     subject.to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle))).subscribe(o);
-    lifecycle.emit(Lifecycle.Event.ON_CREATE);
-    lifecycle.emit(Lifecycle.Event.ON_START);
-    lifecycle.emit(Lifecycle.Event.ON_RESUME);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
 
     o.takeSubscribe();
     o.assertNoMoreEvents(); // No initial value.
@@ -59,9 +59,9 @@ public final class AndroidLifecycleScopeProviderTest {
     subject.onNext(1);
     assertThat(o.takeNext()).isEqualTo(1);
 
-    lifecycle.emit(Lifecycle.Event.ON_PAUSE);
-    lifecycle.emit(Lifecycle.Event.ON_STOP);
-    lifecycle.emit(Lifecycle.Event.ON_DESTROY);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
 
     subject.onNext(2);
     o.assertNoMoreEvents();
@@ -74,11 +74,11 @@ public final class AndroidLifecycleScopeProviderTest {
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
-    lifecycle.emit(Lifecycle.Event.ON_CREATE);
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
     subject.to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle))).subscribe(o);
-    lifecycle.emit(Lifecycle.Event.ON_START);
-    lifecycle.emit(Lifecycle.Event.ON_RESUME);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
 
     o.takeSubscribe();
     o.assertNoMoreEvents(); // No initial value.
@@ -89,9 +89,9 @@ public final class AndroidLifecycleScopeProviderTest {
     subject.onNext(1);
     assertThat(o.takeNext()).isEqualTo(1);
 
-    lifecycle.emit(Lifecycle.Event.ON_PAUSE);
-    lifecycle.emit(Lifecycle.Event.ON_STOP);
-    lifecycle.emit(Lifecycle.Event.ON_DESTROY);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
 
     subject.onNext(2);
     o.assertNoMoreEvents();
@@ -104,11 +104,11 @@ public final class AndroidLifecycleScopeProviderTest {
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
-    lifecycle.emit(Lifecycle.Event.ON_CREATE);
-    lifecycle.emit(Lifecycle.Event.ON_START);
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
     subject.to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle))).subscribe(o);
-    lifecycle.emit(Lifecycle.Event.ON_RESUME);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
 
     o.takeSubscribe();
     o.assertNoMoreEvents(); // No initial value.
@@ -119,14 +119,14 @@ public final class AndroidLifecycleScopeProviderTest {
     subject.onNext(1);
     assertThat(o.takeNext()).isEqualTo(1);
 
-    lifecycle.emit(Lifecycle.Event.ON_PAUSE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
 
     // We should stop here
-    lifecycle.emit(Lifecycle.Event.ON_STOP);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
     subject.onNext(2);
     o.assertNoMoreEvents();
 
-    lifecycle.emit(Lifecycle.Event.ON_DESTROY);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
   }
 
   @Test
@@ -136,10 +136,10 @@ public final class AndroidLifecycleScopeProviderTest {
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
-    lifecycle.emit(Lifecycle.Event.ON_CREATE);
-    lifecycle.emit(Lifecycle.Event.ON_START);
-    lifecycle.emit(Lifecycle.Event.ON_RESUME);
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
     subject.to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle))).subscribe(o);
 
     o.takeSubscribe();
@@ -152,12 +152,12 @@ public final class AndroidLifecycleScopeProviderTest {
     assertThat(o.takeNext()).isEqualTo(1);
 
     // We should stop here
-    lifecycle.emit(Lifecycle.Event.ON_PAUSE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
     subject.onNext(2);
     o.assertNoMoreEvents();
 
-    lifecycle.emit(Lifecycle.Event.ON_STOP);
-    lifecycle.emit(Lifecycle.Event.ON_DESTROY);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
   }
 
   @Test
@@ -167,13 +167,13 @@ public final class AndroidLifecycleScopeProviderTest {
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
-    lifecycle.emit(Lifecycle.Event.ON_CREATE);
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
     subject
         .to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle, Lifecycle.Event.ON_PAUSE)))
         .subscribe(o);
-    lifecycle.emit(Lifecycle.Event.ON_START);
-    lifecycle.emit(Lifecycle.Event.ON_RESUME);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
 
     o.takeSubscribe();
     o.assertNoMoreEvents(); // No initial value.
@@ -185,12 +185,12 @@ public final class AndroidLifecycleScopeProviderTest {
     assertThat(o.takeNext()).isEqualTo(1);
 
     // We should stop here
-    lifecycle.emit(Lifecycle.Event.ON_PAUSE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
     subject.onNext(2);
     o.assertNoMoreEvents();
 
-    lifecycle.emit(Lifecycle.Event.ON_STOP);
-    lifecycle.emit(Lifecycle.Event.ON_DESTROY);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
   }
 
   @Test
@@ -200,10 +200,10 @@ public final class AndroidLifecycleScopeProviderTest {
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
-    lifecycle.emit(Lifecycle.Event.ON_CREATE);
-    lifecycle.emit(Lifecycle.Event.ON_START);
-    lifecycle.emit(Lifecycle.Event.ON_RESUME);
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
     subject
         .to(
             autoDisposable(
@@ -219,14 +219,14 @@ public final class AndroidLifecycleScopeProviderTest {
     subject.onNext(1);
     assertThat(o.takeNext()).isEqualTo(1);
 
-    lifecycle.emit(Lifecycle.Event.ON_PAUSE);
-    lifecycle.emit(Lifecycle.Event.ON_STOP);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
 
     subject.onNext(2);
     assertThat(o.takeNext()).isEqualTo(2);
 
     // We should stop here
-    lifecycle.emit(Lifecycle.Event.ON_DESTROY);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
     subject.onNext(3);
     o.assertNoMoreEvents();
   }
@@ -237,11 +237,11 @@ public final class AndroidLifecycleScopeProviderTest {
     final RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     final PublishSubject<Integer> subject = PublishSubject.create();
 
-    TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
-    lifecycle.emit(Lifecycle.Event.ON_CREATE);
-    lifecycle.emit(Lifecycle.Event.ON_START);
-    lifecycle.emit(Lifecycle.Event.ON_RESUME);
-    lifecycle.emit(Lifecycle.Event.ON_PAUSE);
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
     subject.to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle))).subscribe(o);
 
     o.takeSubscribe();
@@ -250,12 +250,12 @@ public final class AndroidLifecycleScopeProviderTest {
     assertThat(o.takeNext()).isEqualTo(2);
 
     // We could resume again
-    lifecycle.emit(Lifecycle.Event.ON_RESUME);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
     subject.onNext(3);
     assertThat(o.takeNext()).isEqualTo(3);
 
     // We should stop here
-    lifecycle.emit(Lifecycle.Event.ON_STOP);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
     subject.onNext(3);
     o.assertNoMoreEvents();
   }
@@ -266,12 +266,12 @@ public final class AndroidLifecycleScopeProviderTest {
     final RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     final PublishSubject<Integer> subject = PublishSubject.create();
 
-    TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
-    lifecycle.emit(Lifecycle.Event.ON_CREATE);
-    lifecycle.emit(Lifecycle.Event.ON_START);
-    lifecycle.emit(Lifecycle.Event.ON_RESUME);
-    lifecycle.emit(Lifecycle.Event.ON_PAUSE);
-    lifecycle.emit(Lifecycle.Event.ON_STOP);
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
     // In a CREATED state now but the next event will be destroy
     // This simulates subscribing in fragments' onDestroyView, where we want the subscription to
     // still dispose properly in onDestroy.
@@ -283,7 +283,7 @@ public final class AndroidLifecycleScopeProviderTest {
     assertThat(o.takeNext()).isEqualTo(2);
 
     // We should stop here
-    lifecycle.emit(Lifecycle.Event.ON_DESTROY);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
     subject.onNext(3);
     o.assertNoMoreEvents();
   }
@@ -294,13 +294,13 @@ public final class AndroidLifecycleScopeProviderTest {
     PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
     InstrumentationRegistry.getInstrumentation()
         .runOnMainSync(
             () -> {
-              lifecycle.emit(Lifecycle.Event.ON_CREATE);
-              lifecycle.emit(Lifecycle.Event.ON_START);
-              lifecycle.emit(Lifecycle.Event.ON_RESUME);
+              lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
+              lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
+              lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
             });
     subject.to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle))).subscribe(o);
     o.takeSubscribe();
@@ -316,13 +316,13 @@ public final class AndroidLifecycleScopeProviderTest {
     final RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     final PublishSubject<Integer> subject = PublishSubject.create();
 
-    TestLifecycleOwner lifecycle = TestLifecycleOwner.create();
-    lifecycle.emit(Lifecycle.Event.ON_CREATE);
-    lifecycle.emit(Lifecycle.Event.ON_START);
-    lifecycle.emit(Lifecycle.Event.ON_RESUME);
-    lifecycle.emit(Lifecycle.Event.ON_PAUSE);
-    lifecycle.emit(Lifecycle.Event.ON_STOP);
-    lifecycle.emit(Lifecycle.Event.ON_DESTROY);
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
+    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
     subject.to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle))).subscribe(o);
 
     Disposable d = o.takeSubscribe();

--- a/android/autodispose-androidx-lifecycle/src/androidTest/java/autodispose2/androidx/lifecycle/AndroidLifecycleScopeProviderTest.java
+++ b/android/autodispose-androidx-lifecycle/src/androidTest/java/autodispose2/androidx/lifecycle/AndroidLifecycleScopeProviderTest.java
@@ -20,10 +20,10 @@ import static com.google.common.truth.Truth.assertThat;
 
 import android.util.Log;
 import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.testing.TestLifecycleOwner;
 import androidx.test.annotation.UiThreadTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.lifecycle.testing.TestLifecycleOwner;
 import autodispose2.lifecycle.LifecycleEndedException;
 import autodispose2.test.RecordingObserver;
 import io.reactivex.rxjava3.disposables.Disposable;
@@ -270,8 +270,7 @@ public final class AndroidLifecycleScopeProviderTest {
     // Spin it up
     TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
     InstrumentationRegistry.getInstrumentation()
-        .runOnMainSync(
-            () -> lifecycle.setCurrentState(Lifecycle.State.RESUMED));
+        .runOnMainSync(() -> lifecycle.setCurrentState(Lifecycle.State.RESUMED));
     subject.to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle))).subscribe(o);
     o.takeSubscribe();
     Throwable t = o.takeError();

--- a/android/autodispose-androidx-lifecycle/src/androidTest/java/autodispose2/androidx/lifecycle/AndroidLifecycleScopeProviderTest.java
+++ b/android/autodispose-androidx-lifecycle/src/androidTest/java/autodispose2/androidx/lifecycle/AndroidLifecycleScopeProviderTest.java
@@ -46,9 +46,7 @@ public final class AndroidLifecycleScopeProviderTest {
     // Spin it up
     TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
     subject.to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle))).subscribe(o);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    lifecycle.setCurrentState(Lifecycle.State.RESUMED);
 
     o.takeSubscribe();
     o.assertNoMoreEvents(); // No initial value.
@@ -59,9 +57,7 @@ public final class AndroidLifecycleScopeProviderTest {
     subject.onNext(1);
     assertThat(o.takeNext()).isEqualTo(1);
 
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
+    lifecycle.setCurrentState(Lifecycle.State.DESTROYED);
 
     subject.onNext(2);
     o.assertNoMoreEvents();
@@ -74,11 +70,9 @@ public final class AndroidLifecycleScopeProviderTest {
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.CREATED);
     subject.to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle))).subscribe(o);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    lifecycle.setCurrentState(Lifecycle.State.RESUMED);
 
     o.takeSubscribe();
     o.assertNoMoreEvents(); // No initial value.
@@ -89,9 +83,7 @@ public final class AndroidLifecycleScopeProviderTest {
     subject.onNext(1);
     assertThat(o.takeNext()).isEqualTo(1);
 
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
+    lifecycle.setCurrentState(Lifecycle.State.DESTROYED);
 
     subject.onNext(2);
     o.assertNoMoreEvents();
@@ -104,11 +96,9 @@ public final class AndroidLifecycleScopeProviderTest {
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.STARTED);
     subject.to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle))).subscribe(o);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    lifecycle.setCurrentState(Lifecycle.State.RESUMED);
 
     o.takeSubscribe();
     o.assertNoMoreEvents(); // No initial value.
@@ -136,10 +126,7 @@ public final class AndroidLifecycleScopeProviderTest {
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.RESUMED);
     subject.to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle))).subscribe(o);
 
     o.takeSubscribe();
@@ -167,13 +154,11 @@ public final class AndroidLifecycleScopeProviderTest {
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.CREATED);
     subject
         .to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle, Lifecycle.Event.ON_PAUSE)))
         .subscribe(o);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    lifecycle.setCurrentState(Lifecycle.State.RESUMED);
 
     o.takeSubscribe();
     o.assertNoMoreEvents(); // No initial value.
@@ -200,10 +185,7 @@ public final class AndroidLifecycleScopeProviderTest {
     final PublishSubject<Integer> subject = PublishSubject.create();
 
     // Spin it up
-    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.RESUMED);
     subject
         .to(
             autoDisposable(
@@ -237,10 +219,7 @@ public final class AndroidLifecycleScopeProviderTest {
     final RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     final PublishSubject<Integer> subject = PublishSubject.create();
 
-    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.RESUMED);
     lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
     subject.to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle))).subscribe(o);
 
@@ -266,10 +245,7 @@ public final class AndroidLifecycleScopeProviderTest {
     final RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     final PublishSubject<Integer> subject = PublishSubject.create();
 
-    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.RESUMED);
     lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
     lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
     // In a CREATED state now but the next event will be destroy
@@ -297,11 +273,7 @@ public final class AndroidLifecycleScopeProviderTest {
     TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
     InstrumentationRegistry.getInstrumentation()
         .runOnMainSync(
-            () -> {
-              lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
-              lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
-              lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
-            });
+            () -> lifecycle.setCurrentState(Lifecycle.State.RESUMED));
     subject.to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle))).subscribe(o);
     o.takeSubscribe();
     Throwable t = o.takeError();
@@ -316,13 +288,8 @@ public final class AndroidLifecycleScopeProviderTest {
     final RecordingObserver<Integer> o = new RecordingObserver<>(LOGGER);
     final PublishSubject<Integer> subject = PublishSubject.create();
 
-    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.INITIALIZED);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
+    TestLifecycleOwner lifecycle = new TestLifecycleOwner(Lifecycle.State.RESUMED);
+    lifecycle.setCurrentState(Lifecycle.State.DESTROYED);
     subject.to(autoDisposable(AndroidLifecycleScopeProvider.from(lifecycle))).subscribe(o);
 
     Disposable d = o.takeSubscribe();

--- a/android/autodispose-androidx-lifecycle/src/androidTest/java/autodispose2/androidx/lifecycle/AndroidLifecycleScopeProviderTest.java
+++ b/android/autodispose-androidx-lifecycle/src/androidTest/java/autodispose2/androidx/lifecycle/AndroidLifecycleScopeProviderTest.java
@@ -116,7 +116,7 @@ public final class AndroidLifecycleScopeProviderTest {
     subject.onNext(2);
     o.assertNoMoreEvents();
 
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
+    lifecycle.setCurrentState(Lifecycle.State.DESTROYED);
   }
 
   @Test
@@ -143,8 +143,7 @@ public final class AndroidLifecycleScopeProviderTest {
     subject.onNext(2);
     o.assertNoMoreEvents();
 
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
+    lifecycle.setCurrentState(Lifecycle.State.DESTROYED);
   }
 
   @Test
@@ -174,8 +173,7 @@ public final class AndroidLifecycleScopeProviderTest {
     subject.onNext(2);
     o.assertNoMoreEvents();
 
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP);
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
+    lifecycle.setCurrentState(Lifecycle.State.DESTROYED);
   }
 
   @Test
@@ -208,7 +206,7 @@ public final class AndroidLifecycleScopeProviderTest {
     assertThat(o.takeNext()).isEqualTo(2);
 
     // We should stop here
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
+    lifecycle.setCurrentState(Lifecycle.State.DESTROYED);
     subject.onNext(3);
     o.assertNoMoreEvents();
   }
@@ -259,7 +257,7 @@ public final class AndroidLifecycleScopeProviderTest {
     assertThat(o.takeNext()).isEqualTo(2);
 
     // We should stop here
-    lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY);
+    lifecycle.setCurrentState(Lifecycle.State.DESTROYED);
     subject.onNext(3);
     o.assertNoMoreEvents();
   }

--- a/docs/index.md
+++ b/docs/index.md
@@ -178,8 +178,7 @@ for generating `CompletableSource` representations from `LifecycleScopeProvider`
 
 There are three artifacts with extra support for Android:
 * `autodispose-android` has a `ViewScopeProvider` for use with Android `View` classes.
-* `autodispose-android-archcomponents` has a `AndroidLifecycleScopeProvider` for use with `LifecycleOwner` and `Lifecycle` implementations.
-* `autodispose-android-archcomponents-test` has a `TestLifecycleOwner` for use in testing.
+* `autodispose-androidx-lifecycle` has a `AndroidLifecycleScopeProvider` for use with `LifecycleOwner` and `Lifecycle` implementations.
 
 Note that the project is compiled against Java 8. If you need support for lower Java versions, you should
 use D8 (Android Gradle Plugin 3.2+) or desugar as needed (depending on the build system).

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -84,6 +84,7 @@ def androidx = [
         common: "androidx.lifecycle:lifecycle-common:${versions.androidxLifecycle}",
         runtime: "androidx.lifecycle:lifecycle-runtime:${versions.androidxLifecycle}",
         runtimeKtx: "androidx.lifecycle:lifecycle-runtime-ktx:${versions.androidxLifecycle}",
+        runtimeTest: "androidx.lifecycle:lifecycle-runtime-testing:${versions.androidxLifecycle}",
         vmKtx: "androidx.lifecycle:lifecycle-viewmodel-ktx:${versions.androidxLifecycle}"
     ]
 ]

--- a/settings.gradle
+++ b/settings.gradle
@@ -47,11 +47,11 @@ pluginManagement {
 
 rootProject.name = 'autodispose-root'
 if (System.getenv("ANDROID_HOME") != null) {
+  include ':android:autodispose-android'
+  include ':android:autodispose-androidx-lifecycle'
+  include ':android:autodispose-androidx-lifecycle-test'
+  include ':sample'
 }
-include ':android:autodispose-android'
-include ':android:autodispose-androidx-lifecycle'
-include ':android:autodispose-androidx-lifecycle-test'
-include ':sample'
 include ':autodispose'
 include ':autodispose-interop:coroutines'
 include ':autodispose-lifecycle'

--- a/settings.gradle
+++ b/settings.gradle
@@ -47,11 +47,11 @@ pluginManagement {
 
 rootProject.name = 'autodispose-root'
 if (System.getenv("ANDROID_HOME") != null) {
-  include ':android:autodispose-android'
-  include ':android:autodispose-androidx-lifecycle'
-  include ':android:autodispose-androidx-lifecycle-test'
-  include ':sample'
 }
+include ':android:autodispose-android'
+include ':android:autodispose-androidx-lifecycle'
+include ':android:autodispose-androidx-lifecycle-test'
+include ':sample'
 include ':autodispose'
 include ':autodispose-interop:coroutines'
 include ':autodispose-lifecycle'


### PR DESCRIPTION
In favor of the androidx 1st party alternative - https://cs.android.com/androidx/platform/frameworks/support/+/androidx-master-dev:lifecycle/lifecycle-runtime-testing/src/main/java/androidx/lifecycle/testing/TestLifecycleOwner.kt

<!--
Thank you for contributing to AutoDispose. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
