### PR TITLE
Don't use an env at all in snapshot uploading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,5 @@ jobs:
       - name: Final checks
         run: ./gradlew check --stacktrace
       - name: Upload snapshot (main only)
-        run: ./gradlew publishAllPublicationsToMavenCentralRepository -PmavenCentralUsername="$SONATYPE_NEXUS_USERNAME" -PmavenCentralPassword="$SONATYPE_NEXUS_PASSWORD"
-        env:
-          SONATYPE_NEXUS_USERNAME: ${{ secrets.SonatypeUsername }}
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.SonatypePassword }}
+        run: ./gradlew publishAllPublicationsToMavenCentralRepository -PmavenCentralUsername="${{ secrets.SonatypeUsername }}" -PmavenCentralPassword="${{ secrets.SonatypePassword }}"
         if: success() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && matrix.java_version == '11'


### PR DESCRIPTION
Newer versions of the publish plugin will error on the presence of the old env arg even if the new gradle property is present
