### PR TITLE
Improve RxJava versions support documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -245,16 +245,15 @@ Special thanks go to [Dan Lew][dan] (creator of RxLifecycle), who helped pioneer
  
 ## RxJava versions support
 
-- RxJava 3
-  - AutoDispose 2.x
-- RxJava 2
-  - AutoDispose 1.x
-- RxJava 1
-  - We do not plan to try to backport this to RxJava 1. This pattern is *sort of* possible in 
-  RxJava 1, but only on `Subscriber` (via `onStart()`) and `CompletableObserver` (which matches the 
-  API of RxJava 2+).
+| RxJava version | AutoDispose version  |
+|----------------|----------------------|
+| RxJava 3       | AutoDispose 2.x      |
+| RxJava 2       | AutoDispose 1.x      |
+| RxJava 1       | Unsupported          |
 
-2.x versions of AutoDispose are built for RxJava 3.
+- We do not plan to try to backport this to RxJava 1. This pattern is *sort of* possible in RxJava 1, but only on `Subscriber` (via `onStart()`) and `CompletableObserver` (which matches the API of RxJava 2+)
+
+- 2.x versions of AutoDispose are built for RxJava 3.
 
 ## Static analysis
 


### PR DESCRIPTION
**Description**:
This improves the readability of the **RxJava versions support** section of the documentation by displaying the version mapping as a table. Also, when rendered to GitHub Pages, the sub bullet indentations don't seem to be translating...

**Before:**
<img width="792" alt="Screen Shot 2022-02-22 at 9 43 01 AM" src="https://user-images.githubusercontent.com/987398/155155654-9f042c0f-4c1d-4a52-be6a-65584d9e8d89.png">

When reading this it didn't cross my mind initially that this was basically a compatibility matrix until I tried to use AutoDispose 2.x with RxJava 2.x and re-read the documentation.

**After:**
<img width="780" alt="Screen Shot 2022-02-22 at 10 30 38 AM" src="https://user-images.githubusercontent.com/987398/155165040-4e1b0cef-7423-4a9f-afb2-5b0bf11a1ae0.png">

**Related issue(s)**: N/A
