### PR TITLE
Update annotated packages for NullAway

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,7 +197,7 @@ subprojects {
       project.tasks.withType(JavaCompile).configureEach {
         options.errorprone.nullaway {
           severity = CheckSeverity.ERROR
-          annotatedPackages.add("com.uber")
+          annotatedPackages.add("autodispose2")
         }
       }
       project.tasks.withType(Test) {
@@ -211,7 +211,7 @@ subprojects {
         variant.getJavaCompileProvider().configure {
           options.errorprone.nullaway {
             severity = CheckSeverity.ERROR
-            annotatedPackages.add("com.uber")
+            annotatedPackages.add("autodispose2")
           }
         }
       }


### PR DESCRIPTION


<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**: Update NullAway's annotated packages setting to point to the new source package, `autodispose2`.

It's possible that `io.reactivex.rxjava3` should also be treated as an annotated package (if you want to prevent passing of `null` into Rx APIs), but I'm not sure.