### PR TITLE
Add lint check support for kotlin extensions 

### DIFF
--- a/docs/lint-check.md
+++ b/docs/lint-check.md
@@ -61,6 +61,14 @@ autodispose.lenient=true
 
 The default value of this is `false`. 
 
+### Kotlin Extension
+
+By default, subscribe and subscribeWith methods are checked. To support other subscribe methods such as subscribeBy in RxKotlin, you can add your own subscribe extensions.
+In your **app-level** `gradle.properties` files, add kotlin extension functions in format of `{full package name for extension's scope}#{functionName}` and comma-separated-values like so:
+```groovy
+autodispose.kotlinExtensionFunctions="io.reactivex.rxjava3.kotlin.subscribers#subscribeBy,com.sample.app.SubscribeExt#subscribe2"
+```
+
 #### Examples
 ```java
 // This is allowed in lenient mode
@@ -77,4 +85,7 @@ Observable.just(1).subscribe();
 
 // This is not allowed in lenient mode, because that subscribe() overload just returns void
 Observable.just(1).subscribe(new Observer...)
+
+// This is not allowed when kotlin extension functions option is used
+Observable.just(1).subscribeBy { }
 ```

--- a/docs/lint-check.md
+++ b/docs/lint-check.md
@@ -65,6 +65,7 @@ The default value of this is `false`.
 
 By default, subscribe and subscribeWith methods are checked. To support other subscribe methods such as subscribeBy in RxKotlin, you can add your own subscribe extensions.
 In your **app-level** `gradle.properties` files, add kotlin extension functions in format of `{full package name for extension's scope}#{functionName}` and comma-separated-values like so:
+
 ```groovy
 autodispose.kotlinExtensionFunctions="io.reactivex.rxjava3.kotlin.subscribers#subscribeBy,com.sample.app.SubscribeExt#subscribe2"
 ```

--- a/docs/lint-check.md
+++ b/docs/lint-check.md
@@ -63,7 +63,7 @@ The default value of this is `false`.
 
 ### Kotlin Extension
 
-By default, subscribe and subscribeWith methods are checked. To support other subscribe methods such as subscribeBy in RxKotlin, you can add your own subscribe extensions.
+By default, `subscribe` and `subscribeWith` methods are checked. To support other subscribe methods such as `subscribeBy` in RxKotlin, you can add your own subscribe extensions.
 In your **app-level** `gradle.properties` files, add kotlin extension functions in format of `{full package name for extension's scope}#{functionName}` and comma-separated-values like so:
 
 ```groovy

--- a/docs/lint-check.md
+++ b/docs/lint-check.md
@@ -66,7 +66,7 @@ The default value of this is `false`.
 By default, `subscribe` and `subscribeWith` methods are checked. To support other subscribe methods such as `subscribeBy` in RxKotlin, you can add your own subscribe extensions.
 In your **app-level** `gradle.properties` files, add kotlin extension functions in format of `{full package name for extension's scope}#{functionName}` and comma-separated-values like so:
 
-```groovy
+```properties
 autodispose.kotlinExtensionFunctions="io.reactivex.rxjava3.kotlin.subscribers#subscribeBy,com.sample.app.SubscribeExt#subscribe2"
 ```
 

--- a/static-analysis/autodispose-lint/src/test/kotlin/autodispose2/lint/AutoDisposeDetectorTest.kt
+++ b/static-analysis/autodispose-lint/src/test/kotlin/autodispose2/lint/AutoDisposeDetectorTest.kt
@@ -99,11 +99,32 @@ class AutoDisposeDetectorTest {
           }
         """).indented().within("src/")
 
-    private fun lenientPropertiesFile(lenient: Boolean = true): TestFile.PropertyTestFile {
+    private val RX_KOTLIN = kotlin(
+        "io/reactivex/rxjava3/kotlin/subscribers.kt",
+        """
+          @file:JvmName("subscribers")
+          package io.reactivex.rxjava3.kotlin
+
+          import io.reactivex.rxjava3.core.*
+          import io.reactivex.rxjava3.disposables.Disposable
+
+          fun <G : Any> Observable<G>.subscribeBy(
+                  onNext: (G) -> Unit
+          ): Disposable = subscribe()
+        """).indented().within("src/")
+
+    private fun propertiesFile(lenient: Boolean = true, kotlinExtensionFunctions: String? = null): TestFile.PropertyTestFile {
       val properties = projectProperties()
       properties.property(LENIENT, lenient.toString())
+      kotlinExtensionFunctions?.also {
+        properties.property(KOTLIN_EXTENSION_FUNCTIONS, it)
+      }
       properties.to(AutoDisposeDetector.PROPERTY_FILE)
       return properties
+    }
+
+    private fun lenientPropertiesFile(lenient: Boolean = true): TestFile.PropertyTestFile {
+      return propertiesFile(lenient)
     }
   }
 
@@ -1000,6 +1021,62 @@ class AutoDisposeDetectorTest {
         .issues(AutoDisposeDetector.ISSUE)
         .run()
         .expectClean()
+  }
+
+  @Test fun kotlinExtensionFunctionNotConfigured() {
+    lint()
+        .files(rxJava3(),
+            LIFECYCLE_OWNER,
+            RX_KOTLIN,
+            FRAGMENT,
+            kotlin("""
+          package foo
+          import io.reactivex.rxjava3.core.Observable
+          import io.reactivex.rxjava3.observers.DisposableObserver
+          import io.reactivex.rxjava3.kotlin.subscribeBy
+          import androidx.fragment.app.Fragment
+
+          class ExampleClass : Fragment() {
+            fun names() {
+              val obs = Observable.just(1, 2, 3, 4)
+              obs.subscribeBy { }
+            }
+          }
+        """).indented())
+        .allowCompilationErrors(false)
+        .issues(AutoDisposeDetector.ISSUE)
+        .run()
+        .expectClean()
+  }
+
+  @Test fun kotlinExtensionFunctionNotHandled() {
+    lint()
+        .files(rxJava3(),
+            propertiesFile(kotlinExtensionFunctions = "io.reactivex.rxjava3.kotlin.subscribers#subscribeBy"),
+            LIFECYCLE_OWNER,
+            RX_KOTLIN,
+            FRAGMENT,
+            kotlin("""
+          package foo
+          import io.reactivex.rxjava3.core.Observable
+          import io.reactivex.rxjava3.observers.DisposableObserver
+          import io.reactivex.rxjava3.kotlin.subscribeBy
+          import androidx.fragment.app.Fragment
+
+          class ExampleClass : Fragment() {
+            fun names() {
+              val obs = Observable.just(1, 2, 3, 4)
+              obs.subscribeBy { }
+            }
+          }
+        """).indented())
+        .allowCompilationErrors(false)
+        .issues(AutoDisposeDetector.ISSUE)
+        .run()
+        .expect("""src/foo/ExampleClass.kt:10: Error: ${AutoDisposeDetector.LINT_DESCRIPTION} [AutoDispose]
+          |    obs.subscribeBy { }
+          |    ~~~~~~~~~~~~~~~~~~~
+          |1 errors, 0 warnings""".trimMargin())
   }
 
   @Test fun subscribeWithCapturedNonDisposableType() {


### PR DESCRIPTION
<!--
Thank you for contributing to AutoDispose. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:

Lint check should be able to check RxKotlin's subscribeBy.
Looking at the discussion in #304, I get that the library doesn't want to add support only for RxKotlin because it's not part of the api.

So this PR supports kotlin extensions with configuration in gradle.properties. 

For the concern that it would slow down lint-check, I couldn't check for big project but I think this implementation would not slow down lint check much for those who don't use the added configuration. 

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**: #304

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
