### PR TITLE
Use project instead of mainProject

### DIFF
--- a/static-analysis/autodispose-lint/src/main/kotlin/autodispose2/lint/AutoDisposeDetector.kt
+++ b/static-analysis/autodispose-lint/src/main/kotlin/autodispose2/lint/AutoDisposeDetector.kt
@@ -114,7 +114,7 @@ class AutoDisposeDetector : Detector(), SourceCodeScanner {
 
     // Add the custom scopes defined in configuration.
     val props = Properties()
-    context.mainProject.propertyFiles.find { it.name == PROPERTY_FILE }?.apply {
+    context.project.propertyFiles.find { it.name == PROPERTY_FILE }?.apply {
       val content = StringReader(context.client.readFile(this).toString())
       props.load(content)
       props.getProperty(CUSTOM_SCOPE_KEY)?.let { scopeProperty ->


### PR DESCRIPTION
mainProject is forbidden to use in CLI mode on (AGP) 7.0+ as it doesn't really work as expected.