### PR TITLE
Remove jcenter() repository from project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           java-version: ${{ matrix.java_version }}
       - name: Install Android SDK
-        uses: malinskiy/action-android/install-sdk@release/0.0.3
+        uses: malinskiy/action-android/install-sdk@release/0.1.1
       # TODO Caching disabled for now due to the size of Gradle's cache rendering this super slow
 #      - name: Cache build .gradle dir
 #        uses: actions/cache@v1.0.1
@@ -54,7 +54,7 @@ jobs:
       - name: Run tests
         run: ./gradlew test --stacktrace
       - name: Run instrumentation tests
-        uses: malinskiy/action-android/emulator-run-cmd@release/0.0.3
+        uses: malinskiy/action-android/emulator-run-cmd@release/0.1.1
         with:
           cmd: ./gradlew connectedCheck --stacktrace
           api: 18

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ buildscript {
       google()
       mavenCentral()
       gradlePluginPortal()
-      jcenter()
     }
     dependencies {
       classpath deps.build.gradlePlugins.android
@@ -57,7 +56,6 @@ subprojects {
   repositories {
     google()
     mavenCentral()
-    jcenter()
   }
 
   apply from: rootProject.file('gradle/dependencies.gradle')

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,7 +48,6 @@ pluginManagement {
     mavenCentral()
     google()
     gradlePluginPortal()
-    jcenter()
   }
 }
 


### PR DESCRIPTION
Change to avoid things to break after [JCenter sunset](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/).