### PR TITLE
[Coroutines Interop] Dispose the handle returned by `Job.invokeOnCompletion` when Rx subscription is disposed.

### DIFF
--- a/autodispose-interop/coroutines/src/main/kotlin/autodispose2/interop/coroutines/AutoDisposeCoroutinesInterop.kt
+++ b/autodispose-interop/coroutines/src/main/kotlin/autodispose2/interop/coroutines/AutoDisposeCoroutinesInterop.kt
@@ -81,12 +81,13 @@ private fun CoroutineScope.asUndeferredCompletable(): Completable {
     val job = coroutineContext[Job] ?: error(
       "Scope cannot be created because it does not have a job: ${this@asUndeferredCompletable}"
     )
-    job.invokeOnCompletion {
+    val handle = job.invokeOnCompletion {
       when (it) {
         null, is CancellationException -> emitter.onComplete()
         else -> emitter.onError(it)
       }
     }
+    emitter.setCancellable(handle::dispose)
   }
 }
 


### PR DESCRIPTION
The `Completable` `emitter` is captured by the `Job.invokeOnCompletion` closure (`CompletionHandler`), so if we don't dispose the handler when Rx subscription is disposed, we are holding onto a reference to `CompletableEmitter` until the job is completed (and the handler is called and disposed).

Calling the handler after the subscription is disposed is not an issue, because `CompletableEmitter.onError` and `CompletableEmitter.onComplete` checks for disposal before taking any action -- but it stills presents a potential memory leak.